### PR TITLE
fix: CallKit auto-answer on iOS cold launch from VoIP push

### DIFF
--- a/react-voice-commons-sdk/CHANGELOG.md
+++ b/react-voice-commons-sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG.md
 
+## [0.2.1](https://github.com/team-telnyx/react-native-voice-commons/releases/tag/commons-sdk-v0.2.1) (2026-04-02)
+
+### Bug Fixing
+
+- Fixed CallKit auto-answer not working on iOS when user answers from CallKit UI during app cold launch from VoIP push. The native `CXAnswerCallAction` event was silently dropped because JS listeners weren't registered yet. Now persists the answer action in UserDefaults so the JS side can detect and honor it.
+
 ## [0.2.0](https://github.com/team-telnyx/react-native-voice-commons/releases/tag/commons-sdk-v0.2.0) (2026-04-01)
 
 ### Enhancement

--- a/react-voice-commons-sdk/CHANGELOG.md
+++ b/react-voice-commons-sdk/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixing
 
+- Preserve an iOS CallKit answer that occurs before React Native event listeners attach during a VoIP-push cold launch.
 - Hydrate iOS login and reconnect configurations from the current native PushKit token when callers omit one, preventing locked-device inbound calls from being missed when JavaScript login races token delivery.
 - Support two simultaneous iOS CallKit calls with UUID-targeted answer, end, hold, resume, and survivor restoration.
 - Route app hold/resume through CallKit and compensate partial call-swap failures to keep native and WebRTC state aligned.

--- a/react-voice-commons-sdk/ios/CallKitBridge.swift
+++ b/react-voice-commons-sdk/ios/CallKitBridge.swift
@@ -533,6 +533,12 @@ import React
             NSLog("📞 TelnyxVoice: CALLKIT ANSWER ACTION - Provider: \(provider), Action: \(action)")
             NSLog("TelnyxVoice: User answered call with UUID: \(action.callUUID)")
 
+            // Always persist the answer action in UserDefaults so the JS side can detect it
+            // even when the RCTEventEmitter bridge is not yet ready (app cold-launched from push).
+            UserDefaults.standard.set(action.callUUID.uuidString, forKey: "pending_callkit_answer")
+            UserDefaults.standard.synchronize()
+            NSLog("TelnyxVoice: Stored pending CallKit answer for UUID: \(action.callUUID)")
+
             // Check if this is a programmatic answer (call already answered in WebRTC)
             // vs a user answer from CallKit UI
             if let callData = activeCalls[action.callUUID],
@@ -554,6 +560,10 @@ import React
 
         public func provider(_ provider: CXProvider, perform action: CXEndCallAction) {
             NSLog("TelnyxVoice: User ended call with UUID: \(action.callUUID)")
+
+            // Clear any pending CallKit answer (prevents stale auto-answer on next call)
+            UserDefaults.standard.removeObject(forKey: "pending_callkit_answer")
+            UserDefaults.standard.synchronize()
 
             // Notify React Native via CallKit bridge
             CallKitBridge.shared?.emitCallEvent(

--- a/react-voice-commons-sdk/ios/CallKitBridge.swift
+++ b/react-voice-commons-sdk/ios/CallKitBridge.swift
@@ -94,8 +94,9 @@ import React
         }
 
         // Direct event emission methods called by TelnyxVoiceAppDelegate
-        public func emitCallEvent(_ eventName: String, callUUID: UUID, callData: [String: Any]?) {
-            guard hasListeners else { return }
+        @discardableResult
+        public func emitCallEvent(_ eventName: String, callUUID: UUID, callData: [String: Any]?) -> Bool {
+            guard hasListeners else { return false }
 
             let eventData: [String: Any] = [
                 "callUUID": callUUID.uuidString,
@@ -103,6 +104,7 @@ import React
             ]
 
             sendEvent(withName: eventName, body: eventData)
+            return true
         }
 
         @discardableResult
@@ -1328,9 +1330,14 @@ import React
                 NSLog("TelnyxVoice: Call already answered in WebRTC, skipping emission")
             } else {
                 // Notify React Native via CallKit bridge (only for user-initiated answers)
-                CallKitBridge.shared?.emitCallEvent(
+                let eventDelivered = CallKitBridge.shared?.emitCallEvent(
                     "CallKitDidPerformAnswerCallAction", callUUID: action.callUUID,
-                    callData: activeCalls[action.callUUID])
+                    callData: activeCalls[action.callUUID]) ?? false
+                if !eventDelivered {
+                    UserDefaults.standard.set(action.callUUID.uuidString, forKey: "pending_callkit_answer")
+                    UserDefaults.standard.synchronize()
+                    NSLog("TelnyxVoice: Stored pending CallKit answer for UUID: \(action.callUUID)")
+                }
             }
 
             // Defer action.fulfill() until reportCallConnected when peer connection is ready
@@ -1386,6 +1393,10 @@ import React
                 NSLog("TelnyxVoice: Failing end action for unknown UUID: \(action.callUUID)")
                 action.fail()
                 return
+            }
+            if UserDefaults.standard.string(forKey: "pending_callkit_answer") == action.callUUID.uuidString {
+                UserDefaults.standard.removeObject(forKey: "pending_callkit_answer")
+                UserDefaults.standard.synchronize()
             }
 
             // Notify React Native via CallKit bridge

