### PR TITLE
fix: add nonnull annotation to reportCallEnded reason parameter

### DIFF
--- a/react-voice-commons-sdk/ios/CallKitBridge.m
+++ b/react-voice-commons-sdk/ios/CallKitBridge.m
@@ -28,7 +28,7 @@ RCT_EXTERN_METHOD(reportCallConnected:(NSString *)callUUID
                   rejecter:(RCTPromiseRejectBlock)reject)
 
 RCT_EXTERN_METHOD(reportCallEnded:(NSString *)callUUID 
-                  reason:(NSNumber *)reason
+                  reason:(nonnull NSNumber *)reason
                   resolver:(RCTPromiseResolveBlock)resolve 
                   rejecter:(RCTPromiseRejectBlock)reject)
 


### PR DESCRIPTION
## Summary

Fixes #9 and #11

React Native requires explicit nullability annotations on all `NSNumber` parameters for iOS/Android interoperability. Without this annotation, the app crashes when disconnecting a call.

## Error

```
Argument 1 (NSNumber) of CallKitBridge.reportCallEnded has unspecified nullability 
but React requires that all NSNumber arguments are explicitly marked as 'nonnull' 
to ensure compatibility with Android
```

## Fix

```diff
- reason:(NSNumber *)reason
+ reason:(nonnull NSNumber *)reason
```

Credit to @rb-sage and @praneetsah for reporting and providing the fix!