### PR TITLE
chore: Upgrade GitHub Actions to v5

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,10 +23,10 @@ jobs:
     environment: npm-pub
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
@@ -66,10 +66,10 @@ jobs:
     environment: npm-pub
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'

--- a/package/CHANGELOG.md
+++ b/package/CHANGELOG.md
@@ -1,12 +1,6 @@
 # CHANGELOG.md
 
-## [0.4.3](https://github.com/team-telnyx/react-native-voice-commons/releases/tag/voice-sdk-v0.4.3) (2026-04-01)
-
-### Enhancement
-
-- Switch to npm trusted publishing with OIDC (no stored secrets)
-
-## [0.4.1](https://github.com/team-telnyx/react-native-voice-commons/releases/tag/voice-sdk-v0.4.1) (2026-03-31)
+## [0.4.1](https://github.com/team-telnyx/react-native-voice-commons/releases/tag/voice-sdk-v0.4.1) (2026-04-01)
 
 ### Bug Fixing
 

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@telnyx/react-native-voice-sdk",
-  "version": "0.4.3",
+  "version": "0.4.1",
   "description": "Telnyx React Native Voice SDK - A complete WebRTC voice calling solution",
   "main": "lib/index.ts",
   "module": "lib/index.ts",
@@ -31,10 +31,10 @@
   ],
   "author": "Telnyx",
   "license": "MIT",
-  "homepage": "https://github.com/team-telnyx/react-native-voice-sdk",
+  "homepage": "https://github.com/team-telnyx/react-native-voice-commons",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/team-telnyx/react-native-voice-sdk.git"
+    "url": "git+https://github.com/team-telnyx/react-native-voice-commons.git"
   },
   "bugs": {
     "url": "https://github.com/team-telnyx/react-native-voice-sdk/issues"


### PR DESCRIPTION
## Summary
- Upgrade `actions/checkout` and `actions/setup-node` from v4 to v5
- Node.js 20 actions are deprecated and will be forced to Node 24 on June 2nd, 2026

## Test plan
- [ ] Merge and verify next publish workflow runs without deprecation warnings