### PR TITLE
security: OIDC npm publish workflow with provenance

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,79 @@
+name: Publish to npm
+
+# Trigger on GitHub Releases only — no manual npm publish allowed.
+# Use release tag prefixes to control which package(s) to publish:
+#   voice-sdk/v0.4.1   → publishes @telnyx/react-native-voice-sdk only
+#   commons-sdk/v0.2.0 → publishes @telnyx/react-voice-commons-sdk only
+#   v0.2.0             → publishes both packages
+on:
+  release:
+    types: [published]
+
+# OIDC: Grant the workflow a short-lived identity token that npm uses to
+# verify this publish came from this repo. No stored secrets on any machine.
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish-voice-sdk:
+    name: Publish @telnyx/react-native-voice-sdk
+    if: startsWith(github.event.release.tag_name, 'voice-sdk/') || startsWith(github.event.release.tag_name, 'v')
+    runs-on: ubuntu-latest
+    environment: npm_bub
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        working-directory: package
+        run: npm install --legacy-peer-deps
+
+      - name: Publish with provenance
+        working-directory: package
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.REACT_NATIVE_TOKEN }}
+
+  publish-commons-sdk:
+    name: Publish @telnyx/react-voice-commons-sdk
+    runs-on: ubuntu-latest
+    needs: publish-voice-sdk
+    # Run if: tag targets commons-sdk or both, AND voice-sdk either succeeded or was skipped
+    if: |
+      always() &&
+      (startsWith(github.event.release.tag_name, 'commons-sdk/') || startsWith(github.event.release.tag_name, 'v')) &&
+      (needs.publish-voice-sdk.result == 'success' || needs.publish-voice-sdk.result == 'skipped')
+    environment: npm_bub
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        working-directory: react-voice-commons-sdk
+        run: |
+          # Switch from local file dependency to published version
+          npm run dev:published
+          npm install --legacy-peer-deps
+
+      - name: Build
+        working-directory: react-voice-commons-sdk
+        run: npm run build
+
+      - name: Publish with provenance
+        working-directory: react-voice-commons-sdk
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.REACT_NATIVE_TOKEN }}

--- a/package/package.json
+++ b/package/package.json
@@ -61,5 +61,8 @@
   },
   "engines": {
     "node": ">=16"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
## Summary
- Adds GitHub Actions publish workflow triggered by GitHub Releases (no more manual `npm publish` from developer machines)
- Uses `--provenance` flag for OIDC trusted publishing — npm cryptographically links each package to this repo/workflow run
- Supports independent package releases via tag prefixes:
  - `voice-sdk/v*` → publishes `@telnyx/react-native-voice-sdk` only
  - `commons-sdk/v*` → publishes `@telnyx/react-voice-commons-sdk` only
  - `v*` → publishes both packages
- Gated behind `npm_bub` environment with required reviewer approval and branch/tag restrictions
- Adds `publishConfig` to `@telnyx/react-native-voice-sdk` for scoped public access

## Context
Per the PyPI supply chain incident response — centralizing publish credentials under ITOps and eliminating manual publishes from developer machines.

## Remaining steps (ITOps)
1. Create ITOps-owned npm service account
2. Replace `REACT_NATIVE_TOKEN` secret in `npm_bub` environment with ITOps token
3. Revoke all personal npm publish access

## Test plan
- [ ] Verify workflow syntax passes GitHub Actions validation
- [ ] Test with a dry-run release (pre-release tag) to confirm OIDC provenance works
- [ ] Confirm environment approval gate triggers before publish step

🤖 Generated with [Claude Code](https://claude.com/claude-code)