### PR TITLE
docs: address PR #53 review feedback on push/navigation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ You do not need to wire up JS push handlers. The native layer does the work:
 
 In both cases the SDK connects the socket and restores the call internally — you just observe the VoIP client's streams to render UI.
 
+> In the snippets below, `voipClient` is the instance returned by `createTelnyxVoipClient()` (see [Basic Setup](#basic-setup)). It is a singleton, so it's safe to reference the same module-level value from any component, or to read it from context.
+
 **What to observe after the SDK-driven push login:**
 
 - `voipClient.connectionState$` — emits `CONNECTED` when the socket is up and authenticated (there is no separate `loginState$`).

--- a/docs-markdown/push-notification/app-setup.md
+++ b/docs-markdown/push-notification/app-setup.md
@@ -276,7 +276,9 @@ Do **not** call `messaging().setBackgroundMessageHandler(...)` from `@react-nati
 
 When the OS wakes your app from a terminated state to deliver an incoming call, the SDK is already handling the login internally as part of the push flow. If your app **also** triggers its own `login*` call on mount, you end up with two competing sessions — this is the single most common integration bug.
 
-Use the static method `TelnyxVoipClient.isLaunchedFromPushNotification()` to guard your own auto-login:
+> **This applies to _any_ login entry point**, not just a splash screen `useEffect`. Login forms that auto-resubmit stored credentials, deep-link handlers that call `loginWithToken()`, and background tasks that refresh tokens all need the same guard. If any code path can run `login*` on a cold start, wrap it with the `isLaunchedFromPushNotification()` check below.
+
+Use the static method `TelnyxVoipClient.isLaunchedFromPushNotification()` to guard your own auto-login. `voipClient` in the examples below is the instance returned by `createTelnyxVoipClient()` (see [Step 1](#step-1-configure-telnyxvoiceapp) above) — typically a module-level singleton or a value read from React context:
 
 ```tsx
 import React from 'react';
@@ -324,8 +326,6 @@ React.useEffect(() => {
 ```
 
 **Symptoms of double-login:** the incoming call rings briefly then disappears, the socket disconnects mid-call, CallKit shows a call that immediately ends, or you see rapid `CONNECTED → DISCONNECTED → CONNECTED` cycles in the logs right after a push is delivered. If you hit these, audit every `useEffect` in your app for an unguarded `login*` call on mount.
-
-Applies to any login entry point — including login forms that re-submit stored credentials, splash screens that eagerly log in, and background tasks that refresh tokens.
 
 **What to observe after the SDK finishes the push login:**
 

--- a/react-voice-commons-sdk/README.md
+++ b/react-voice-commons-sdk/README.md
@@ -120,14 +120,16 @@ call.callState$.subscribe((state) => {
 
 As of **v0.3.0**, the SDK no longer navigates the host app. Routing on state transitions (e.g. redirecting to a login screen on disconnect, surfacing an in-call screen when a call arrives via push) is entirely the host app's responsibility. Subscribe to the observables below and invoke your own navigator.
 
+> In the snippets below, `voipClient` is the instance returned by `createTelnyxVoipClient()` (see [Basic Setup](#basic-setup)). It is a singleton, so it's safe to reference the same module-level value from any component, or to read it from context.
+
 **What to observe:**
 
-| Observable                    | Emits                                                                                        | Use it for                                                                                                                                                                        |
-| ----------------------------- | -------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `voipClient.connectionState$` | `TelnyxConnectionState` (`CONNECTING`, `CONNECTED`, `RECONNECTING`, `DISCONNECTED`, `ERROR`) | Redirect to login on `DISCONNECTED`; gate outbound-call UI on `CONNECTED`. There is no separate `loginState$` — `CONNECTED` means the socket is up **and** authenticated.         |
-| `voipClient.activeCall$`      | `Call \| null`                                                                               | Navigate to your in-call screen when a call appears. Primary signal for push-launched cold starts — when the SDK finishes the push-driven login and the call arrives, this emits. |
-| `voipClient.calls$`           | `Call[]`                                                                                     | Multi-call UIs (call waiting, conference).                                                                                                                                        |
-| `call.callState$`             | `TelnyxCallState`                                                                            | Per-call transitions (ringing / active / held / ended).                                                                                                                           |
+| Observable                    | Emits                                                                                        | Use it for                                                                                                                                                                |
+| ----------------------------- | -------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `voipClient.connectionState$` | `TelnyxConnectionState` (`CONNECTING`, `CONNECTED`, `RECONNECTING`, `DISCONNECTED`, `ERROR`) | Redirect to login on `DISCONNECTED`; gate outbound-call UI on `CONNECTED`. There is no separate `loginState$` — `CONNECTED` means the socket is up **and** authenticated. |
+| `voipClient.activeCall$`      | `Call \| null`                                                                               | Emits the `Call` once the SDK has processed the push and the call has arrived. Navigate to your in-call screen here. Fires for push-launched, foreground, and outbound.   |
+| `voipClient.calls$`           | `Call[]`                                                                                     | Multi-call UIs (call waiting, conference).                                                                                                                                |
+| `call.callState$`             | `TelnyxCallState`                                                                            | Per-call transitions (ringing / active / held / ended).                                                                                                                   |
 
 #### Redirect to login on disconnect
 
@@ -172,6 +174,8 @@ useEffect(() => {
 **Note on CallKit / ConnectionService:** the native call UI (ringtone, answer/decline) is shown by the OS regardless — your RN screen is only visible once the user taps into the app. If you only need native UI, you can skip the navigation step entirely.
 
 #### Optional: gate outbound-call UI on CONNECTED
+
+`canMakeCalls(state)` is a small helper that returns `true` only when `state === TelnyxConnectionState.CONNECTED`. It exists purely to keep the check readable — you can inline the comparison if you prefer.
 
 ```tsx
 import { canMakeCalls } from '@telnyx/react-voice-commons-sdk';


### PR DESCRIPTION
Follow-up to #53 applying the five suggestions from [review 4128211513](https://github.com/team-telnyx/react-native-voice-commons/pull/53#pullrequestreview-4128211513).

## Summary

1. **app-setup.md Step 3 callout** — pulled the "any login entry point" note up as a blockquote at the top of the section so it's visible before the code examples. Dropped the now-duplicate trailing paragraph.
2. **`voipClient` provenance** — added a one-liner in every snippet section (root `README.md` push flow, `react-voice-commons-sdk/README.md` Navigation, `docs-markdown/push-notification/app-setup.md` Step 3) explaining that `voipClient` is the instance from `createTelnyxVoipClient()` — a module-level singleton or context value.
3. **Step renumbering check** — verified no stale references to old Step 3/4 numbering; the anchor links in `docs-markdown/README.md` and `docs-markdown/error-handling/ErrorHandling.md` resolve correctly to the renamed headings. No edit needed.
4. **`canMakeCalls()` helper** — added a short note in the Navigation section explaining it returns `true` only when `state === TelnyxConnectionState.CONNECTED` and exists purely for readability.
5. **Wording consistency** — unified the `activeCall$` table row in `react-voice-commons-sdk/README.md` with the more precise root README phrasing ("Emits the `Call` once the SDK has processed the push and the call has arrived") and noted it fires for push-launched, foreground, and outbound calls.

Docs-only, no code changes. Prettier passes locally.

## Test plan

- [ ] Render each changed markdown file on GitHub and verify the new blockquote callouts render correctly.
- [ ] Confirm anchor links in `docs-markdown/README.md` and `docs-markdown/error-handling/ErrorHandling.md` still resolve to `#step-3-detect-push-launched-cold-starts-avoid-double-login`.
- [ ] `npx prettier --check "**/*.{js,jsx,ts,tsx,json,md}"` passes in CI.