### PR TITLE
chore: bump @telnyx/react-native-voice-sdk from ^0.1.2 to ^0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@rn-primitives/progress": "~1.2.0",
     "@rn-primitives/slot": "^1.2.0",
     "@rn-primitives/tooltip": "~1.2.0",
-    "@telnyx/react-native-voice-sdk": "^0.1.2",
+    "@telnyx/react-native-voice-sdk": "^0.3.0",
     "@telnyx/react-voice-commons-sdk": "file:react-voice-commons-sdk",
     "@ungap/structured-clone": "^1.3.0",
     "class-variance-authority": "^0.7.1",


### PR DESCRIPTION
## Summary

Updates the demo app's `@telnyx/react-native-voice-sdk` dependency from `^0.1.2` to `^0.3.0`.

## Why

In semver 0.x, `^0.1.2` resolves to `>=0.1.2 <0.2.0` — meaning the demo app was locked out of versions 0.2.0 and 0.3.0. The parent SDK is now at **0.3.0** on npm.

Note: The commons library itself (`react-voice-commons-sdk/`) already correctly references `^0.3.0` in its publish scripts. This fix is for the demo app's direct dependency.

---
*Automated dependency sync by Olitron* ⚡