### PR TITLE
fix(ci): use corepack instead of npm self-upgrade in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: '22'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Verify tag version matches package.json
@@ -68,7 +68,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: '22'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Verify tag version matches package.json

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,7 @@ jobs:
         # "Cannot find module 'promise-retry'" while the old npm is mid-teardown.
         run: |
           corepack enable
-          corepack prepare npm@11.5.1 --activate
+          corepack prepare npm@11 --activate
           npm --version
 
       - name: Verify tag version matches package.json
@@ -58,7 +58,7 @@ jobs:
 
       - name: Publish with provenance
         working-directory: package
-        run: npm publish --provenance --access public
+        run: npm publish --provenance --access public --verbose
 
   publish-commons-sdk:
     name: Publish @telnyx/react-voice-commons-sdk
@@ -86,7 +86,7 @@ jobs:
         # "Cannot find module 'promise-retry'" while the old npm is mid-teardown.
         run: |
           corepack enable
-          corepack prepare npm@11.5.1 --activate
+          corepack prepare npm@11 --activate
           npm --version
 
       - name: Verify tag version matches package.json
@@ -113,4 +113,4 @@ jobs:
 
       - name: Publish with provenance
         working-directory: react-voice-commons-sdk
-        run: npm publish --provenance --access public
+        run: npm publish --provenance --access public --verbose

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,13 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Upgrade npm for OIDC trusted publishing
-        run: npm install -g npm@11
+        # Use corepack instead of `npm install -g npm@<ver>` because the
+        # self-replacement races on CI and intermittently fails with
+        # "Cannot find module 'promise-retry'" while the old npm is mid-teardown.
+        run: |
+          corepack enable
+          corepack prepare npm@11.5.1 --activate
+          npm --version
 
       - name: Verify tag version matches package.json
         working-directory: package
@@ -75,7 +81,13 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Upgrade npm for OIDC trusted publishing
-        run: npm install -g npm@11
+        # Use corepack instead of `npm install -g npm@<ver>` because the
+        # self-replacement races on CI and intermittently fails with
+        # "Cannot find module 'promise-retry'" while the old npm is mid-teardown.
+        run: |
+          corepack enable
+          corepack prepare npm@11.5.1 --activate
+          npm --version
 
       - name: Verify tag version matches package.json
         working-directory: react-voice-commons-sdk

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,13 +32,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Upgrade npm for OIDC trusted publishing
-        # Use corepack instead of `npm install -g npm@<ver>` because the
-        # self-replacement races on CI and intermittently fails with
-        # "Cannot find module 'promise-retry'" while the old npm is mid-teardown.
-        run: |
-          corepack enable
-          corepack prepare npm@11 --activate
-          npm --version
+        run: npm install -g npm@latest
 
       - name: Verify tag version matches package.json
         working-directory: package
@@ -58,7 +52,7 @@ jobs:
 
       - name: Publish with provenance
         working-directory: package
-        run: npm publish --provenance --access public --verbose
+        run: npm publish --provenance --access public
 
   publish-commons-sdk:
     name: Publish @telnyx/react-voice-commons-sdk
@@ -81,13 +75,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Upgrade npm for OIDC trusted publishing
-        # Use corepack instead of `npm install -g npm@<ver>` because the
-        # self-replacement races on CI and intermittently fails with
-        # "Cannot find module 'promise-retry'" while the old npm is mid-teardown.
-        run: |
-          corepack enable
-          corepack prepare npm@11 --activate
-          npm --version
+        run: npm install -g npm@latest
 
       - name: Verify tag version matches package.json
         working-directory: react-voice-commons-sdk
@@ -113,4 +101,4 @@ jobs:
 
       - name: Publish with provenance
         working-directory: react-voice-commons-sdk
-        run: npm publish --provenance --access public --verbose
+        run: npm publish --provenance --access public

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,15 +47,6 @@ jobs:
         working-directory: package
         run: npm install --legacy-peer-deps
 
