### PR TITLE
Bump react-native-voice-sdk to 0.4.2

### DIFF
--- a/package/CHANGELOG.md
+++ b/package/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG.md
 
+## [0.4.2](https://github.com/team-telnyx/react-native-voice-commons/releases/tag/voice-sdk-v0.4.2) (2026-04-01)
+
+### Enhancement
+
+- Switch to npm trusted publishing with OIDC (no stored secrets)
+
 ## [0.4.1](https://github.com/team-telnyx/react-native-voice-commons/releases/tag/voice-sdk-v0.4.1) (2026-03-31)
 
 ### Bug Fixing

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@telnyx/react-native-voice-sdk",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Telnyx React Native Voice SDK - A complete WebRTC voice calling solution",
   "main": "lib/index.ts",
   "module": "lib/index.ts",


### PR DESCRIPTION
## Summary
- Bump version to 0.4.2 to test OIDC trusted publishing

## Test plan
- [ ] Merge to main
- [ ] Create release with tag `voice-sdk-v0.4.2`
- [ ] Verify OIDC publish succeeds