### PR TITLE
WEBRTC-3344: Handle telnyx_call_control_id in telnyx_rtc.answer

### DIFF
--- a/package/__tests__/answerEvent.test.ts
+++ b/package/__tests__/answerEvent.test.ts
@@ -1,0 +1,136 @@
+import { isAnswerEvent, type AnswerEvent } from '../lib/messages/call';
+
+describe('AnswerEvent', () => {
+  describe('isAnswerEvent type guard', () => {
+    it('should return true for valid answer event with telnyx_call_control_id', () => {
+      const event: AnswerEvent = {
+        id: 12346,
+        jsonrpc: '2.0',
+        method: 'telnyx_rtc.answer',
+        params: {
+          callID: 'a2f31dd9-b9e6-403a-89d8-33767df14a56',
+          dialogParams: { custom_headers: [] },
+          sdp: 'v=0\r\no=- 0 0 IN IP4 127.0.0.1\r\n',
+          variables: { 'Core-UUID': 'test-uuid' },
+          telnyx_call_control_id: 'v3:mXnwxhjqOG0oDW6V6m7pEYGFCibIeNnsHQwvvUbqyADtTXKaX6uK4g',
+          telnyx_leg_id: '04461b14-1885-11f1-87f2-02420aefba1f',
+          telnyx_session_id: '044613a8-1885-11f1-87c4-02420aefba1f',
+        },
+        voice_sdk_id: 'VSDK1Ch8iUTpajWQf9DmIQHqdeNCIBdn5hw',
+      };
+
+      expect(isAnswerEvent(event)).toBe(true);
+    });
+
+    it('should return true for valid answer event without telnyx_call_control_id (backwards compatibility)', () => {
+      const event = {
+        id: 12346,
+        jsonrpc: '2.0',
+        method: 'telnyx_rtc.answer',
+        params: {
+          callID: 'a2f31dd9-b9e6-403a-89d8-33767df14a56',
+          dialogParams: { custom_headers: [] },
+          sdp: 'v=0\r\no=- 0 0 IN IP4 127.0.0.1\r\n',
+          variables: { 'Core-UUID': 'test-uuid' },
+        },
+        voice_sdk_id: 'VSDK1Ch8iUTpajWQf9DmIQHqdeNCIBdn5hw',
+      };
+
+      expect(isAnswerEvent(event)).toBe(true);
+    });
+
+    it('should return false for null', () => {
+      expect(isAnswerEvent(null)).toBe(false);
+    });
+
+    it('should return false for undefined', () => {
+      expect(isAnswerEvent(undefined)).toBe(false);
+    });
+
+    it('should return false for event with wrong method', () => {
+      const event = {
+        id: 12346,
+        jsonrpc: '2.0',
+        method: 'telnyx_rtc.ringing',
+        params: {
+          callID: 'a2f31dd9-b9e6-403a-89d8-33767df14a56',
+          sdp: 'v=0\r\n',
+        },
+        voice_sdk_id: 'VSDK1Ch8iUTpajWQf9DmIQHqdeNCIBdn5hw',
+      };
+
+      expect(isAnswerEvent(event)).toBe(false);
+    });
+
+    it('should return false for event without callID', () => {
+      const event = {
+        id: 12346,
+        jsonrpc: '2.0',
+        method: 'telnyx_rtc.answer',
+        params: {
+          dialogParams: { custom_headers: [] },
+          sdp: 'v=0\r\n',
+          variables: { 'Core-UUID': 'test-uuid' },
+        },
+        voice_sdk_id: 'VSDK1Ch8iUTpajWQf9DmIQHqdeNCIBdn5hw',
+      };
+
+      expect(isAnswerEvent(event)).toBe(false);
+    });
+  });
+
+  describe('AnswerEvent type', () => {
+    it('should allow telnyx_call_control_id to be optional', () => {
+      const eventWithId: AnswerEvent = {
+        id: 1,
+        jsonrpc: '2.0',
+        method: 'telnyx_rtc.answer',
+        params: {
+          callID: 'test-call-id',
+          dialogParams: { custom_headers: [] },
+          sdp: 'v=0\r\n',
+          variables: { 'Core-UUID': 'test-uuid' },
+          telnyx_call_control_id: 'v3:test-control-id',
+          telnyx_leg_id: 'test-leg-id',
+          telnyx_session_id: 'test-session-id',
+        },
+        voice_sdk_id: 'test-sdk-id',
+      };
+
+      const eventWithoutId: AnswerEvent = {
+        id: 1,
+        jsonrpc: '2.0',
+        method: 'telnyx_rtc.answer',
+        params: {
+          callID: 'test-call-id',
+          dialogParams: { custom_headers: [] },
+          sdp: 'v=0\r\n',
+          variables: { 'Core-UUID': 'test-uuid' },
+        },
+        voice_sdk_id: 'test-sdk-id',
+      };
+
+      expect(eventWithId.params.telnyx_call_control_id).toBe('v3:test-control-id');
+      expect(eventWithoutId.params.telnyx_call_control_id).toBeUndefined();
+    });
+
+    it('should correctly type telnyx_leg_id and telnyx_session_id as optional', () => {
+      const event: AnswerEvent = {
+        id: 1,
+        jsonrpc: '2.0',
+        method: 'telnyx_rtc.answer',
+        params: {
+          callID: 'test-call-id',
+          dialogParams: { custom_headers: [] },
+          sdp: 'v=0\r\n',
+          variables: { 'Core-UUID': 'test-uuid' },
+          telnyx_leg_id: 'test-leg-id',
+        },
+        voice_sdk_id: 'test-sdk-id',
+      };
+
+      expect(event.params.telnyx_leg_id).toBe('test-leg-id');
+      expect(event.params.telnyx_session_id).toBeUndefined();
+    });
+  });
+});

