### PR TITLE
fix: Add peer deps as devDependencies for CI build

### DIFF
--- a/react-voice-commons-sdk/package.json
+++ b/react-voice-commons-sdk/package.json
@@ -97,9 +97,11 @@
     "rxjs": "^7.8.2"
   },
   "devDependencies": {
+    "@react-native-async-storage/async-storage": "^2.1.0",
     "@types/jest": "^29.5.0",
     "@types/react": "~19.0.14",
     "@types/react-native": "^0.72.8",
+    "expo-router": "^5.1.0",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",
     "eslint": "^8.0.0",


### PR DESCRIPTION
## Summary
- Add `expo-router` and `@react-native-async-storage/async-storage` to devDependencies
- These are peer deps that TypeScript needs to resolve during `tsc` in CI

## Test plan
- [x] Verified locally: `dev:published` → `npm install` → `npm run build` passes
- [ ] Merge and recreate `commons-sdk-v0.2.0` release