### PR TITLE
fix: Add prettier to commons-sdk devDependencies

### DIFF
--- a/react-voice-commons-sdk/package.json
+++ b/react-voice-commons-sdk/package.json
@@ -109,6 +109,7 @@
     "ts-jest": "^29.1.0",
     "typedoc": "^0.28.14",
     "typedoc-plugin-markdown": "^4.9.0",
+    "prettier": "^3.0.0",
     "typescript": "^5.0.0"
   },
   "engines": {


### PR DESCRIPTION
## Summary
- Add `prettier` to devDependencies — the `postbuild` script requires it but it wasn't listed

## Test plan
- [ ] Merge and recreate `commons-sdk-v0.2.0` release