### PR TITLE
feat!: 0.3.0 — remove expo-router coupling; support bare React Native

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -2,7 +2,7 @@ import '~/global.css';
 
 import { DarkTheme, DefaultTheme, Theme, ThemeProvider } from '@react-navigation/native';
 import { PortalHost } from '@rn-primitives/portal';
-import { Slot, Stack } from 'expo-router';
+import { router, Slot, Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import * as React from 'react';
 import { Appearance, Platform } from 'react-native';
@@ -10,6 +10,7 @@ import { setAndroidNavigationBar } from '~/lib/ui/android-navigation-bar';
 import { NAV_THEME } from '~/lib/theme/constants';
 import { useColorScheme } from '~/lib/theme/useColorScheme';
 import {
+  TelnyxConnectionState,
   TelnyxVoiceApp,
   TelnyxVoipClient,
   createTelnyxVoipClient,
@@ -67,6 +68,15 @@ export default function RootLayout() {
       // voipClient.loginFromStoredConfig();
       console.log('[RootLayout] Normal launch — auto-login could be triggered here');
     });
+  }, []);
+
+  React.useEffect(() => {
+    const sub = voipClient.connectionState$.subscribe((state) => {
+      if (state === TelnyxConnectionState.DISCONNECTED) {
+        router.replace('/');
+      }
+    });
+    return () => sub.unsubscribe();
   }, []);
 
   return (

--- a/react-voice-commons-sdk/CHANGELOG.md
+++ b/react-voice-commons-sdk/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG.md
 
+## [0.2.2] (2026-04-15)
+
+### Enhancement
+
+- Bare React Native (non-Expo) support: `expo-router` is now an optional peer dependency and `useAppStateHandler` guards its import at runtime, so bare RN projects that don't use Expo Router no longer fail Metro bundling when importing from the SDK. Navigation on background disconnect is skipped for hosts without expo-router; the host app is responsible for its own navigation.
+- `react-native-url-polyfill` is now a direct dependency and auto-loaded from the SDK entry point. Previously, bare RN apps running Hermes crashed on the second login attempt with `URLSearchParams.set is not implemented` because the SDK constructs the WebSocket URL via `URLSearchParams`, which is incomplete in Hermes.
+
 ## [0.2.0](https://github.com/team-telnyx/react-native-voice-commons/releases/tag/commons-sdk-v0.2.0) (2026-04-01)
 
 ### Enhancement

--- a/react-voice-commons-sdk/CHANGELOG.md
+++ b/react-voice-commons-sdk/CHANGELOG.md
@@ -1,11 +1,28 @@
 # CHANGELOG.md
 
-## [0.2.2] (2026-04-15)
+## [0.3.0] (2026-04-15)
+
+### ⚠️ Breaking changes
+
+- **`expo-router` is no longer a dependency of the SDK.** The SDK previously navigated the host app in a few places (`useAppStateHandler` on background disconnect, `CallKitHandler` after CallKit answer/end). Those calls have been removed — navigation is now exclusively the host app's responsibility.
+  - **Migration for Expo consumers:** subscribe to `voipClient.connectionState$` and `voipClient.activeCall$` in your app and navigate there. Example:
+    ```tsx
+    useEffect(() => {
+      const sub = voipClient.connectionState$.subscribe((state) => {
+        if (state === TelnyxConnectionState.DISCONNECTED) {
+          router.replace('/');
+        }
+      });
+      return () => sub.unsubscribe();
+    }, []);
+    ```
+  - `CallKitHandler` already exposed `onNavigateToDialer` / `onNavigateBack` callback props; those are now the only way to wire navigation.
+  - The `navigateToLoginOnDisconnect` option on `useAppStateHandler` is retained in the type signature for source compatibility but no longer has any effect.
+- **Bare React Native (non-Expo) projects are now supported.** Metro bundling no longer fails on missing `expo-router`; SDK-level behavior is identical for Expo and bare RN consumers.
 
 ### Enhancement
 
-- Bare React Native (non-Expo) support: `expo-router` is now an optional peer dependency and `useAppStateHandler` guards its import at runtime, so bare RN projects that don't use Expo Router no longer fail Metro bundling when importing from the SDK. Navigation on background disconnect is skipped for hosts without expo-router; the host app is responsible for its own navigation.
-- `react-native-url-polyfill` is now a direct dependency and auto-loaded from the SDK entry point. Previously, bare RN apps running Hermes crashed on the second login attempt with `URLSearchParams.set is not implemented` because the SDK constructs the WebSocket URL via `URLSearchParams`, which is incomplete in Hermes.
+- **`react-native-url-polyfill` is now a direct dependency and auto-loaded** from the SDK entry point. Previously, apps running Hermes crashed on the second login attempt with `URLSearchParams.set is not implemented` because the SDK constructs the WebSocket URL via `URLSearchParams`, which is incomplete in Hermes. No action required from consumers.
 
 ## [0.2.0](https://github.com/team-telnyx/react-native-voice-commons/releases/tag/commons-sdk-v0.2.0) (2026-04-01)
 

--- a/react-voice-commons-sdk/README.md
+++ b/react-voice-commons-sdk/README.md
@@ -11,6 +11,7 @@ A high-level, state-agnostic, drop-in module for the Telnyx React Native SDK tha
 - **Reactive State Management**: RxJS-based state streams for real-time UI updates
 - **TypeScript Support**: Full TypeScript definitions for better developer experience
 - **Cross-Platform**: Built for both iOS and Android with React Native
+- **Framework-agnostic**: Works in both Expo and bare React Native projects. See the [bare RN reference demo](https://github.com/team-telnyx/telnyx-react-native-bare-demo) for non-Expo integration.
 
 ## About @telnyx/react-voice-commons-sdk
 
@@ -114,6 +115,29 @@ call.callState$.subscribe((state) => {
   console.log('Call state:', state);
 });
 ```
+
+### Navigation
+
+As of **v0.3.0**, the SDK no longer navigates the host app. Routing on state transitions (e.g. redirecting to a login screen on disconnect, surfacing a dialer screen after answering a call via CallKit) is entirely the host app's responsibility. Subscribe to `connectionState$` and `activeCall$` and invoke your own navigator.
+
+Example using `expo-router`:
+
+```tsx
+import { router } from 'expo-router';
+import { useEffect } from 'react';
+import { TelnyxConnectionState } from '@telnyx/react-voice-commons-sdk';
+
+useEffect(() => {
+  const sub = voipClient.connectionState$.subscribe((state) => {
+    if (state === TelnyxConnectionState.DISCONNECTED) {
+      router.replace('/');
+    }
+  });
+  return () => sub.unsubscribe();
+}, []);
+```
+
+The same pattern works with `react-navigation`, React Router, or any other navigator — the SDK is agnostic.
 
 ### 4. Call Management
 

--- a/react-voice-commons-sdk/lib/hooks/useAppStateHandler.js
+++ b/react-voice-commons-sdk/lib/hooks/useAppStateHandler.js
@@ -11,17 +11,6 @@ const react_native_1 = require('react-native');
 const async_storage_1 = __importDefault(require('@react-native-async-storage/async-storage'));
 const connection_state_1 = require('../models/connection-state');
 const call_state_1 = require('../models/call-state');
-// Resolve `expo-router`'s router lazily so bare React Native projects (which
-// don't have expo-router installed) can import this hook without Metro
-// failing to bundle. If expo-router is absent, navigation calls become no-ops
-// and the host app is responsible for redirecting to its login screen.
-let router = null;
-try {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  router = require('expo-router').router;
-} catch {
-  router = null;
-}
 /**
  * Hook to handle app state changes for VoIP behavior
  * When app goes to background without an active call, disconnect socket and redirect to login
@@ -80,9 +69,6 @@ const useAppStateHandler = ({
               if (!stillInProgress) {
                 log('AppStateHandler: Push notification call completed, now disconnecting socket');
                 await voipClient.logout();
-                if (navigateToLoginOnDisconnect) {
-                  router?.replace('/');
-                }
               }
             }, 5000); // Wait 5 seconds
             appState.current = nextAppState;
@@ -93,14 +79,6 @@ const useAppStateHandler = ({
             // Disconnect the socket with background reason
             await voipClient.logout();
             log('AppStateHandler: Socket disconnected successfully');
-            // Navigate to login screen
-            if (navigateToLoginOnDisconnect) {
-              // Use a small delay to ensure the disconnect completes
-              setTimeout(() => {
-                log('AppStateHandler: Navigating to login screen');
-                router?.replace('/');
-              }, 100);
-            }
           } catch (error) {
             console.error('AppStateHandler: Error during background disconnect:', error);
           }

--- a/react-voice-commons-sdk/lib/hooks/useAppStateHandler.js
+++ b/react-voice-commons-sdk/lib/hooks/useAppStateHandler.js
@@ -8,10 +8,20 @@ Object.defineProperty(exports, '__esModule', { value: true });
 exports.useAppStateHandler = void 0;
 const react_1 = require('react');
 const react_native_1 = require('react-native');
-const expo_router_1 = require('expo-router');
 const async_storage_1 = __importDefault(require('@react-native-async-storage/async-storage'));
 const connection_state_1 = require('../models/connection-state');
 const call_state_1 = require('../models/call-state');
+// Resolve `expo-router`'s router lazily so bare React Native projects (which
+// don't have expo-router installed) can import this hook without Metro
+// failing to bundle. If expo-router is absent, navigation calls become no-ops
+// and the host app is responsible for redirecting to its login screen.
+let router = null;
+try {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  router = require('expo-router').router;
+} catch {
+  router = null;
+}
 /**
  * Hook to handle app state changes for VoIP behavior
  * When app goes to background without an active call, disconnect socket and redirect to login
@@ -71,7 +81,7 @@ const useAppStateHandler = ({
                 log('AppStateHandler: Push notification call completed, now disconnecting socket');
                 await voipClient.logout();
                 if (navigateToLoginOnDisconnect) {
-                  expo_router_1.router.replace('/');
+                  router?.replace('/');
                 }
               }
             }, 5000); // Wait 5 seconds
@@ -88,7 +98,7 @@ const useAppStateHandler = ({
               // Use a small delay to ensure the disconnect completes
               setTimeout(() => {
                 log('AppStateHandler: Navigating to login screen');
-                expo_router_1.router.replace('/');
+                router?.replace('/');
               }, 100);
             }
           } catch (error) {

--- a/react-voice-commons-sdk/lib/index.d.ts
+++ b/react-voice-commons-sdk/lib/index.d.ts
@@ -8,6 +8,7 @@
  * call state transitions, push notification processing, and native call UI
  * integration.
  */
+import 'react-native-url-polyfill/auto';
 export {
   TelnyxVoipClient,
   createTelnyxVoipClient,

--- a/react-voice-commons-sdk/lib/index.js
+++ b/react-voice-commons-sdk/lib/index.js
@@ -62,6 +62,10 @@ exports.useAppReadyNotifier =
   exports.createTelnyxVoipClient =
   exports.TelnyxVoipClient =
     void 0;
+// Polyfill URL / URLSearchParams so the WebSocket URL builder works under
+// Hermes (whose built-in URLSearchParams is missing .set/.get/.has).
+// Side-effect import — must run before any code that constructs URLs.
+require('react-native-url-polyfill/auto');
 // Main client
 var telnyx_voip_client_1 = require('./telnyx-voip-client');
 Object.defineProperty(exports, 'TelnyxVoipClient', {

--- a/react-voice-commons-sdk/lib/index.js
+++ b/react-voice-commons-sdk/lib/index.js
@@ -62,9 +62,6 @@ exports.useAppReadyNotifier =
   exports.createTelnyxVoipClient =
   exports.TelnyxVoipClient =
     void 0;
-// Polyfill URL / URLSearchParams so the WebSocket URL builder works under
-// Hermes (whose built-in URLSearchParams is missing .set/.get/.has).
-// Side-effect import — must run before any code that constructs URLs.
 require('react-native-url-polyfill/auto');
 // Main client
 var telnyx_voip_client_1 = require('./telnyx-voip-client');

--- a/react-voice-commons-sdk/lib/internal/CallKitHandler.js
+++ b/react-voice-commons-sdk/lib/internal/CallKitHandler.js
@@ -8,7 +8,6 @@ Object.defineProperty(exports, '__esModule', { value: true });
 exports.CallKitHandler = void 0;
 const react_1 = require('react');
 const react_native_1 = require('react-native');
-const expo_router_1 = require('expo-router');
 const async_storage_1 = __importDefault(require('@react-native-async-storage/async-storage'));
 const TelnyxVoiceContext_1 = require('../context/TelnyxVoiceContext');
 // Global flag to ensure only one CallKitHandler is active
@@ -20,7 +19,6 @@ let isCallKitHandlerActive = false;
  * @internal - Users should not use this component directly
  */
 const CallKitHandler = ({ onLoginRequired, onNavigateToDialer, onNavigateBack }) => {
-  const router = (0, expo_router_1.useRouter)();
   const { voipClient } = (0, TelnyxVoiceContext_1.useTelnyxVoice)();
   // Store active calls by CallKit UUID for coordination
   const activeCallsRef = (0, react_1.useRef)(new Map());
@@ -90,11 +88,8 @@ const CallKitHandler = ({ onLoginRequired, onNavigateToDialer, onNavigateBack })
       callUUID: eventData.callUUID,
       isTrackedCall: activeCallsRef.current.has(eventData.callUUID),
     });
-    // Navigate to dialer after answering
     if (onNavigateToDialer) {
       onNavigateToDialer();
-    } else {
-      router.replace('/dialer');
     }
   };
   const handleEndCall = async (eventData) => {
@@ -105,11 +100,8 @@ const CallKitHandler = ({ onLoginRequired, onNavigateToDialer, onNavigateBack })
     // Clean up our local tracking info
     activeCallsRef.current.delete(eventData.callUUID);
     await async_storage_1.default.removeItem('@push_notification_payload');
-    // Navigate back after call ends
     if (onNavigateBack) {
       onNavigateBack();
-    } else {
-      router.replace('/dialer');
     }
   };
   // This component doesn't render anything, it just handles events

--- a/react-voice-commons-sdk/package.json
+++ b/react-voice-commons-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@telnyx/react-voice-commons-sdk",
-  "version": "0.2.0",
+  "version": "0.2.2",
   "description": "A high-level, state-agnostic, drop-in module for the Telnyx React Native SDK that simplifies WebRTC voice calling integration",
   "main": "lib/index.js",
   "module": "lib/index.js",
@@ -76,7 +76,7 @@
       "optional": false
     },
     "expo-router": {
-      "optional": false
+      "optional": true
     },
     "react": {
       "optional": false
@@ -93,6 +93,7 @@
     "@telnyx/react-native-voice-sdk": "file:../package",
     "eventemitter3": "^5.0.1",
     "expo": "~53.0.22",
+    "react-native-url-polyfill": "^3.0.0",
     "react-native-voip-push-notification": "^3.3.3",
     "rxjs": "^7.8.2"
   },
@@ -101,15 +102,15 @@
     "@types/jest": "^29.5.0",
     "@types/react": "~19.0.14",
     "@types/react-native": "^0.72.8",
-    "expo-router": "^5.1.0",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",
     "eslint": "^8.0.0",
+    "expo-router": "^5.1.0",
     "jest": "^29.5.0",
+    "prettier": "^3.0.0",
     "ts-jest": "^29.1.0",
     "typedoc": "^0.28.14",
     "typedoc-plugin-markdown": "^4.9.0",
-    "prettier": "^3.0.0",
     "typescript": "^5.0.0"
   },
   "engines": {

--- a/react-voice-commons-sdk/package.json
+++ b/react-voice-commons-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@telnyx/react-voice-commons-sdk",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "A high-level, state-agnostic, drop-in module for the Telnyx React Native SDK that simplifies WebRTC voice calling integration",
   "main": "lib/index.js",
   "module": "lib/index.js",
@@ -66,7 +66,6 @@
   },
   "peerDependencies": {
     "@react-native-async-storage/async-storage": "^2.1.0",
-    "expo-router": "^5.1.0",
     "react": ">=19.0.0 <20.0.0",
     "react-native": ">=0.79.0 <1.0.0",
     "react-native-webrtc": "^124.0.5"
@@ -74,9 +73,6 @@
   "peerDependenciesMeta": {
     "@react-native-async-storage/async-storage": {
       "optional": false
-    },
-    "expo-router": {
-      "optional": true
     },
     "react": {
       "optional": false
@@ -105,7 +101,6 @@
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",
     "eslint": "^8.0.0",
-    "expo-router": "^5.1.0",
     "jest": "^29.5.0",
     "prettier": "^3.0.0",
     "ts-jest": "^29.1.0",

--- a/react-voice-commons-sdk/src/callkit/callkit-coordinator.ts
+++ b/react-voice-commons-sdk/src/callkit/callkit-coordinator.ts
@@ -2,7 +2,6 @@ import { Platform, AppState } from 'react-native';
 import CallKit, { CallEndReason } from './callkit';
 import { Call } from '@telnyx/react-native-voice-sdk';
 import { VoicePnBridge } from '../internal/voice-pn-bridge';
-import { router } from 'expo-router';
 import { TelnyxVoipClient } from '../telnyx-voip-client';
 import { TelnyxConnectionState } from '../models/connection-state';
 import { act } from 'react';

--- a/react-voice-commons-sdk/src/hooks/useAppStateHandler.ts
+++ b/react-voice-commons-sdk/src/hooks/useAppStateHandler.ts
@@ -1,10 +1,21 @@
 import { useEffect, useRef } from 'react';
 import { AppState, AppStateStatus } from 'react-native';
-import { router } from 'expo-router';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { TelnyxVoipClient } from '../telnyx-voip-client';
 import { TelnyxConnectionState } from '../models/connection-state';
 import { TelnyxCallState, CallStateHelpers } from '../models/call-state';
+
+// Resolve `expo-router`'s router lazily so bare React Native projects (which
+// don't have expo-router installed) can import this hook without Metro
+// failing to bundle. If expo-router is absent, navigation calls become no-ops
+// and the host app is responsible for redirecting to its login screen.
+let router: { replace: (path: string) => void } | null = null;
+try {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  router = require('expo-router').router;
+} catch {
+  router = null;
+}
 
 interface UseAppStateHandlerOptions {
   voipClient: TelnyxVoipClient;
@@ -77,7 +88,7 @@ export const useAppStateHandler = ({
                 log('AppStateHandler: Push notification call completed, now disconnecting socket');
                 await voipClient.logout();
                 if (navigateToLoginOnDisconnect) {
-                  router.replace('/');
+                  router?.replace('/');
                 }
               }
             }, 5000); // Wait 5 seconds
@@ -98,7 +109,7 @@ export const useAppStateHandler = ({
               // Use a small delay to ensure the disconnect completes
               setTimeout(() => {
                 log('AppStateHandler: Navigating to login screen');
-                router.replace('/');
+                router?.replace('/');
               }, 100);
             }
           } catch (error) {

--- a/react-voice-commons-sdk/src/hooks/useAppStateHandler.ts
+++ b/react-voice-commons-sdk/src/hooks/useAppStateHandler.ts
@@ -5,18 +5,6 @@ import { TelnyxVoipClient } from '../telnyx-voip-client';
 import { TelnyxConnectionState } from '../models/connection-state';
 import { TelnyxCallState, CallStateHelpers } from '../models/call-state';
 
-// Resolve `expo-router`'s router lazily so bare React Native projects (which
-// don't have expo-router installed) can import this hook without Metro
-// failing to bundle. If expo-router is absent, navigation calls become no-ops
-// and the host app is responsible for redirecting to its login screen.
-let router: { replace: (path: string) => void } | null = null;
-try {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  router = require('expo-router').router;
-} catch {
-  router = null;
-}
-
 interface UseAppStateHandlerOptions {
   voipClient: TelnyxVoipClient;
   disconnectOnBackground?: boolean;
@@ -87,9 +75,6 @@ export const useAppStateHandler = ({
               if (!stillInProgress) {
                 log('AppStateHandler: Push notification call completed, now disconnecting socket');
                 await voipClient.logout();
-                if (navigateToLoginOnDisconnect) {
-                  router?.replace('/');
-                }
               }
             }, 5000); // Wait 5 seconds
             appState.current = nextAppState;
@@ -103,15 +88,6 @@ export const useAppStateHandler = ({
             await voipClient.logout();
 
             log('AppStateHandler: Socket disconnected successfully');
-
-            // Navigate to login screen
-            if (navigateToLoginOnDisconnect) {
-              // Use a small delay to ensure the disconnect completes
-              setTimeout(() => {
-                log('AppStateHandler: Navigating to login screen');
-                router?.replace('/');
-              }, 100);
-            }
           } catch (error) {
             console.error('AppStateHandler: Error during background disconnect:', error);
           }

--- a/react-voice-commons-sdk/src/index.ts
+++ b/react-voice-commons-sdk/src/index.ts
@@ -9,9 +9,6 @@
  * integration.
  */
 
-// Polyfill URL / URLSearchParams so the WebSocket URL builder works under
-// Hermes (whose built-in URLSearchParams is missing .set/.get/.has).
-// Side-effect import — must run before any code that constructs URLs.
 import 'react-native-url-polyfill/auto';
 
 // Main client

--- a/react-voice-commons-sdk/src/index.ts
+++ b/react-voice-commons-sdk/src/index.ts
@@ -9,6 +9,11 @@
  * integration.
  */
 
+// Polyfill URL / URLSearchParams so the WebSocket URL builder works under
+// Hermes (whose built-in URLSearchParams is missing .set/.get/.has).
+// Side-effect import — must run before any code that constructs URLs.
+import 'react-native-url-polyfill/auto';
+
 // Main client
 export {
   TelnyxVoipClient,

--- a/react-voice-commons-sdk/src/internal/CallKitHandler.tsx
+++ b/react-voice-commons-sdk/src/internal/CallKitHandler.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useRef } from 'react';
 import { Platform, DeviceEventEmitter } from 'react-native';
-import { useRouter } from 'expo-router';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useTelnyxVoice } from '../context/TelnyxVoiceContext';
 import { callKitCoordinator } from '../callkit';
@@ -36,7 +35,6 @@ export const CallKitHandler: React.FC<CallKitHandlerProps> = ({
   onNavigateToDialer,
   onNavigateBack,
 }) => {
-  const router = useRouter();
   const { voipClient } = useTelnyxVoice();
 
   // Store active calls by CallKit UUID for coordination
@@ -118,11 +116,8 @@ export const CallKitHandler: React.FC<CallKitHandlerProps> = ({
       isTrackedCall: activeCallsRef.current.has(eventData.callUUID),
     });
 
-    // Navigate to dialer after answering
     if (onNavigateToDialer) {
       onNavigateToDialer();
-    } else {
-      router.replace('/dialer');
     }
   };
 
@@ -136,11 +131,8 @@ export const CallKitHandler: React.FC<CallKitHandlerProps> = ({
     activeCallsRef.current.delete(eventData.callUUID);
     await AsyncStorage.removeItem('@push_notification_payload');
 
-    // Navigate back after call ends
     if (onNavigateBack) {
       onNavigateBack();
-    } else {
-      router.replace('/dialer');
     }
   };
 


### PR DESCRIPTION
## Summary

**Breaking change (v0.3.0).** Removes the SDK's coupling to `expo-router` entirely. Navigation on state transitions becomes the host app's responsibility. Enables use of the SDK in bare React Native (non-Expo) projects.

## Breaking changes

### `expo-router` is no longer a dependency of the SDK

Three call sites that previously invoked `router.replace()` now no-op:

- `useAppStateHandler` — used to `router.replace('/')` on background disconnect
- `CallKitHandler.handleAnswerCall` — used to `router.replace('/dialer')` when no `onNavigateToDialer` callback was provided
- `CallKitHandler.handleEndCall` — used to `router.replace('/dialer')` when no `onNavigateBack` callback was provided

`expo-router` is removed from `peerDependencies` / `peerDependenciesMeta` / `devDependencies`.

### Migration for Expo consumers

Subscribe to `voipClient.connectionState$` / `voipClient.activeCall$` and navigate from app code:

```tsx
import { router } from 'expo-router';
import { TelnyxConnectionState } from '@telnyx/react-voice-commons-sdk';

useEffect(() => {
  const sub = voipClient.connectionState$.subscribe((state) => {
    if (state === TelnyxConnectionState.DISCONNECTED) {
      router.replace('/');
    }
  });
  return () => sub.unsubscribe();
}, []);
```

The Expo demo (`app/_layout.tsx`) in this PR demonstrates the migration.

For `CallKitHandler` consumers: pass the `onNavigateToDialer` / `onNavigateBack` callback props that the component already exposes (no change — these were already the documented way to wire navigation).

## Non-breaking changes

### `react-native-url-polyfill` auto-loaded

Previously, apps running Hermes crashed on the second login attempt with `URLSearchParams.set is not implemented`. Hermes's built-in `URLSearchParams` is incomplete, and the SDK builds the WebSocket URL via `URLSearchParams`.

The polyfill is now a direct dependency and side-effect imported from `src/index.ts`, so any consumer who imports from the SDK gets the polyfill auto-loaded before any SDK code runs. No action required from consumers.

## Test plan

- [ ] Existing Expo demo still builds and navigates to `/` on background disconnect (now via app-level subscription)
- [ ] Bare React Native 0.79 demo ([telnyx-react-native-bare-demo](https://github.com/team-telnyx/telnyx-react-native-bare-demo)) installs and runs without installing expo-router
- [ ] Logout → login cycle no longer crashes with `URLSearchParams.set is not implemented`
- [ ] CallKit answer/end in the Expo demo still navigates correctly (via the `onNavigateTo*` callback pattern)

## Context

The design gaps this PR closes were discovered while building a bare RN reference demo at https://github.com/team-telnyx/telnyx-react-native-bare-demo. Full integration notes + the checklist of undocumented transitive deps are in that repo's README.