### PR TITLE
fix: Quote dev:published value for npm pkg set

### DIFF
--- a/react-voice-commons-sdk/package.json
+++ b/react-voice-commons-sdk/package.json
@@ -39,7 +39,7 @@
     "android": "expo run:android",
     "ios": "expo run:ios",
     "dev:local": "npm pkg set dependencies.@telnyx/react-native-voice-sdk=file:../package",
-    "dev:published": "npm pkg set dependencies.@telnyx/react-native-voice-sdk=>=0.4.1",
+    "dev:published": "npm pkg set \"dependencies.@telnyx/react-native-voice-sdk\"=\">=0.4.1\"",
     "prepublishOnly": "npm run dev:published && npm install --legacy-peer-deps",
     "postpublish": "npm run dev:local && npm install --legacy-peer-deps"
   },


### PR DESCRIPTION
## Summary
- Quote key=value in `dev:published` script so `>=0.4.1` is not misinterpreted by npm 11+ `pkg set`

## Test plan
- [ ] Merge to main
- [ ] Recreate `commons-sdk-v0.2.0` release
- [ ] Verify publish succeeds