### PR TITLE
docs: rewrite push notification guidance; fix double-login anti-pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ CallKit (iOS) and ConnectionService (Android) already render the native incoming
 
 #### Detecting a Push-Launched Cold Start
 
-When the OS wakes your app from a terminated state to deliver a call, the SDK is already logging in with stored credentials as part of the push flow. If your app *also* triggers a login on mount, you will get two competing sessions (double-login), which causes the call to fail or the socket to churn.
+When the OS wakes your app from a terminated state to deliver a call, the SDK is already logging in with stored credentials as part of the push flow. If your app _also_ triggers a login on mount, you will get two competing sessions (double-login), which causes the call to fail or the socket to churn.
 
 Use `TelnyxVoipClient.isLaunchedFromPushNotification()` to skip your own login when a push is in flight:
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,25 @@ You do not need to wire up JS push handlers. The native layer does the work:
 - **Android**: `TelnyxFirebaseMessagingService` receives the FCM message, shows the incoming call notification, and (on Answer/Decline) launches `TelnyxMainActivity` with the call intent.
 - **iOS**: `TelnyxVoipPushHandler` receives the PushKit payload and reports the call to CallKit.
 
-In both cases the SDK connects the socket and restores the call internally — you just observe `voipClient.calls$` to render UI.
+In both cases the SDK connects the socket and restores the call internally — you just observe the VoIP client's streams to render UI.
+
+**What to observe after the SDK-driven push login:**
+
+- `voipClient.connectionState$` — emits `CONNECTED` when the socket is up and authenticated (there is no separate `loginState$`).
+- `voipClient.activeCall$` — emits the `Call` once the SDK has processed the push and the call has arrived. Navigate to your in-call screen here.
+- `voipClient.currentActiveCall` — synchronous accessor for the cold-start race: on a push-launched mount, the call may already be present by the time you subscribe, so check this first and route immediately if set.
+
+```tsx
+React.useEffect(() => {
+  if (voipClient.currentActiveCall) router.replace('/call');
+  const sub = voipClient.activeCall$.subscribe((call) => {
+    if (call) router.replace('/call');
+  });
+  return () => sub.unsubscribe();
+}, []);
+```
+
+CallKit (iOS) and ConnectionService (Android) already render the native incoming-call UI, so this navigation only matters once the user taps into the app.
 
 #### Detecting a Push-Launched Cold Start
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,64 @@ await call.hold();
 await call.hangup();
 ```
 
+### 5. Push Notification Flow (What Actually Happens)
+
+You do not need to wire up JS push handlers. The native layer does the work:
+
+- **Android**: `TelnyxFirebaseMessagingService` receives the FCM message, shows the incoming call notification, and (on Answer/Decline) launches `TelnyxMainActivity` with the call intent.
+- **iOS**: `TelnyxVoipPushHandler` receives the PushKit payload and reports the call to CallKit.
+
+In both cases the SDK connects the socket and restores the call internally — you just observe `voipClient.calls$` to render UI.
+
+#### Detecting a Push-Launched Cold Start
+
+When the OS wakes your app from a terminated state to deliver a call, the SDK is already logging in with stored credentials as part of the push flow. If your app *also* triggers a login on mount, you will get two competing sessions (double-login), which causes the call to fail or the socket to churn.
+
+Use `TelnyxVoipClient.isLaunchedFromPushNotification()` to skip your own login when a push is in flight:
+
+```tsx
+import { TelnyxVoipClient } from '@telnyx/react-voice-commons-sdk';
+
+React.useEffect(() => {
+  TelnyxVoipClient.isLaunchedFromPushNotification().then((isFromPush) => {
+    if (isFromPush) {
+      // SDK is handling login via the push flow — do nothing.
+      return;
+    }
+    // Normal cold start — safe to auto-login.
+    voipClient.loginFromStoredConfig();
+  });
+}, []);
+```
+
+This is a static method (callable before the client is constructed) and works on both platforms. It returns `true` if the app was launched by an FCM intent (Android) or a PushKit payload (iOS) that has not yet been consumed.
+
+#### Common Mistake: Manual or Automatic Login on Push
+
+The single most common integration bug is re-logging in while the SDK is already handling a push:
+
+**Do not do this:**
+
+```tsx
+// WRONG — runs on every mount, including push-launched cold starts
+React.useEffect(() => {
+  voipClient.login(config); // or loginFromStoredConfig(), or loginWithToken()
+}, []);
+```
+
+**Do this instead:**
+
+```tsx
+// Right — guard the login on push-launched cold starts
+React.useEffect(() => {
+  TelnyxVoipClient.isLaunchedFromPushNotification().then((isFromPush) => {
+    if (!isFromPush) voipClient.loginFromStoredConfig();
+  });
+}, []);
+```
+
+Symptoms of getting this wrong: the incoming call rings briefly then disappears, the socket disconnects mid-call, or CallKit shows a call that immediately ends. If you see those, check whether your app is calling `login*` unconditionally on mount.
+
 ### Authentication & Persistent Storage
 
 The library supports both credential-based and token-based authentication with automatic persistence for seamless reconnection.
@@ -231,17 +289,10 @@ The `TelnyxMainActivity` provides:
 
 ### 2. Push Notification Setup
 
-1. Place `google-services.json` in the project root
-2. Register background message handler:
+1. Place `google-services.json` in the project root.
+2. Create an FCM service that extends `TelnyxFirebaseMessagingService` and a notification action receiver that extends `TelnyxNotificationActionReceiver`, then register both in `AndroidManifest.xml`. See [docs-markdown/push-notification/app-setup.md](./docs-markdown/push-notification/app-setup.md) for the full manifest + Kotlin boilerplate.
 
-```tsx
-import messaging from '@react-native-firebase/messaging';
-import { TelnyxVoiceApp } from '@telnyx/react-voice-commons-sdk';
-
-messaging().setBackgroundMessageHandler(async (remoteMessage) => {
-  await TelnyxVoiceApp.handleBackgroundPush(remoteMessage.data);
-});
-```
+> **Do not** register `messaging().setBackgroundMessageHandler(...)` from JS. Android push is handled entirely by the native `TelnyxFirebaseMessagingService` — adding a JS handler will fight the native layer and can double-process calls. There is no `TelnyxVoiceApp.handleBackgroundPush` step required on Android.
 
 ### iOS Integration
 
@@ -422,7 +473,10 @@ npx expo run:ios
 
 ### Double Login
 
-Ensure you're not calling login methods manually when using `TelnyxVoiceApp` with auto-reconnection enabled.
+Two causes to check:
+
+1. You're calling `login*` manually while `TelnyxVoiceApp` is running with `enableAutoReconnect={true}` — pick one.
+2. You're calling `login*` on mount without guarding against push-launched cold starts. Wrap the call with `TelnyxVoipClient.isLaunchedFromPushNotification()` — see [Push Notification Flow](#5-push-notification-flow-what-actually-happens).
 
 ### Background Disconnection
 
@@ -438,7 +492,7 @@ Check if `enableAutoReconnect` is set appropriately for your use case in the `Te
   - Ensure VoIP push certificates are configured in your Apple Developer account
   - Verify AppDelegate implements `PKPushRegistryDelegate` and delegates to `TelnyxVoipPushHandler`
   - Check that `TelnyxVoipPushHandler.initializeVoipRegistration()` is called in `didFinishLaunchingWithOptions`
