### PR TITLE
Bump react-voice-commons-sdk to 0.2.0

### DIFF
--- a/react-voice-commons-sdk/CHANGELOG.md
+++ b/react-voice-commons-sdk/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG.md
 
+## [0.2.0](https://github.com/team-telnyx/react-native-voice-commons/releases/tag/commons-sdk-v0.2.0) (2026-04-01)
+
+### Enhancement
+
+- Upgraded low-level SDK dependency from `@telnyx/react-native-voice-sdk@0.4.0` to `@telnyx/react-native-voice-sdk@0.4.1`
+
+### Bug Fixing
+
+- Fixed push notification flags not being reset after call action execution, causing subsequent calls to be auto-answered
+
 ## [0.1.9](https://github.com/team-telnyx/react-native-voice-commons/releases/tag/0.1.9) (2026-03-19)
 
 ### Enhancement

--- a/react-voice-commons-sdk/package.json
+++ b/react-voice-commons-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@telnyx/react-voice-commons-sdk",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "A high-level, state-agnostic, drop-in module for the Telnyx React Native SDK that simplifies WebRTC voice calling integration",
   "main": "lib/index.js",
   "module": "lib/index.js",

--- a/react-voice-commons-sdk/package.json
+++ b/react-voice-commons-sdk/package.json
@@ -39,7 +39,7 @@
     "android": "expo run:android",
     "ios": "expo run:ios",
     "dev:local": "npm pkg set dependencies.@telnyx/react-native-voice-sdk=file:../package",
-    "dev:published": "npm pkg set dependencies.@telnyx/react-native-voice-sdk=^0.4.0",
+    "dev:published": "npm pkg set dependencies.@telnyx/react-native-voice-sdk=^0.4.1",
     "prepublishOnly": "npm run dev:published && npm install --legacy-peer-deps",
     "postpublish": "npm run dev:local && npm install --legacy-peer-deps"
   },

--- a/react-voice-commons-sdk/package.json
+++ b/react-voice-commons-sdk/package.json
@@ -39,7 +39,7 @@
     "android": "expo run:android",
     "ios": "expo run:ios",
     "dev:local": "npm pkg set dependencies.@telnyx/react-native-voice-sdk=file:../package",
-    "dev:published": "npm pkg set dependencies.@telnyx/react-native-voice-sdk=^0.4.1",
+    "dev:published": "npm pkg set dependencies.@telnyx/react-native-voice-sdk=>=0.4.1",
     "prepublishOnly": "npm run dev:published && npm install --legacy-peer-deps",
     "postpublish": "npm run dev:local && npm install --legacy-peer-deps"
   },


### PR DESCRIPTION
## Summary
- Bump version to 0.2.0
- Upgraded low-level SDK dependency to @telnyx/react-native-voice-sdk@0.4.1
- Inherits push notification flag reset fix from voice-sdk 0.4.1

## Test plan
- [ ] Merge to main
- [ ] Create release with tag `commons-sdk-v0.2.0`
- [ ] Verify OIDC publish succeeds