-      - name: Debug OIDC token claims
-        run: |
-          TOKEN=$(curl -sLS \
-            -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=npm:registry.npmjs.org" | jq -r .value)
-          echo "----- OIDC claims (publish-voice-sdk) -----"
-          echo "$TOKEN" | cut -d. -f2 | base64 -d 2>/dev/null | jq .
-          echo "-------------------------------------------"
-
       - name: Publish with provenance
         working-directory: package
         run: npm publish --provenance --access public
@@ -101,15 +92,6 @@ jobs:
       - name: Build
         working-directory: react-voice-commons-sdk
         run: npm run build
-
-      - name: Debug OIDC token claims
-        run: |
-          TOKEN=$(curl -sLS \
-            -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=npm:registry.npmjs.org" | jq -r .value)
-          echo "----- OIDC claims (publish-commons-sdk) -----"
-          echo "$TOKEN" | cut -d. -f2 | base64 -d 2>/dev/null | jq .
-          echo "---------------------------------------------"
 
       - name: Publish with provenance
         working-directory: react-voice-commons-sdk

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,9 +31,6 @@ jobs:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Upgrade npm for OIDC trusted publishing
-        run: npm install -g npm@latest
-
       - name: Verify tag version matches package.json
         working-directory: package
         run: |
@@ -49,6 +46,15 @@ jobs:
       - name: Install dependencies
         working-directory: package
         run: npm install --legacy-peer-deps
+
+      - name: Debug OIDC token claims
+        run: |
+          TOKEN=$(curl -sLS \
+            -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=npm:registry.npmjs.org" | jq -r .value)
+          echo "----- OIDC claims (publish-voice-sdk) -----"
+          echo "$TOKEN" | cut -d. -f2 | base64 -d 2>/dev/null | jq .
+          echo "-------------------------------------------"
 
       - name: Publish with provenance
         working-directory: package
@@ -74,9 +80,6 @@ jobs:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Upgrade npm for OIDC trusted publishing
-        run: npm install -g npm@latest
-
       - name: Verify tag version matches package.json
         working-directory: react-voice-commons-sdk
         run: |
@@ -98,6 +101,15 @@ jobs:
       - name: Build
         working-directory: react-voice-commons-sdk
         run: npm run build
+
+      - name: Debug OIDC token claims
+        run: |
+          TOKEN=$(curl -sLS \
+            -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=npm:registry.npmjs.org" | jq -r .value)
+          echo "----- OIDC claims (publish-commons-sdk) -----"
+          echo "$TOKEN" | cut -d. -f2 | base64 -d 2>/dev/null | jq .
+          echo "---------------------------------------------"
 
       - name: Publish with provenance
         working-directory: react-voice-commons-sdk

--- a/package/package.json
+++ b/package/package.json
@@ -63,6 +63,7 @@
     "node": ">=16"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   }
 }

--- a/react-voice-commons-sdk/package.json
+++ b/react-voice-commons-sdk/package.json
@@ -112,6 +112,7 @@
     "node": ">=16"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   }
 }


### PR DESCRIPTION
## Summary

Replaces \`npm install -g npm@11\` with a corepack-based install in both jobs of \`.github/workflows/publish.yml\`.

## Why

#50 pinned the target version to \`npm@11\` to avoid chasing the unreleased tip, but the failure continued:

\`\`\`
Run npm install -g npm@11
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
\`\`\`

Turns out the bug is in npm's **self-replacement mechanism itself**, not in any particular target version. When \`npm install -g npm@<anything>\` runs, the currently-executing npm gets torn down and the new one is unpacked in place — and on CI runners with certain filesystem/timing behavior, the teardown and replacement interleave in a way that leaves npm's own module tree partially missing.

## Fix

Use [\`corepack\`](https://nodejs.org/api/corepack.html), which is Node's built-in tool for managing package manager versions. Corepack installs npm into a separate location and atomically activates it via the \`PATH\` — no self-replacement, no race.

\`\`\`yaml
- run: |
    corepack enable
    corepack prepare npm@11.5.1 --activate
    npm --version
\`\`\`

Pinned to \`11.5.1\` because that's the first npm version with full OIDC trusted publishing + provenance support.

## Test plan

- [ ] Trigger a release (create a new tag) and confirm both publish jobs complete without the \`promise-retry\` error