-- **Both**: Check that background message handlers are properly registered
+- **Both**: Verify the SDK is authenticated (or has stored credentials) — the native push flow will attempt to log in using stored credentials when a call comes in
 
 ### Native Integration Issues
 

--- a/docs-markdown/README.md
+++ b/docs-markdown/README.md
@@ -227,17 +227,12 @@ The `TelnyxMainActivity` provides:
 
 ### 2. Push Notification Setup
 
-1. Place `google-services.json` in the project root
-2. Register background message handler:
+1. Place `google-services.json` in the project root.
+2. Create an FCM service that extends `TelnyxFirebaseMessagingService` and a notification action receiver that extends `TelnyxNotificationActionReceiver`, then register both in `AndroidManifest.xml`. See [push-notification/app-setup.md](./push-notification/app-setup.md) for the full boilerplate.
 
-```tsx
-import messaging from '@react-native-firebase/messaging';
-import { TelnyxVoiceApp } from '@telnyx/react-voice-commons-sdk';
-
-messaging().setBackgroundMessageHandler(async (remoteMessage) => {
-  await TelnyxVoiceApp.handleBackgroundPush(remoteMessage.data);
-});
-```
+> **Do not** register `messaging().setBackgroundMessageHandler(...)` from JS. Android push is handled entirely by the native `TelnyxFirebaseMessagingService` — adding a JS handler will fight the native layer and can double-process calls. There is no `TelnyxVoiceApp.handleBackgroundPush` step required on Android.
+>
+> To avoid double-login when the app is cold-started from a push, guard your auto-login with `TelnyxVoipClient.isLaunchedFromPushNotification()`. See [push-notification/app-setup.md → Step 3](./push-notification/app-setup.md#step-3-detect-push-launched-cold-starts-avoid-double-login).
 
 ### iOS Integration
 

--- a/docs-markdown/error-handling/ErrorHandling.md
+++ b/docs-markdown/error-handling/ErrorHandling.md
@@ -323,26 +323,19 @@ const handlePushTokenError = async () => {
 
 ### Background Processing Errors
 
-**Error**: `BACKGROUND_PROCESSING_FAILED`
+**Symptoms**: Incoming calls not handled when the app is backgrounded or terminated.
 
-**Symptoms**: Incoming calls not handled when app is backgrounded.
+**Do not** register `messaging().setBackgroundMessageHandler(...)` from JavaScript. Android background push is handled entirely by the native `TelnyxFirebaseMessagingService` that your `AppFirebaseMessagingService` extends — a JS handler will race the native service and can drop or double-process calls. There is no `TelnyxVoiceApp.handleBackgroundPush` step on Android.
 
-**Solutions**:
+**Things to check instead:**
 
-```tsx
-// Ensure proper background handler setup
-messaging().setBackgroundMessageHandler(async (remoteMessage) => {
-  try {
-    console.log('Background message received:', remoteMessage);
-    await TelnyxVoiceApp.handleBackgroundPush(remoteMessage.data);
-  } catch (error) {
-    console.error('Background processing failed:', error);
+1. Your `MainActivity` extends `TelnyxMainActivity`.
+2. Your FCM service extends `TelnyxFirebaseMessagingService` and is registered in `AndroidManifest.xml`.
+3. Your notification action receiver extends `TelnyxNotificationActionReceiver` and is registered in `AndroidManifest.xml` with the correct action names.
+4. `google-services.json` is present at the project root and the FCM server key is configured in the Telnyx portal.
+5. On cold-start from push, you are not calling `login*` unconditionally — see [Push Notification Flow](../push-notification/app-setup.md#step-3-detect-push-launched-cold-starts-avoid-double-login) and guard with `TelnyxVoipClient.isLaunchedFromPushNotification()`.
 
-    // Log error for debugging
-    crashlytics().recordError(error);
-  }
-});
-```
+See [docs-markdown/push-notification/app-setup.md](../push-notification/app-setup.md) for the full native setup.
 
 ## Network and Connectivity Errors
 

--- a/docs-markdown/push-notification/app-setup.md
+++ b/docs-markdown/push-notification/app-setup.md
@@ -270,7 +270,64 @@ The SDK handles everything natively through:
 
 Simply extend these classes as shown in the native implementation steps above, and push notifications will work automatically.
 
-### Step 3: Token Registration (Optional)
+Do **not** call `messaging().setBackgroundMessageHandler(...)` from `@react-native-firebase/messaging`. There is no JS-side `TelnyxVoiceApp.handleBackgroundPush` step to wire up — a JS handler will fight the native service and can double-process or drop incoming calls.
+
+### Step 3: Detect Push-Launched Cold Starts (Avoid Double-Login)
+
+When the OS wakes your app from a terminated state to deliver an incoming call, the SDK is already handling the login internally as part of the push flow. If your app **also** triggers its own `login*` call on mount, you end up with two competing sessions — this is the single most common integration bug.
+
+Use the static method `TelnyxVoipClient.isLaunchedFromPushNotification()` to guard your own auto-login:
+
+```tsx
+import React from 'react';
+import { TelnyxVoipClient } from '@telnyx/react-voice-commons-sdk';
+
+export default function App() {
+  React.useEffect(() => {
+    TelnyxVoipClient.isLaunchedFromPushNotification().then((isFromPush) => {
+      if (isFromPush) {
+        // SDK is handling login via the push flow. Do nothing here —
+        // do not call login(), loginWithToken(), or loginFromStoredConfig().
+        return;
+      }
+      // Normal cold start: safe to auto-login.
+      voipClient.loginFromStoredConfig();
+    });
+  }, []);
+
+  return (
+    <TelnyxVoiceApp voipClient={voipClient} enableAutoReconnect={true}>
+      <YourAppContent />
+    </TelnyxVoiceApp>
+  );
+}
+```
+
+**How it works:** the method is static (callable before the client is constructed) and returns `true` when there is a pending FCM intent (Android) or PushKit payload (iOS) that has not yet been consumed by the SDK. It works on both platforms.
+
+**Common mistake — manual or automatic login on push:**
+
+```tsx
+// WRONG — runs on every mount, including push-launched cold starts
+React.useEffect(() => {
+  voipClient.login(config); // or loginWithToken(), or loginFromStoredConfig()
+}, []);
+```
+
+```tsx
+// Right — guard the login on push-launched cold starts
+React.useEffect(() => {
+  TelnyxVoipClient.isLaunchedFromPushNotification().then((isFromPush) => {
+    if (!isFromPush) voipClient.loginFromStoredConfig();
+  });
+}, []);
+```
+
+**Symptoms of double-login:** the incoming call rings briefly then disappears, the socket disconnects mid-call, CallKit shows a call that immediately ends, or you see rapid `CONNECTED → DISCONNECTED → CONNECTED` cycles in the logs right after a push is delivered. If you hit these, audit every `useEffect` in your app for an unguarded `login*` call on mount.
+
+Applies to any login entry point — including login forms that re-submit stored credentials, splash screens that eagerly log in, and background tasks that refresh tokens.
+
+### Step 4: Token Registration (Optional)
 
 Push tokens are handled automatically by the SDK during authentication. For most apps, you don't need to do anything additional.
 
@@ -300,7 +357,7 @@ The `VoipTokenFetcher` component automatically:
 - Retrieves FCM tokens (Android) and VoIP tokens (iOS)
 - Handles platform-specific token registration
 
-### Step 4: Authentication
+### Step 5: Authentication
 
 Include push tokens in your login configuration:
 

--- a/docs-markdown/push-notification/app-setup.md
+++ b/docs-markdown/push-notification/app-setup.md
@@ -327,6 +327,24 @@ React.useEffect(() => {
 
 Applies to any login entry point — including login forms that re-submit stored credentials, splash screens that eagerly log in, and background tasks that refresh tokens.
 
+**What to observe after the SDK finishes the push login:**
+
+- `voipClient.connectionState$` → emits `CONNECTED` (there is no separate `loginState$` — `CONNECTED` means socket up **and** authenticated).
+- `voipClient.activeCall$` → emits the `Call` once the SDK has processed the push.
+- `voipClient.currentActiveCall` → synchronous accessor; on push-launched mounts the call may already be present by the time you subscribe, so check this first.
+
+```tsx
+React.useEffect(() => {
+  if (voipClient.currentActiveCall) router.replace('/call');
+  const sub = voipClient.activeCall$.subscribe((call) => {
+    if (call) router.replace('/call');
+  });
+  return () => sub.unsubscribe();
+}, []);
+```
+
+CallKit (iOS) and ConnectionService (Android) already render the native incoming-call UI; this RN-side navigation only matters once the user taps into the app.
+
 ### Step 4: Token Registration (Optional)
 
 Push tokens are handled automatically by the SDK during authentication. For most apps, you don't need to do anything additional.

--- a/react-voice-commons-sdk/README.md
+++ b/react-voice-commons-sdk/README.md
@@ -122,12 +122,12 @@ As of **v0.3.0**, the SDK no longer navigates the host app. Routing on state tra
 
 **What to observe:**
 
-| Observable | Emits | Use it for |
-|---|---|---|
-| `voipClient.connectionState$` | `TelnyxConnectionState` (`CONNECTING`, `CONNECTED`, `RECONNECTING`, `DISCONNECTED`, `ERROR`) | Redirect to login on `DISCONNECTED`; gate outbound-call UI on `CONNECTED`. There is no separate `loginState$` — `CONNECTED` means the socket is up **and** authenticated. |
-| `voipClient.activeCall$` | `Call \| null` | Navigate to your in-call screen when a call appears. Primary signal for push-launched cold starts — when the SDK finishes the push-driven login and the call arrives, this emits. |
-| `voipClient.calls$` | `Call[]` | Multi-call UIs (call waiting, conference). |
-| `call.callState$` | `TelnyxCallState` | Per-call transitions (ringing / active / held / ended). |
+| Observable                    | Emits                                                                                        | Use it for                                                                                                                                                                        |
+| ----------------------------- | -------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `voipClient.connectionState$` | `TelnyxConnectionState` (`CONNECTING`, `CONNECTED`, `RECONNECTING`, `DISCONNECTED`, `ERROR`) | Redirect to login on `DISCONNECTED`; gate outbound-call UI on `CONNECTED`. There is no separate `loginState$` — `CONNECTED` means the socket is up **and** authenticated.         |
+| `voipClient.activeCall$`      | `Call \| null`                                                                               | Navigate to your in-call screen when a call appears. Primary signal for push-launched cold starts — when the SDK finishes the push-driven login and the call arrives, this emits. |
+| `voipClient.calls$`           | `Call[]`                                                                                     | Multi-call UIs (call waiting, conference).                                                                                                                                        |
+| `call.callState$`             | `TelnyxCallState`                                                                            | Per-call transitions (ringing / active / held / ended).                                                                                                                           |
 
 #### Redirect to login on disconnect
 
@@ -211,7 +211,7 @@ The SDK then connects the socket and restores the call internally. You observe `
 
 #### Detecting a Push-Launched Cold Start
 
-When the OS wakes the app from a terminated state to deliver a call, the SDK is already handling login via the push flow. If your app *also* triggers a login on mount, you get two competing sessions (double-login), which causes the call to fail or the socket to churn.
+When the OS wakes the app from a terminated state to deliver a call, the SDK is already handling login via the push flow. If your app _also_ triggers a login on mount, you get two competing sessions (double-login), which causes the call to fail or the socket to churn.
 
 Use the static `TelnyxVoipClient.isLaunchedFromPushNotification()` to guard your login:
 

--- a/react-voice-commons-sdk/README.md
+++ b/react-voice-commons-sdk/README.md
@@ -154,6 +154,56 @@ await call.hold();
 await call.hangup();
 ```
 
+### Push Notification Flow
+
+You do not wire push handlers in JS. The native layer does the work:
+
+- **Android**: `TelnyxFirebaseMessagingService` receives the FCM message, posts the call notification, and launches `TelnyxMainActivity` with the intent on Answer/Decline.
+- **iOS**: `TelnyxVoipPushHandler` receives the PushKit payload and reports the call to CallKit.
+
+The SDK then connects the socket and restores the call internally. You observe `voipClient.calls$` to render UI.
+
+#### Detecting a Push-Launched Cold Start
+
+When the OS wakes the app from a terminated state to deliver a call, the SDK is already handling login via the push flow. If your app *also* triggers a login on mount, you get two competing sessions (double-login), which causes the call to fail or the socket to churn.
+
+Use the static `TelnyxVoipClient.isLaunchedFromPushNotification()` to guard your login:
+
+```tsx
+import { TelnyxVoipClient } from '@telnyx/react-voice-commons-sdk';
+
+React.useEffect(() => {
+  TelnyxVoipClient.isLaunchedFromPushNotification().then((isFromPush) => {
+    if (isFromPush) return; // SDK is handling login via the push flow
+    voipClient.loginFromStoredConfig(); // Normal cold start
+  });
+}, []);
+```
+
+Returns `true` when a pending FCM intent (Android) or PushKit payload (iOS) has not yet been consumed.
+
+#### Common Mistake: Manual or Automatic Login on Push
+
+The single most common integration bug is re-logging in while the SDK is already handling a push:
+
+```tsx
+// WRONG — runs on every mount, including push-launched cold starts
+React.useEffect(() => {
+  voipClient.login(config); // or loginFromStoredConfig(), or loginWithToken()
+}, []);
+```
+
+```tsx
+// Right — guard the login on push-launched cold starts
+React.useEffect(() => {
+  TelnyxVoipClient.isLaunchedFromPushNotification().then((isFromPush) => {
+    if (!isFromPush) voipClient.loginFromStoredConfig();
+  });
+}, []);
+```
+
+Symptoms of getting this wrong: the incoming call rings briefly then disappears, the socket disconnects mid-call, or CallKit shows a call that immediately ends.
+
 ### Authentication & Persistent Storage
 
 The library supports both credential-based and token-based authentication with automatic persistence for seamless reconnection.
@@ -273,17 +323,12 @@ The `TelnyxMainActivity` provides:
 
 ### 2. Push Notification Setup
 
-1. Place `google-services.json` in the project root
-2. Register background message handler:
+1. Place `google-services.json` in the project root.
+2. Create an FCM service that extends `TelnyxFirebaseMessagingService` and a notification action receiver that extends `TelnyxNotificationActionReceiver`, then register both in `AndroidManifest.xml`. See the [push notification app setup guide](../docs-markdown/push-notification/app-setup.md) for the full boilerplate.
 
-```tsx
-import messaging from '@react-native-firebase/messaging';
-import { TelnyxVoiceApp } from '@telnyx/react-voice-commons-sdk';
+> **Do not** register `messaging().setBackgroundMessageHandler(...)` from JS. Android push is handled entirely by the native `TelnyxFirebaseMessagingService` — adding a JS handler will fight the native layer and can double-process calls. There is no `TelnyxVoiceApp.handleBackgroundPush` step required on Android.
 
-messaging().setBackgroundMessageHandler(async (remoteMessage) => {
-  await TelnyxVoiceApp.handleBackgroundPush(remoteMessage.data);
-});
-```
+See [Push Notification Flow](#push-notification-flow) below for how to detect push-launched cold starts and avoid double-login.
 
 ### iOS Integration
 

--- a/react-voice-commons-sdk/README.md
+++ b/react-voice-commons-sdk/README.md
@@ -118,9 +118,18 @@ call.callState$.subscribe((state) => {
 
 ### Navigation
 
-As of **v0.3.0**, the SDK no longer navigates the host app. Routing on state transitions (e.g. redirecting to a login screen on disconnect, surfacing a dialer screen after answering a call via CallKit) is entirely the host app's responsibility. Subscribe to `connectionState$` and `activeCall$` and invoke your own navigator.
+As of **v0.3.0**, the SDK no longer navigates the host app. Routing on state transitions (e.g. redirecting to a login screen on disconnect, surfacing an in-call screen when a call arrives via push) is entirely the host app's responsibility. Subscribe to the observables below and invoke your own navigator.
 
-Example using `expo-router`:
+**What to observe:**
+
+| Observable | Emits | Use it for |
+|---|---|---|
+| `voipClient.connectionState$` | `TelnyxConnectionState` (`CONNECTING`, `CONNECTED`, `RECONNECTING`, `DISCONNECTED`, `ERROR`) | Redirect to login on `DISCONNECTED`; gate outbound-call UI on `CONNECTED`. There is no separate `loginState$` — `CONNECTED` means the socket is up **and** authenticated. |
+| `voipClient.activeCall$` | `Call \| null` | Navigate to your in-call screen when a call appears. Primary signal for push-launched cold starts — when the SDK finishes the push-driven login and the call arrives, this emits. |
+| `voipClient.calls$` | `Call[]` | Multi-call UIs (call waiting, conference). |
+| `call.callState$` | `TelnyxCallState` | Per-call transitions (ringing / active / held / ended). |
+
+#### Redirect to login on disconnect
 
 ```tsx
 import { router } from 'expo-router';
@@ -133,6 +142,43 @@ useEffect(() => {
       router.replace('/');
     }
   });
+  return () => sub.unsubscribe();
+}, []);
+```
+
+#### Navigate to in-call screen when a call arrives (push-launched or otherwise)
+
+This is the piece that pairs with the push flow: after `isLaunchedFromPushNotification()` tells you to skip manual login, the SDK drives login internally and the call shows up on `activeCall$`. The same subscription handles foreground pushes and outbound calls, so you only need one:
+
+```tsx
+import { router } from 'expo-router';
+import { useEffect } from 'react';
+
+useEffect(() => {
+  // Handle the cold-start race: if the call was already delivered before this
+  // component mounted (common on push-launched cold starts), read it synchronously.
+  if (voipClient.currentActiveCall) {
+    router.replace('/call');
+  }
+
+  const sub = voipClient.activeCall$.subscribe((call) => {
+    if (call) router.replace('/call');
+    else router.replace('/dialer');
+  });
+  return () => sub.unsubscribe();
+}, []);
+```
+
+**Note on CallKit / ConnectionService:** the native call UI (ringtone, answer/decline) is shown by the OS regardless — your RN screen is only visible once the user taps into the app. If you only need native UI, you can skip the navigation step entirely.
+
+#### Optional: gate outbound-call UI on CONNECTED
+
+```tsx
+import { canMakeCalls } from '@telnyx/react-voice-commons-sdk';
+
+const [canCall, setCanCall] = useState(false);
+useEffect(() => {
+  const sub = voipClient.connectionState$.subscribe((s) => setCanCall(canMakeCalls(s)));
   return () => sub.unsubscribe();
 }, []);
 ```


### PR DESCRIPTION
## Summary

- Remove the misleading `messaging().setBackgroundMessageHandler(...)` + `TelnyxVoiceApp.handleBackgroundPush()` snippet from all four doc surfaces (root `README.md`, `docs-markdown/README.md`, `react-voice-commons-sdk/README.md`, `docs-markdown/error-handling/ErrorHandling.md`). Android push is handled entirely by `TelnyxFirebaseMessagingService` — a JS handler fights the native layer and can double-process or drop calls.
- Document `TelnyxVoipClient.isLaunchedFromPushNotification()` (previously undocumented, but already used by the demo at `app/_layout.tsx:62`) in the main READMEs and in `docs-markdown/push-notification/app-setup.md` as a new Step 3.
- Document the single most common integration bug: calling `login()` / `loginWithToken()` / `loginFromStoredConfig()` unconditionally in a `useEffect` on mount, which races the SDK's internal push-driven login. Shows the WRONG vs Right guarded pattern and the symptom list (ring-then-drop, socket churn, CallKit immediately ending).
- Strengthen the "Double Login" troubleshooting entry to point at the new push-launched guidance.

No code changes — documentation only.

## Test plan

- [ ] Render each changed markdown file on GitHub and confirm links resolve:
  - [ ] `README.md` → anchor `#5-push-notification-flow-what-actually-happens` and link to `./docs-markdown/push-notification/app-setup.md`
  - [ ] `docs-markdown/README.md` → link to `./push-notification/app-setup.md#step-3-detect-push-launched-cold-starts-avoid-double-login`
  - [ ] `docs-markdown/error-handling/ErrorHandling.md` → link to `../push-notification/app-setup.md#step-3-detect-push-launched-cold-starts-avoid-double-login`
  - [ ] `react-voice-commons-sdk/README.md` → anchor `#push-notification-flow`
- [ ] Verify step numbering in `docs-markdown/push-notification/app-setup.md` is sequential (Step 1 → Step 5 under "JavaScript/TypeScript Integration").
- [ ] Confirm prettier check passes: `npx prettier --check "**/*.{js,jsx,ts,tsx,json,md}"`