--- a/package/lib/call.ts
+++ b/package/lib/call.ts
@@ -108,6 +108,7 @@ export class Call extends EventEmitter<CallEvents> {
       direction: 'inbound',
       telnyxLegId,
       telnyxSessionId,
+      telnyxCallControlId,
       callId,
       callState: initialState,
     });

--- a/package/lib/client.ts
+++ b/package/lib/client.ts
@@ -1099,6 +1099,17 @@ export class TelnyxRTC extends EventEmitter<TelnyxRTCEvents> {
       // Store custom headers from the ANSWER message
       targetCall.answerCustomHeaders = msg.params.dialogParams?.custom_headers || null;
 
+      // Extract Telnyx IDs from answer event params (for outbound flows)
+      if (msg.params.telnyx_call_control_id) {
+        targetCall.telnyxCallControlId = msg.params.telnyx_call_control_id;
+      }
+      if (msg.params.telnyx_leg_id) {
+        targetCall.telnyxLegId = msg.params.telnyx_leg_id;
+      }
+      if (msg.params.telnyx_session_id) {
+        targetCall.telnyxSessionId = msg.params.telnyx_session_id;
+      }
+
       // If answer event has SDP, set it as remote description
       if (sdp) {
         log.debug('[TelnyxRTC] Answer event contains SDP - setting as remote description');

--- a/package/lib/messages/call.ts
+++ b/package/lib/messages/call.ts
@@ -118,6 +118,12 @@ export type AnswerEvent = {
     variables: {
       'Core-UUID': string;
     };
+    /** The Telnyx call control ID for outbound flows (parked & bridged) */
+    telnyx_call_control_id?: string;
+    /** The Telnyx leg ID */
+    telnyx_leg_id?: string;
+    /** The Telnyx session ID */
+    telnyx_session_id?: string;
   };
   voice_sdk_id: string;
 };


### PR DESCRIPTION
## Summary
- Add `telnyx_call_control_id`, `telnyx_leg_id`, and `telnyx_session_id` optional fields to `AnswerEvent` type in `package/lib/messages/call.ts`
- Extract and store Telnyx IDs from answer event params in `package/lib/client.ts` for outbound call flows
- Pass `telnyxCallControlId` through `createInboundCall` to the `Call` constructor in `package/lib/call.ts`
- Add unit tests for `isAnswerEvent` type guard and `AnswerEvent` type validation

## Related
- Ports [telnyx-react-native-voice-sdk#10](https://github.com/team-telnyx/telnyx-react-native-voice-sdk/pull/10) to the `package/` directory
- [WEBRTC-3344](https://telnyx.atlassian.net/browse/WEBRTC-3344)

## Test plan
- [x] All 8 new unit tests pass
- [x] Prettier formatting passes
- [ ] Verify outbound call flows correctly expose `telnyxCallControlId` on the call object

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[WEBRTC-3344]: https://telnyx.atlassian.net/browse/WEBRTC-3344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