--- a/react-voice-commons-sdk/ios/VoicePnBridge.m
+++ b/react-voice-commons-sdk/ios/VoicePnBridge.m
@@ -22,6 +22,12 @@ RCT_EXTERN_METHOD(getPendingVoipPush:(RCTPromiseResolveBlock)resolve
 RCT_EXTERN_METHOD(clearPendingVoipPush:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(getPendingCallKitAnswer:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(clearPendingCallKitAnswer:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
 RCT_EXTERN_METHOD(getPendingVoipAction:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 

--- a/react-voice-commons-sdk/ios/VoicePnBridge.swift
+++ b/react-voice-commons-sdk/ios/VoicePnBridge.swift
@@ -71,6 +71,21 @@ class VoicePnBridge: NSObject {
     }
     
     @objc
+    func getPendingCallKitAnswer(_ resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
+        let answer = UserDefaults.standard.string(forKey: "pending_callkit_answer")
+        NSLog("[VoicePnBridge] getPendingCallKitAnswer - answer: \(answer ?? "nil")")
+        resolve(answer)
+    }
+
+    @objc
+    func clearPendingCallKitAnswer(_ resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
+        UserDefaults.standard.removeObject(forKey: "pending_callkit_answer")
+        UserDefaults.standard.synchronize()
+        NSLog("[VoicePnBridge] clearPendingCallKitAnswer - cleared")
+        resolve(true)
+    }
+
+    @objc
     func getPendingVoipAction(_ resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
         let pending = UserDefaults.standard.string(forKey: "pending_voip_action")
         NSLog("[VoicePnBridge] getPendingVoipAction called. pending=\(pending ?? "(nil)")")

--- a/react-voice-commons-sdk/ios/VoicePnBridge.swift
+++ b/react-voice-commons-sdk/ios/VoicePnBridge.swift
@@ -72,6 +72,21 @@ class VoicePnBridge: NSObject {
     }
     
     @objc
+    func getPendingCallKitAnswer(_ resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
+        let answer = UserDefaults.standard.string(forKey: "pending_callkit_answer")
+        NSLog("[VoicePnBridge] getPendingCallKitAnswer - answer: \(answer ?? "nil")")
+        resolve(answer)
+    }
+
+    @objc
+    func clearPendingCallKitAnswer(_ resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
+        UserDefaults.standard.removeObject(forKey: "pending_callkit_answer")
+        UserDefaults.standard.synchronize()
+        NSLog("[VoicePnBridge] clearPendingCallKitAnswer - cleared")
+        resolve(true)
+    }
+
+    @objc
     func getPendingVoipAction(_ resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
         let pending = UserDefaults.standard.string(forKey: "pending_voip_action")
         NSLog("[VoicePnBridge] getPendingVoipAction called. pending=\(pending ?? "(nil)")")

--- a/react-voice-commons-sdk/lib/callkit/callkit-coordinator.js
+++ b/react-voice-commons-sdk/lib/callkit/callkit-coordinator.js
@@ -258,6 +258,10 @@ class CallKitCoordinator {
       console.log('CallKitCoordinator: Answer action already being processed, skipping duplicate');
       return;
     }
+    // Clear native-side pending answer since JS received the event normally
+    try {
+      await voice_pn_bridge_1.VoicePnBridge.clearPendingCallKitAnswer();
+    } catch (_) {}
     const call = this.callMap.get(callKitUUID);
     if (!call) {
       console.warn('CallKitCoordinator: No WebRTC call found for CallKit answer action', {
@@ -440,6 +444,21 @@ class CallKitCoordinator {
         ...realPushData.metadata,
         from_callkit: true,
       };
+      // Check if the user answered from CallKit before JS listeners were ready.
+      // The native CXAnswerCallAction handler persists the answer UUID in UserDefaults
+      // so we can detect it here even when the JS event was dropped.
+      try {
+        const pendingAnswer = await voice_pn_bridge_1.VoicePnBridge.getPendingCallKitAnswer();
+        if (pendingAnswer) {
+          console.log(
+            'CallKitCoordinator: Found pending CallKit answer from native (JS event was missed), setting auto-answer flag'
+          );
+          this.shouldAutoAnswerNextCall = true;
+          await voice_pn_bridge_1.VoicePnBridge.clearPendingCallKitAnswer();
+        }
+      } catch (e) {
+        // Ignore - method may not exist on older native versions
+      }
       // Check if auto-answer is set and add from_notification flag
       const shouldAddFromNotification = this.shouldAutoAnswerNextCall;
       let pushData;
@@ -717,6 +736,10 @@ class CallKitCoordinator {
   async cleanupPushNotificationState() {
     console.log('CallKitCoordinator: ✅ Cleared auto-answer flag');
     this.shouldAutoAnswerNextCall = false;
+    // Also clear native-side pending answer to prevent stale auto-answer
+    try {
+      await voice_pn_bridge_1.VoicePnBridge.clearPendingCallKitAnswer();
+    } catch (_) {}
   }
   /**
    * Get reference to the SDK client (for queuing actions when call doesn't exist yet)

--- a/react-voice-commons-sdk/lib/callkit/callkit-coordinator.js
+++ b/react-voice-commons-sdk/lib/callkit/callkit-coordinator.js
@@ -637,6 +637,18 @@ class CallKitCoordinator {
       // This app-facing UUID is attached to the next inbound Call while the
       // socket INVITE retains its own signaling callID.
       voipClient.setPushNotificationCallKitUUID(callKitUUID);
+      // Restore an answer that native CallKit received before React Native had
+      // attached listeners. Never apply an answer UUID to a different incoming call.
+      try {
+        const pendingAnswer = await voice_pn_bridge_1.VoicePnBridge.getPendingCallKitAnswer();
+        if (pendingAnswer && this.normalizeUUID(pendingAnswer) === callKitUUID) {
+          console.log('CallKitCoordinator: Restoring pending CallKit answer for matching UUID');
+          this.autoAnswerCallUUIDs.add(callKitUUID);
+          await voice_pn_bridge_1.VoicePnBridge.clearPendingCallKitAnswer();
+        }
+      } catch {
+        // The bridge method is unavailable on older native builds.
+      }
       // A pre-INVITE CallKit answer is represented only by the UUID-keyed
       // pending action. Do not also add legacy notification flags.
       const shouldAddFromNotification = this.autoAnswerCallUUIDs.has(callKitUUID);

--- a/react-voice-commons-sdk/lib/internal/voice-pn-bridge.d.ts
+++ b/react-voice-commons-sdk/lib/internal/voice-pn-bridge.d.ts
@@ -25,6 +25,8 @@ export interface VoicePnBridgeInterface {
   ): Promise<boolean>;
   hideOngoingCallNotification(): Promise<boolean>;
   hideIncomingCallNotification(): Promise<boolean>;
+  getPendingCallKitAnswer(): Promise<string | null>;
+  clearPendingCallKitAnswer(): Promise<boolean>;
   getVoipToken(): Promise<string | null>;
   getPendingVoipPush(): Promise<string | null>;
   clearPendingVoipPush(): Promise<boolean>;
@@ -87,6 +89,16 @@ export declare class VoicePnBridge {
    * Useful for dismissing notifications when call is answered/rejected in app
    */
   static hideIncomingCallNotification(): Promise<boolean>;
+  /**
+   * Get pending CallKit answer UUID from native storage (iOS only).
+   * When the user answers a CallKit call before JS listeners are ready,
+   * the native side persists the answer UUID in UserDefaults so JS can detect it.
+   */
+  static getPendingCallKitAnswer(): Promise<string | null>;
+  /**
+   * Clear pending CallKit answer from native storage (iOS only)
+   */
+  static clearPendingCallKitAnswer(): Promise<boolean>;
   /**
    * Get VoIP token from native storage
    */

--- a/react-voice-commons-sdk/lib/internal/voice-pn-bridge.d.ts
+++ b/react-voice-commons-sdk/lib/internal/voice-pn-bridge.d.ts
@@ -25,6 +25,8 @@ export interface VoicePnBridgeInterface {
   ): Promise<boolean>;
   hideOngoingCallNotification(): Promise<boolean>;
   hideIncomingCallNotification(): Promise<boolean>;
+  getPendingCallKitAnswer(): Promise<string | null>;
+  clearPendingCallKitAnswer(): Promise<boolean>;
   getVoipToken(): Promise<string | null>;
   getPendingVoipPush(): Promise<string | null>;
   clearPendingVoipPush(): Promise<boolean>;
@@ -91,6 +93,16 @@ export declare class VoicePnBridge {
    * Useful for dismissing notifications when call is answered/rejected in app
    */
   static hideIncomingCallNotification(): Promise<boolean>;
+  /**
+   * Get pending CallKit answer UUID from native storage (iOS only).
+   * When the user answers a CallKit call before JS listeners are ready,
+   * the native side persists the answer UUID in UserDefaults so JS can detect it.
+   */
+  static getPendingCallKitAnswer(): Promise<string | null>;
+  /**
+   * Clear pending CallKit answer from native storage (iOS only)
+   */
+  static clearPendingCallKitAnswer(): Promise<boolean>;
   /**
    * Get VoIP token from native storage
    */

--- a/react-voice-commons-sdk/lib/internal/voice-pn-bridge.js
+++ b/react-voice-commons-sdk/lib/internal/voice-pn-bridge.js
@@ -125,6 +125,32 @@ class VoicePnBridge {
     }
   }
   /**
+   * Get pending CallKit answer UUID from native storage (iOS only).
+   * When the user answers a CallKit call before JS listeners are ready,
+   * the native side persists the answer UUID in UserDefaults so JS can detect it.
+   */
+  static async getPendingCallKitAnswer() {
+    if (react_native_1.Platform.OS !== 'ios') return null;
+    try {
+      return await NativeBridge.getPendingCallKitAnswer();
+    } catch (error) {
+      console.error('VoicePnBridge: Error getting pending CallKit answer:', error);
+      return null;
+    }
+  }
+  /**
+   * Clear pending CallKit answer from native storage (iOS only)
+   */
+  static async clearPendingCallKitAnswer() {
+    if (react_native_1.Platform.OS !== 'ios') return true;
+    try {
+      return await NativeBridge.clearPendingCallKitAnswer();
+    } catch (error) {
+      console.error('VoicePnBridge: Error clearing pending CallKit answer:', error);
+      return false;
+    }
+  }
+  /**
    * Get VoIP token from native storage
    */
   static async getVoipToken() {

--- a/react-voice-commons-sdk/package.json
+++ b/react-voice-commons-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@telnyx/react-voice-commons-sdk",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A high-level, state-agnostic, drop-in module for the Telnyx React Native SDK that simplifies WebRTC voice calling integration",
   "main": "lib/index.js",
   "module": "lib/index.js",
@@ -101,15 +101,15 @@
     "@types/jest": "^29.5.0",
     "@types/react": "~19.0.14",
     "@types/react-native": "^0.72.8",
-    "expo-router": "^5.1.0",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",
     "eslint": "^8.0.0",
+    "expo-router": "^5.1.0",
     "jest": "^29.5.0",
+    "prettier": "^3.0.0",
     "ts-jest": "^29.1.0",
     "typedoc": "^0.28.14",
     "typedoc-plugin-markdown": "^4.9.0",
-    "prettier": "^3.0.0",
     "typescript": "^5.0.0"
   },
   "engines": {

--- a/react-voice-commons-sdk/package.json
+++ b/react-voice-commons-sdk/package.json
@@ -101,6 +101,7 @@
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "@typescript-eslint/parser": "^8.0.0",
     "eslint": "^8.0.0",
+    "expo-router": "^5.1.0",
     "jest": "^29.5.0",
     "prettier": "^3.0.0",
     "react": "^19.0.0",

--- a/react-voice-commons-sdk/src/callkit/callkit-coordinator.ts
+++ b/react-voice-commons-sdk/src/callkit/callkit-coordinator.ts
@@ -5,7 +5,6 @@ import { VoicePnBridge } from '../internal/voice-pn-bridge';
 import { router } from 'expo-router';
 import { TelnyxVoipClient } from '../telnyx-voip-client';
 import { TelnyxConnectionState } from '../models/connection-state';
-import { act } from 'react';
 
 /**
  * CallKit Coordinator - Manages the proper CallKit-first flow for iOS
@@ -254,6 +253,11 @@ class CallKitCoordinator {
       return;
     }
 
+    // Clear native-side pending answer since JS received the event normally
+    try {
+      await VoicePnBridge.clearPendingCallKitAnswer();
+    } catch (_) {}
+
     const call = this.callMap.get(callKitUUID);
 
     if (!call) {
@@ -468,6 +472,22 @@ class CallKitCoordinator {
         ...realPushData.metadata,
         from_callkit: true,
       };
+
+      // Check if the user answered from CallKit before JS listeners were ready.
+      // The native CXAnswerCallAction handler persists the answer UUID in UserDefaults
+      // so we can detect it here even when the JS event was dropped.
+      try {
+        const pendingAnswer = await VoicePnBridge.getPendingCallKitAnswer();
+        if (pendingAnswer) {
+          console.log(
+            'CallKitCoordinator: Found pending CallKit answer from native (JS event was missed), setting auto-answer flag'
+          );
+          this.shouldAutoAnswerNextCall = true;
+          await VoicePnBridge.clearPendingCallKitAnswer();
+        }
+      } catch (e) {
+        // Ignore - method may not exist on older native versions
+      }
 
       // Check if auto-answer is set and add from_notification flag
       const shouldAddFromNotification = this.shouldAutoAnswerNextCall;
@@ -789,6 +809,10 @@ class CallKitCoordinator {
   private async cleanupPushNotificationState(): Promise<void> {
     console.log('CallKitCoordinator: ✅ Cleared auto-answer flag');
     this.shouldAutoAnswerNextCall = false;
+    // Also clear native-side pending answer to prevent stale auto-answer
+    try {
+      await VoicePnBridge.clearPendingCallKitAnswer();
+    } catch (_) {}
   }
 
   /**

--- a/react-voice-commons-sdk/src/callkit/callkit-coordinator.ts
+++ b/react-voice-commons-sdk/src/callkit/callkit-coordinator.ts
@@ -702,6 +702,21 @@ class CallKitCoordinator {
       // socket INVITE retains its own signaling callID.
       voipClient.setPushNotificationCallKitUUID(callKitUUID);
 
+      // Restore an answer that native CallKit received before React Native had
+      // attached listeners. Never apply an answer UUID to a different incoming call.
+      try {
+        const pendingAnswer = await VoicePnBridge.getPendingCallKitAnswer();
+        if (pendingAnswer && this.normalizeUUID(pendingAnswer) === callKitUUID) {
+          console.log(
+            'CallKitCoordinator: Restoring pending CallKit answer for matching UUID'
+          );
+          this.autoAnswerCallUUIDs.add(callKitUUID);
+          await VoicePnBridge.clearPendingCallKitAnswer();
+        }
+      } catch {
+        // The bridge method is unavailable on older native builds.
+      }
+
       // A pre-INVITE CallKit answer is represented only by the UUID-keyed
       // pending action. Do not also add legacy notification flags.
       const shouldAddFromNotification = this.autoAnswerCallUUIDs.has(callKitUUID);

--- a/react-voice-commons-sdk/src/callkit/callkit-coordinator.ts
+++ b/react-voice-commons-sdk/src/callkit/callkit-coordinator.ts
@@ -707,9 +707,7 @@ class CallKitCoordinator {
       try {
         const pendingAnswer = await VoicePnBridge.getPendingCallKitAnswer();
         if (pendingAnswer && this.normalizeUUID(pendingAnswer) === callKitUUID) {
-          console.log(
-            'CallKitCoordinator: Restoring pending CallKit answer for matching UUID'
-          );
+          console.log('CallKitCoordinator: Restoring pending CallKit answer for matching UUID');
           this.autoAnswerCallUUIDs.add(callKitUUID);
           await VoicePnBridge.clearPendingCallKitAnswer();
         }

--- a/react-voice-commons-sdk/src/internal/voice-pn-bridge.ts
+++ b/react-voice-commons-sdk/src/internal/voice-pn-bridge.ts
@@ -32,6 +32,10 @@ export interface VoicePnBridgeInterface {
   hideOngoingCallNotification(): Promise<boolean>;
   hideIncomingCallNotification(): Promise<boolean>;
 
+  // CallKit answer persistence (iOS only)
+  getPendingCallKitAnswer(): Promise<string | null>;
+  clearPendingCallKitAnswer(): Promise<boolean>;
+
   // Additional UserDefaults methods
   getVoipToken(): Promise<string | null>;
   getPendingVoipPush(): Promise<string | null>;
@@ -175,6 +179,34 @@ export class VoicePnBridge {
       return await NativeBridge.hideIncomingCallNotification();
     } catch (error) {
       console.error('VoicePnBridge: Error hiding incoming call notification:', error);
+      return false;
+    }
+  }
+
+  /**
+   * Get pending CallKit answer UUID from native storage (iOS only).
+   * When the user answers a CallKit call before JS listeners are ready,
+   * the native side persists the answer UUID in UserDefaults so JS can detect it.
+   */
+  static async getPendingCallKitAnswer(): Promise<string | null> {
+    if (Platform.OS !== 'ios') return null;
+    try {
+      return await NativeBridge.getPendingCallKitAnswer();
+    } catch (error) {
+      console.error('VoicePnBridge: Error getting pending CallKit answer:', error);
+      return null;
+    }
+  }
+
+  /**
+   * Clear pending CallKit answer from native storage (iOS only)
+   */
+  static async clearPendingCallKitAnswer(): Promise<boolean> {
+    if (Platform.OS !== 'ios') return true;
+    try {
+      return await NativeBridge.clearPendingCallKitAnswer();
+    } catch (error) {
+      console.error('VoicePnBridge: Error clearing pending CallKit answer:', error);
       return false;
     }
   }

--- a/react-voice-commons-sdk/src/internal/voice-pn-bridge.ts
+++ b/react-voice-commons-sdk/src/internal/voice-pn-bridge.ts
@@ -32,6 +32,10 @@ export interface VoicePnBridgeInterface {
   hideOngoingCallNotification(): Promise<boolean>;
   hideIncomingCallNotification(): Promise<boolean>;
 
+  // CallKit answer persistence (iOS only)
+  getPendingCallKitAnswer(): Promise<string | null>;
+  clearPendingCallKitAnswer(): Promise<boolean>;
+
   // Additional UserDefaults methods
   getVoipToken(): Promise<string | null>;
   getPendingVoipPush(): Promise<string | null>;
@@ -179,6 +183,34 @@ export class VoicePnBridge {
       return await NativeBridge.hideIncomingCallNotification();
     } catch (error) {
       console.error('VoicePnBridge: Error hiding incoming call notification:', error);
+      return false;
+    }
+  }
+
+  /**
+   * Get pending CallKit answer UUID from native storage (iOS only).
+   * When the user answers a CallKit call before JS listeners are ready,
+   * the native side persists the answer UUID in UserDefaults so JS can detect it.
+   */
+  static async getPendingCallKitAnswer(): Promise<string | null> {
+    if (Platform.OS !== 'ios') return null;
+    try {
+      return await NativeBridge.getPendingCallKitAnswer();
+    } catch (error) {
+      console.error('VoicePnBridge: Error getting pending CallKit answer:', error);
+      return null;
+    }
+  }
+
+  /**
+   * Clear pending CallKit answer from native storage (iOS only)
+   */
+  static async clearPendingCallKitAnswer(): Promise<boolean> {
+    if (Platform.OS !== 'ios') return true;
+    try {
+      return await NativeBridge.clearPendingCallKitAnswer();
+    } catch (error) {
+      console.error('VoicePnBridge: Error clearing pending CallKit answer:', error);
       return false;
     }
   }


### PR DESCRIPTION
## Summary
- Fixed CallKit auto-answer not working when user answers from CallKit UI during app cold launch from VoIP push
- Root cause: native `CXAnswerCallAction` event was silently dropped because `hasListeners` was `false` (JS bridge not yet ready)
- Fix: persist answer UUID in UserDefaults on native side, check it in `handleCallKitPushReceived` on JS side

## Changes
- **CallKitBridge.swift** — Store answer UUID in UserDefaults in `CXAnswerCallAction` handler; clear on `CXEndCallAction`
- **VoicePnBridge.swift/.m** — Add `getPendingCallKitAnswer` / `clearPendingCallKitAnswer` bridge methods
- **voice-pn-bridge.ts** — Add JS interface and static methods for new bridge methods
- **callkit-coordinator.ts** — Check `getPendingCallKitAnswer()` in `handleCallKitPushReceived`; clear on normal answer path and cleanup

## Test plan
- [ ] Cold launch from VoIP push → answer from CallKit UI → call should auto-answer (WebRTC)
- [ ] Foreground incoming call → answer from app UI → call works as before
- [ ] Decline call from CallKit → no stale auto-answer flag on next call
- [ ] Second call after first ends → no accidental auto-answer