### PR TITLE
fix: emit DISCONNECTED before client teardown to avoid stale CONNECTED reads

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -70,7 +70,7 @@ export default function RootLayout() {
   }, []);
 
   return (
-    <TelnyxVoiceApp voipClient={voipClient} enableAutoReconnect={false} debug={true}>
+    <TelnyxVoiceApp voipClient={voipClient} enableAutoReconnect={true} debug={true}>
       <ThemeProvider value={isDarkColorScheme ? DARK_THEME : LIGHT_THEME}>
         <StatusBar style="dark" backgroundColor="#ffffff" />
         <Stack

--- a/react-voice-commons-sdk/CHANGELOG.md
+++ b/react-voice-commons-sdk/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG.md
 
+## [0.2.1-beta.0] (2026-04-12)
+
+### Bug Fixing
+
+- Fixed stale `CONNECTED` state during background disconnect: `SessionManager.disconnect()` now emits `DISCONNECTED` before awaiting the underlying client teardown. Previously, observers (including the auto-reconnect logic in `TelnyxVoiceApp`) could read a stale `CONNECTED` value while the socket was being torn down, causing auto-reconnection to be skipped and subsequent `newCall()` attempts to fail with `Cannot make call when connection state is: DISCONNECTED` or `No connection exists. Please connect first.`
+- Tracked calls are now cleared on disconnect. Previously, calls left in non-terminal states when the socket was torn down would accumulate across background/foreground cycles, since a dead socket never emits the `ENDED`/`FAILED` events that normally trigger per-call cleanup.
+
 ## [0.2.0](https://github.com/team-telnyx/react-native-voice-commons/releases/tag/commons-sdk-v0.2.0) (2026-04-01)
 
 ### Enhancement

--- a/react-voice-commons-sdk/lib/internal/calls/call-state-controller.d.ts
+++ b/react-voice-commons-sdk/lib/internal/calls/call-state-controller.d.ts
@@ -72,6 +72,13 @@ export declare class CallStateController {
     onInviteAutoAccepted: () => void;
   }): void;
   /**
+   * Clear all tracked calls. Called when the session disconnects so that
+   * calls left in non-terminal states (because the socket died before
+   * their ENDED/FAILED events could arrive) don't accumulate as ghosts
+   * across reconnect cycles.
+   */
+  clearAllCalls(): void;
+  /**
    * Dispose of the controller and clean up resources
    */
   dispose(): void;

