### PR TITLE
fix: use caller name/number for CallKit foreground incoming calls

### DIFF
--- a/react-voice-commons-sdk/src/internal/calls/call-state-controller.ts
+++ b/react-voice-commons-sdk/src/internal/calls/call-state-controller.ts
@@ -392,7 +392,7 @@ export class CallStateController {
       } else if (call.isIncoming) {
         // Handle incoming call with CallKit (only if not already integrated)
         console.log('CallStateController: Reporting incoming call to CallKitCoordinator');
-        callKitCoordinator.reportIncomingCall(telnyxCall, call.destination, call.destination);
+        callKitCoordinator.reportIncomingCall(telnyxCall, call.callerName, call.callerNumber);
       } else {
         // Handle outgoing call with CallKit
         console.log('CallStateController: Starting outgoing call with CallKitCoordinator');

--- a/react-voice-commons-sdk/src/models/call.ts
+++ b/react-voice-commons-sdk/src/models/call.ts
@@ -67,6 +67,22 @@ export class Call {
   }
 
   /**
+   * The original caller name (from_display_name) received in the INVITE message.
+   * Falls back to destination if not available.
+   */
+  get callerName(): string {
+    return this._originalCallerName || this._destination;
+  }
+
+  /**
+   * The original caller number received in the INVITE message.
+   * Falls back to destination if not available.
+   */
+  get callerNumber(): string {
+    return this._originalCallerNumber || this._destination;
+  }
+
+  /**
    * Current call state (synchronous access)
    */
   get currentState(): TelnyxCallState {


### PR DESCRIPTION
## Summary

When receiving incoming calls in the foreground via WebSocket, `reportIncomingCall()` was passing `call.destination` for both the name and handle parameters, ignoring the `caller_id_name` from the INVITE message. This meant CallKit always showed the callee's own number instead of the caller's name.

## Changes

- Added public `callerName` / `callerNumber` getters to the `Call` model
- Updated the foreground incoming call path to use these getters when reporting to CallKit
- Matches the behavior already working correctly for push notification (background) calls

## Testing

- Foreground incoming call → CallKit now displays the caller's name from the INVITE
- Push notification incoming call → unchanged, still works correctly

Fixes #17