### PR TITLE
fix(ci): pin npm to @11 in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Upgrade npm for OIDC trusted publishing
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
 
       - name: Verify tag version matches package.json
         working-directory: package
@@ -75,7 +75,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Upgrade npm for OIDC trusted publishing
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
 
       - name: Verify tag version matches package.json
         working-directory: react-voice-commons-sdk


### PR DESCRIPTION
## Summary

Replaces \`npm install -g npm@latest\` with \`npm install -g npm@11\` in both jobs of \`.github/workflows/publish.yml\`.

## Why

Release runs were failing intermittently with:

\`\`\`
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
\`\`\`

This is a [known npm self-upgrade race](https://github.com/npm/cli/issues/6032) where the old npm's modules get torn down before the new ones are in place. Pinning to the current major version (\`npm@11\`) sidesteps the race while still giving us OIDC trusted publishing support.

## Test plan

- [ ] Create a new release tag and confirm the \`publish.yml\` workflow completes without the \`promise-retry\` error