--- a/react-voice-commons-sdk/lib/internal/calls/call-state-controller.js
+++ b/react-voice-commons-sdk/lib/internal/calls/call-state-controller.js
@@ -162,6 +162,29 @@ class CallStateController {
     this._onInviteAutoAccepted = callbacks.onInviteAutoAccepted;
   }
   /**
+   * Clear all tracked calls. Called when the session disconnects so that
+   * calls left in non-terminal states (because the socket died before
+   * their ENDED/FAILED events could arrive) don't accumulate as ghosts
+   * across reconnect cycles.
+   */
+  clearAllCalls() {
+    if (this._callMap.size === 0) {
+      return;
+    }
+    console.log(
+      `CallStateController: Clearing ${this._callMap.size} tracked call(s) on disconnect`
+    );
+    for (const call of this._callMap.values()) {
+      try {
+        call.dispose();
+      } catch (error) {
+        console.warn('CallStateController: Error disposing call during clear:', error);
+      }
+    }
+    this._callMap.clear();
+    this._calls.next([]);
+  }
+  /**
    * Dispose of the controller and clean up resources
    */
   dispose() {

--- a/react-voice-commons-sdk/lib/internal/session/session-manager.d.ts
+++ b/react-voice-commons-sdk/lib/internal/session/session-manager.d.ts
@@ -15,6 +15,7 @@ export declare class SessionManager {
   private _sessionId;
   private _disposed;
   private _onClientReady?;
+  private _onDisconnect?;
   constructor();
   /**
    * Observable stream of connection state changes
@@ -24,6 +25,11 @@ export declare class SessionManager {
    * Set callback to be called when the Telnyx client is ready
    */
   setOnClientReady(callback: () => void): void;
+  /**
+   * Set callback to be called when the session disconnects, so dependent
+   * subsystems (e.g. the call state controller) can clear their state.
+   */
+  setOnDisconnect(callback: () => void): void;
   /**
    * Current connection state (synchronous access)
    */
@@ -45,7 +51,14 @@ export declare class SessionManager {
    */
   connectWithToken(config: TokenConfig): Promise<void>;
   /**
-   * Disconnect from the Telnyx platform
+   * Disconnect from the Telnyx platform.
+   *
+   * The DISCONNECTED state is emitted BEFORE awaiting the underlying
+   * client teardown so that observers (including the auto-reconnect logic
+   * in TelnyxVoiceApp) cannot read a stale CONNECTED value during the
+   * short window while the socket is being torn down. Tracked calls are
+   * cleared here too, since a torn-down socket will never emit the
+   * ENDED/FAILED events that normally trigger per-call cleanup.
    */
   disconnect(): Promise<void>;
   /**

--- a/react-voice-commons-sdk/lib/internal/session/session-manager.js
+++ b/react-voice-commons-sdk/lib/internal/session/session-manager.js
@@ -86,6 +86,13 @@ class SessionManager {
     this._onClientReady = callback;
   }
   /**
+   * Set callback to be called when the session disconnects, so dependent
+   * subsystems (e.g. the call state controller) can clear their state.
+   */
+  setOnDisconnect(callback) {
+    this._onDisconnect = callback;
+  }
+  /**
    * Current connection state (synchronous access)
    */
   get currentState() {
@@ -124,13 +131,28 @@ class SessionManager {
     await this._connect();
   }
   /**
-   * Disconnect from the Telnyx platform
+   * Disconnect from the Telnyx platform.
+   *
+   * The DISCONNECTED state is emitted BEFORE awaiting the underlying
+   * client teardown so that observers (including the auto-reconnect logic
+   * in TelnyxVoiceApp) cannot read a stale CONNECTED value during the
+   * short window while the socket is being torn down. Tracked calls are
+   * cleared here too, since a torn-down socket will never emit the
+   * ENDED/FAILED events that normally trigger per-call cleanup.
    */
   async disconnect() {
     if (this._disposed) {
       return;
     }
     this._currentConfig = undefined;
+    this._connectionState.next(connection_state_1.TelnyxConnectionState.DISCONNECTED);
+    if (this._onDisconnect) {
+      try {
+        this._onDisconnect();
+      } catch (error) {
+        console.error('Error in onDisconnect callback:', error);
+      }
+    }
     if (this._telnyxClient) {
       try {
         await this._telnyxClient.disconnect();
@@ -138,7 +160,6 @@ class SessionManager {
         console.error('Error during disconnect:', error);
       }
     }
-    this._connectionState.next(connection_state_1.TelnyxConnectionState.DISCONNECTED);
   }
   /**
    * Disable push notifications for the current session.

--- a/react-voice-commons-sdk/lib/telnyx-voip-client.js
+++ b/react-voice-commons-sdk/lib/telnyx-voip-client.js
@@ -66,6 +66,11 @@ class TelnyxVoipClient {
       );
       this._callStateController.initializeClientListeners();
     });
+    // Clear any tracked calls when the session disconnects, so ghosts
+    // don't accumulate across background → foreground reconnect cycles.
+    this._sessionManager.setOnDisconnect(() => {
+      this._callStateController.clearAllCalls();
+    });
     if (this._options.debug) {
       console.log('TelnyxVoipClient initialized with options:', this._options);
     }

--- a/react-voice-commons-sdk/package.json
+++ b/react-voice-commons-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@telnyx/react-voice-commons-sdk",
-  "version": "0.2.0",
+  "version": "0.2.1-beta.0",
   "description": "A high-level, state-agnostic, drop-in module for the Telnyx React Native SDK that simplifies WebRTC voice calling integration",
   "main": "lib/index.js",
   "module": "lib/index.js",

--- a/react-voice-commons-sdk/src/internal/calls/call-state-controller.ts
+++ b/react-voice-commons-sdk/src/internal/calls/call-state-controller.ts
@@ -191,6 +191,30 @@ export class CallStateController {
   }
 
   /**
+   * Clear all tracked calls. Called when the session disconnects so that
+   * calls left in non-terminal states (because the socket died before
+   * their ENDED/FAILED events could arrive) don't accumulate as ghosts
+   * across reconnect cycles.
+   */
+  clearAllCalls(): void {
+    if (this._callMap.size === 0) {
+      return;
+    }
+
+    console.log(`CallStateController: Clearing ${this._callMap.size} tracked call(s) on disconnect`);
+
+    for (const call of this._callMap.values()) {
+      try {
+        call.dispose();
+      } catch (error) {
+        console.warn('CallStateController: Error disposing call during clear:', error);
+      }
+    }
+    this._callMap.clear();
+    this._calls.next([]);
+  }
+
+  /**
    * Dispose of the controller and clean up resources
    */
   dispose(): void {

--- a/react-voice-commons-sdk/src/internal/calls/call-state-controller.ts
+++ b/react-voice-commons-sdk/src/internal/calls/call-state-controller.ts
@@ -201,7 +201,9 @@ export class CallStateController {
       return;
     }
 
-    console.log(`CallStateController: Clearing ${this._callMap.size} tracked call(s) on disconnect`);
+    console.log(
+      `CallStateController: Clearing ${this._callMap.size} tracked call(s) on disconnect`
+    );
 
     for (const call of this._callMap.values()) {
       try {

--- a/react-voice-commons-sdk/src/internal/session/session-manager.ts
+++ b/react-voice-commons-sdk/src/internal/session/session-manager.ts
@@ -26,6 +26,7 @@ export class SessionManager {
   private _sessionId: string;
   private _disposed = false;
   private _onClientReady?: () => void;
+  private _onDisconnect?: () => void;
 
   constructor() {
     this._sessionId = this._generateSessionId();
@@ -43,6 +44,14 @@ export class SessionManager {
    */
   setOnClientReady(callback: () => void): void {
     this._onClientReady = callback;
+  }
+
+  /**
+   * Set callback to be called when the session disconnects, so dependent
+   * subsystems (e.g. the call state controller) can clear their state.
+   */
+  setOnDisconnect(callback: () => void): void {
+    this._onDisconnect = callback;
   }
 
   /**
@@ -91,7 +100,14 @@ export class SessionManager {
   }
 
   /**
-   * Disconnect from the Telnyx platform
+   * Disconnect from the Telnyx platform.
+   *
+   * The DISCONNECTED state is emitted BEFORE awaiting the underlying
+   * client teardown so that observers (including the auto-reconnect logic
+   * in TelnyxVoiceApp) cannot read a stale CONNECTED value during the
+   * short window while the socket is being torn down. Tracked calls are
+   * cleared here too, since a torn-down socket will never emit the
+   * ENDED/FAILED events that normally trigger per-call cleanup.
    */
   async disconnect(): Promise<void> {
     if (this._disposed) {
@@ -99,6 +115,15 @@ export class SessionManager {
     }
 
     this._currentConfig = undefined;
+    this._connectionState.next(TelnyxConnectionState.DISCONNECTED);
+
+    if (this._onDisconnect) {
+      try {
+        this._onDisconnect();
+      } catch (error) {
+        console.error('Error in onDisconnect callback:', error);
+      }
+    }
 
     if (this._telnyxClient) {
       try {
@@ -107,8 +132,6 @@ export class SessionManager {
         console.error('Error during disconnect:', error);
       }
     }
-
-    this._connectionState.next(TelnyxConnectionState.DISCONNECTED);
   }
 
   /**

--- a/react-voice-commons-sdk/src/telnyx-voip-client.ts
+++ b/react-voice-commons-sdk/src/telnyx-voip-client.ts
@@ -82,6 +82,12 @@ export class TelnyxVoipClient {
       this._callStateController.initializeClientListeners();
     });
 
+    // Clear any tracked calls when the session disconnects, so ghosts
+    // don't accumulate across background → foreground reconnect cycles.
+    this._sessionManager.setOnDisconnect(() => {
+      this._callStateController.clearAllCalls();
+    });
+
     if (this._options.debug) {
       console.log('TelnyxVoipClient initialized with options:', this._options);
     }


### PR DESCRIPTION
## Summary

Fixes a race where `SessionManager.disconnect()` emitted `DISCONNECTED` on the connection state subject **after** awaiting the underlying `TelnyxRTC.disconnect()`. During that await, the subject still reported `CONNECTED` even though the socket had been torn down. Any observer reading `currentConnectionState` in that window saw a stale `CONNECTED` and made wrong decisions — most notably, the auto-reconnect logic in `TelnyxVoiceApp.handleAppResumed` checks this value to decide whether to reconnect on foreground, and a stale `CONNECTED` caused it to **skip reconnection entirely**.

Subsequent `newCall()` attempts then failed with one of two errors depending on timing:

- `Cannot make call when connection state is: DISCONNECTED` (from our own guard, after the late emit finally landed)
- `No connection exists. Please connect first.` (from `TelnyxRTC` directly, while the wrapper state was still the stale `CONNECTED`)

Both are the same underlying bug surfacing at different tap windows.

### Changes

- `SessionManager.disconnect()` now emits `DISCONNECTED` **before** awaiting client teardown, closing the stale-read window.
- Added `setOnDisconnect` callback hook on `SessionManager`, wired in `TelnyxVoipClient` to clear tracked calls via a new `CallStateController.clearAllCalls()`. A torn-down socket never emits `ENDED`/`FAILED`, so calls in non-terminal states were accumulating as ghosts across reconnect cycles.
- Version bumped to `0.2.1-beta.0` for customer beta testing.
- Demo app: `enableAutoReconnect={true}` (matches customer-facing recommendation).

## Test plan

- [x] On device (Android): log in → `CONNECTED`.
- [x] Background the app.
- [x] Foreground — watch logs for `DISCONNECTED` emitted immediately on background, then `CONNECTING → CONNECTED` on foreground via `loginFromStoredConfig`.
- [x] Make a call → should succeed without "No connection exists" or "Cannot make call…" errors.
- [x] Cycle background/foreground several times without calling → `currentCalls` should stay at 0, not accumulate.
- [x] Repeat on iOS.