### PR TITLE
fix(ci): strip git+ prefix from repository.url for OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: '24'
+          registry-url: 'https://registry.npmjs.org/'
 
       - name: Verify tag version matches package.json
         working-directory: package
@@ -68,6 +69,7 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: '24'
+          registry-url: 'https://registry.npmjs.org/'
 
       - name: Verify tag version matches package.json
         working-directory: react-voice-commons-sdk

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,6 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: '24'
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Verify tag version matches package.json
         working-directory: package
@@ -69,7 +68,6 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: '24'
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Verify tag version matches package.json
         working-directory: react-voice-commons-sdk

--- a/package/package.json
+++ b/package/package.json
@@ -34,7 +34,7 @@
   "homepage": "https://github.com/team-telnyx/react-native-voice-commons",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/team-telnyx/react-native-voice-commons.git"
+    "url": "https://github.com/team-telnyx/react-native-voice-commons.git"
   },
   "bugs": {
     "url": "https://github.com/team-telnyx/react-native-voice-sdk/issues"

--- a/react-voice-commons-sdk/package.json
+++ b/react-voice-commons-sdk/package.json
@@ -59,7 +59,7 @@
   "homepage": "https://github.com/team-telnyx/react-native-voice-commons",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/team-telnyx/react-native-voice-commons.git"
+    "url": "https://github.com/team-telnyx/react-native-voice-commons.git"
   },
   "bugs": {
     "url": "https://github.com/team-telnyx/react-native-voice-commons/issues"


### PR DESCRIPTION
## Summary

Unblocks OIDC trusted publishing of \`@telnyx/react-voice-commons-sdk\` and \`@telnyx/react-native-voice-sdk\` from GitHub Actions.

## What changed

1. \`react-voice-commons-sdk/package.json\` — \`repository.url\`: \`git+https://...\` → \`https://...\`
2. \`package/package.json\` — same
3. \`.github/workflows/publish.yml\` — \`registry-url\` restored with trailing slash (\`https://registry.npmjs.org/\`) to match npm's official trusted-publisher docs and a working dev.to reference config

## Why

After extensive debugging of \`E404 - PUT /@telnyx/react-voice-commons-sdk\` on every OIDC publish attempt, and verifying everything in [npm/cli#8730](https://github.com/npm/cli/issues/8730) including:

- Node 24 with bundled npm 11.x
- \`id-token: write\` permission
- Matching \`environment: npm-pub\`
- \`publishConfig.provenance: true\`
- Trusted publisher entry deleted and recreated
- OIDC token claims verified identical to trusted-publisher config

…the publish succeeded only after stripping the \`git+\` prefix from \`repository.url\`. Matches npm's docs example format (\`"url": "https://github.com/..."\`). The trailing slash on \`registry-url\` is a belt-and-suspenders alignment with npm's [documentation](https://github.com/npm/documentation/pull/1820).

\`0.3.1\` was published via this config:  https://www.npmjs.com/package/@telnyx/react-voice-commons-sdk/v/0.3.1

## Test plan

- [x] Cut release \`commons-sdk-v0.3.1\` from this branch → workflow publishes to npm successfully via OIDC (confirmed: 0.3.1 is live)