### PR TITLE
release: voice-sdk v0.4.2 + commons-sdk v0.4.0 — DTMF support, @ReactModule fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG.md
 
+## Unreleased (2026-04-19)
+
+### Enhancement
+
+• Consumes `@telnyx/react-voice-commons-sdk@0.4.0` — demo now exposes DTMF in the active-call UI via `call.dtmf(digits)`.
+
+### Bug Fixing
+
+• Fixed `Attempted to navigate before mounting the Root Layout component` crash on cold start. `app/_layout.tsx` now gates the `connectionState$` → `router.replace('/')` subscription on `useRootNavigationState()` and skips the initial BehaviorSubject emission, so the redirect only fires on genuine `DISCONNECTED` transitions after the expo-router navigator is ready.
+
 ## [0.1.8-beta.0](https://github.com/team-telnyx/react-native-voice-commons/releases/tag/0.1.8-beta.0) (2026-02-27)
 
 ### Bug Fixing

--- a/README.md
+++ b/README.md
@@ -110,7 +110,13 @@ await call.answer();
 await call.mute();
 await call.hold();
 await call.hangup();
+
+// Send DTMF tones (for IVRs, conference pins, etc.)
+await call.dtmf('1'); // single digit
+await call.dtmf('1234#'); // whole string
 ```
+
+**DTMF:** `call.dtmf(digits)` sends each character as a Verto `INFO` message. Valid characters are `0-9`, `A-D`, `*`, and `#`; anything else is silently dropped. The call must be `ACTIVE` — throws otherwise.
 
 ### 5. Push Notification Flow (What Actually Happens)
 

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -2,7 +2,7 @@ import '~/global.css';
 
 import { DarkTheme, DefaultTheme, Theme, ThemeProvider } from '@react-navigation/native';
 import { PortalHost } from '@rn-primitives/portal';
-import { router, Slot, Stack } from 'expo-router';
+import { router, Slot, Stack, useRootNavigationState } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import * as React from 'react';
 import { Appearance, Platform } from 'react-native';
@@ -55,6 +55,11 @@ const voipClient = createTelnyxVoipClient({
 export default function RootLayout() {
   usePlatformSpecificSetup();
   const { isDarkColorScheme } = useColorScheme();
+  // Gate all router.* calls on this: expo-router's navigation state is not
+  // ready until rootNavState.key is set, and router.replace() before then
+  // throws "Attempted to navigate before mounting the Root Layout component".
+  const rootNavState = useRootNavigationState();
+  const isNavReady = !!rootNavState?.key;
 
   // If the app was cold-started from a push notification, skip auto-login —
   // the SDK handles login internally via the push notification flow.
@@ -71,13 +76,19 @@ export default function RootLayout() {
   }, []);
 
   React.useEffect(() => {
+    if (!isNavReady) return;
+    let skipInitial = true;
     const sub = voipClient.connectionState$.subscribe((state) => {
+      if (skipInitial) {
+        skipInitial = false;
+        return;
+      }
       if (state === TelnyxConnectionState.DISCONNECTED) {
         router.replace('/');
       }
     });
     return () => sub.unsubscribe();
-  }, []);
+  }, [isNavReady]);
 
   return (
     <TelnyxVoiceApp voipClient={voipClient} enableAutoReconnect={true} debug={true}>

--- a/components/ActiveCall.tsx
+++ b/components/ActiveCall.tsx
@@ -1,14 +1,24 @@
 import React, { useState, useEffect } from 'react';
+import { View, TouchableOpacity } from 'react-native';
 import { Call, TelnyxCallState } from '../react-voice-commons-sdk/src';
 import { RTCView } from 'react-native-webrtc';
 import { CallModal } from '~/components/CallModal';
+import { Text } from '~/components/ui/text';
 
 type Props = {
   call: Call;
 };
 
+const DTMF_KEYS = [
+  ['1', '2', '3'],
+  ['4', '5', '6'],
+  ['7', '8', '9'],
+  ['*', '0', '#'],
+];
+
 export function ActiveCall({ call }: Props) {
   const [isOpen, setIsOpen] = useState(true);
+  const [dtmfLog, setDtmfLog] = useState('');
 
   console.log('ActiveCall: Rendering with call:', {
     callId: call.callId,
@@ -63,6 +73,14 @@ export function ActiveCall({ call }: Props) {
     }
   };
 
+  const handleDtmf = (digit: string) => {
+    console.log(`ActiveCall: Sending DTMF "${digit}"`);
+    call
+      .dtmf(digit)
+      .then(() => setDtmfLog((prev) => (prev + digit).slice(-20)))
+      .catch((err) => console.log('ActiveCall: DTMF error:', err));
+  };
+
   // Only render if we have an active or held call
   if (
     !call ||
@@ -76,12 +94,78 @@ export function ActiveCall({ call }: Props) {
   }
 
   const isOnHold = call.currentState === TelnyxCallState.HELD;
+  const canDtmf = call.currentState === TelnyxCallState.ACTIVE;
+
+  const dialpad = (
+    <View>
+      <Text
+        style={{
+          fontSize: 12,
+          color: '#6b7280',
+          marginBottom: 6,
+          textAlign: 'center',
+        }}
+      >
+        DTMF test pad {canDtmf ? '' : '(inactive)'}
+      </Text>
+      <Text
+        style={{
+          fontSize: 14,
+          color: '#111827',
+          textAlign: 'center',
+          marginBottom: 8,
+          minHeight: 18,
+          letterSpacing: 2,
+          fontFamily: 'Courier',
+        }}
+      >
+        {dtmfLog || ' '}
+      </Text>
+      {DTMF_KEYS.map((row, rowIdx) => (
+        <View
+          key={rowIdx}
+          style={{
+            flexDirection: 'row',
+            justifyContent: 'space-between',
+            marginBottom: 6,
+          }}
+        >
+          {row.map((digit) => (
+            <TouchableOpacity
+              key={digit}
+              disabled={!canDtmf}
+              onPress={() => handleDtmf(digit)}
+              style={{
+                flex: 1,
+                marginHorizontal: 3,
+                paddingVertical: 10,
+                borderRadius: 6,
+                backgroundColor: canDtmf ? '#e5e7eb' : '#f3f4f6',
+                alignItems: 'center',
+              }}
+            >
+              <Text
+                style={{
+                  fontSize: 18,
+                  fontWeight: '600',
+                  color: canDtmf ? '#111827' : '#9ca3af',
+                }}
+              >
+                {digit}
+              </Text>
+            </TouchableOpacity>
+          ))}
+        </View>
+      ))}
+    </View>
+  );
 
   return (
     <CallModal
       visible={isOpen}
       title={isOnHold ? 'Call is on hold' : 'Call is active'}
       description={`${call.isIncoming ? 'Incoming' : 'Outgoing'}: ${call.destination}`}
+      extraContent={dialpad}
       buttons={[
         {
           text: 'Hangup',

--- a/components/CallModal.tsx
+++ b/components/CallModal.tsx
@@ -13,6 +13,7 @@ type CallModalProps = {
     onPress: () => void;
     variant?: 'primary' | 'secondary' | 'danger';
   }>;
+  extraContent?: React.ReactNode;
   onRequestClose?: () => void;
 };
 
@@ -23,6 +24,7 @@ export function CallModal({
   isLoading,
   loadingText,
   buttons,
+  extraContent,
   onRequestClose,
 }: CallModalProps) {
   const getButtonStyle = (variant: 'primary' | 'secondary' | 'danger' = 'primary') => {
@@ -120,6 +122,9 @@ export function CallModal({
               </Text>
             )
           )}
+
+          {/* Extra content (e.g. DTMF dialpad) */}
+          {!isLoading && extraContent && <View style={{ marginBottom: 16 }}>{extraContent}</View>}
 
           {/* Buttons */}
           {!isLoading && buttons.length > 0 && (

--- a/docs-markdown/README.md
+++ b/docs-markdown/README.md
@@ -469,6 +469,13 @@ useEffect(() => {
 
 For complete API documentation and advanced usage patterns, see the [TelnyxVoiceApp Documentation](./react-voice-commons-sdk/TELNYX_VOICE_APP.md).
 
+### Guides
+
+- [Push Notification Setup](./push-notification/app-setup.md) — FCM/APNs setup and avoiding double-login on push-launched cold starts.
+- [Sending DTMF Tones](./call-features/dtmf.md) — dialpad presses, IVR sequences, and gating on call state.
+- [Error Handling](./error-handling/ErrorHandling.md) — common errors and recovery patterns.
+- [Expo Integration](./expo/ExpoIntegration.md) — Expo-specific setup.
+
 ## License
 
 MIT License - see LICENSE file for details.

--- a/docs-markdown/call-features/dtmf.md
+++ b/docs-markdown/call-features/dtmf.md
@@ -1,0 +1,89 @@
+# Sending DTMF Tones
+
+DTMF (Dual-Tone Multi-Frequency) tones are how your app interacts with phone-side menus — IVRs, conference PINs, voicemail shortcuts. The Telnyx React Voice Commons SDK exposes DTMF directly on the `Call` object.
+
+## API
+
+```ts
+call.dtmf(digits: string): Promise<void>
+```
+
+Each character of `digits` is sent as a Verto `INFO` message to the Telnyx platform, which forwards it as RFC 2833 / `INFO` DTMF to the remote party.
+
+### Accepted characters
+
+| Group             | Characters          |
+| ----------------- | ------------------- |
+| Digits            | `0` `1` `2` … `9`   |
+| Letters (A–D row) | `A` `B` `C` `D`     |
+| Symbols           | `*` `#`             |
+
+Any character outside this set is **silently dropped** by the underlying SDK. This is consistent with the [Telnyx Android WebRTC SDK](https://github.com/team-telnyx/telnyx-webrtc-android) behavior.
+
+### State requirements
+
+`dtmf()` will throw `Error('Cannot send DTMF in state: <state>')` unless the call is in the `ACTIVE` state. Check `call.currentState` or subscribe to `call.callState$` before sending if you cannot guarantee the call is active.
+
+## Usage
+
+### Single digit (dialpad press)
+
+Wire each dialpad button to `dtmf` with a one-character string:
+
+```tsx
+function Dialpad({ call }: { call: Call }) {
+  const onPress = (digit: string) => {
+    call.dtmf(digit).catch((err) => {
+      console.error(`DTMF "${digit}" failed:`, err);
+    });
+  };
+
+  return (
+    <View>
+      {['1', '2', '3', '4', '5', '6', '7', '8', '9', '*', '0', '#'].map((d) => (
+        <Button key={d} title={d} onPress={() => onPress(d)} />
+      ))}
+    </View>
+  );
+}
+```
+
+### Whole string (pre-recorded sequence)
+
+For a known sequence such as a conference PIN or voicemail password, pass the whole string:
+
+```tsx
+// Punch in a conference PIN after the system prompt
+await call.dtmf('482193#');
+```
+
+There is no built-in inter-digit delay — the SDK queues the `INFO` messages and the remote side (the Telnyx platform and the destination PBX) interprets them in order.
+
+### Gating on state
+
+If your UI lets the user press the dialpad before the call becomes `ACTIVE` (for example, during `CONNECTING`), guard the call site:
+
+```tsx
+import { TelnyxCallState } from '@telnyx/react-voice-commons-sdk';
+
+const [state, setState] = useState(call.currentState);
+useEffect(() => {
+  const sub = call.callState$.subscribe(setState);
+  return () => sub.unsubscribe();
+}, [call]);
+
+const onPress = (digit: string) => {
+  if (state !== TelnyxCallState.ACTIVE) return;
+  call.dtmf(digit);
+};
+```
+
+## Platform notes
+
+DTMF is handled entirely by the underlying `@telnyx/react-native-voice-sdk` and travels over the existing Verto signaling socket. There is **no native bridge work required** on iOS or Android — extending `TelnyxMainActivity` / `PKPushRegistryDelegate` as you already do for push notifications is sufficient.
+
+## Common pitfalls
+
+- **Calling `dtmf()` before the call is `ACTIVE`.** Will throw. Gate on `callState$` or on `CallStateHelpers.isActive(state)`.
+- **Passing non-DTMF characters** (letters outside `A-D`, whitespace, punctuation other than `*#`). They are silently dropped — the platform will not error, but the tones you expect will not be sent. Normalize input upstream if you accept user-typed strings.
+- **Expecting DTMF to interrupt the remote audio locally.** DTMF is a signaling feature; the local party does not hear a feedback tone unless your UI plays one. Most dialpads play a short local beep on press purely for UX.

--- a/package/CHANGELOG.md
+++ b/package/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG.md
 
+## [0.4.2](https://github.com/team-telnyx/react-native-voice-commons/releases/tag/voice-sdk-v0.4.2) (2026-04-19)
+
+### Bug Fixing
+
+- **Fixed `Call.dtmf()` throwing `Invalid DTMF response received` on every call.** `isDTMFResponse` required `result.message === 'SENT'`, but the Telnyx gateway acks DTMF INFO requests with just `{ sessid }` — no `message` field — so valid acks were rejected even though the tones were delivered. The validator now accepts any JSON-RPC `result` frame that echoes back the session id (matching the Android SDK's fire-and-forget semantics). `DTMFResponse.result.message` remains in the type as an optional field so older gateway builds that still emit `{ message: 'SENT', sessid }` continue to type-check.
+- Corrected the JSDoc on `Call.dtmf()` — it previously claimed the resolved value was the string `'SENT'`; the resolved value is the gateway ack object `{ sessid, message? }`.
+
 ## [0.4.1](https://github.com/team-telnyx/react-native-voice-commons/releases/tag/voice-sdk-v0.4.1) (2026-04-01)
 
 ### Bug Fixing

--- a/package/lib/call.ts
+++ b/package/lib/call.ts
@@ -514,16 +514,16 @@ export class Call extends EventEmitter<CallEvents> {
   };
 
   /**
+   * Send DTMF tones on this call as a Verto `telnyx_rtc.info` message.
    *
-   * @param digits The DTMF digits to send
-   * This method will send a DTMF request to the Telnyx platform,
-   * and return the result of the DTMF action.
-   * @throws {Error} If the DTMF response is invalid
-   * @returns {Promise<string>} A promise that resolves with the DTMF result
+   * @param digits One or more DTMF characters. Valid characters are `0-9`, `A-D`,
+   *   `*`, and `#`; anything else is silently dropped by the platform.
+   * @returns A promise that resolves with the gateway ack object (`{ sessid, message? }`)
+   *   once the INFO request has been acknowledged.
+   * @throws If the socket returns an error frame or a malformed response (no `result.sessid`).
    * @example
    * ```typescript
-   * const result = await call.dtmf('1234');
-   * console.log(result); // 'SENT' or other result based on the DTMF action
+   * await call.dtmf('1234#');
    * ```
    */
   public dtmf = async (digits: string) => {

--- a/package/lib/messages/call.ts
+++ b/package/lib/messages/call.ts
@@ -386,14 +386,20 @@ export function createDTMFRequest({ digits, sessionId }: CreateDTMFRequestParams
 type DTMFResponse = {
   id: string;
   jsonrpc: '2.0';
-  result: { message: string; sessid: string };
-  voice_sdk_id: string;
+  // `message` is legacy — the Telnyx gateway currently acks DTMF with just `sessid`.
+  // Kept optional so older servers that still emit `{ message: 'SENT', sessid }` still type-check.
+  result: { message?: string; sessid: string };
+  voice_sdk_id?: string;
 };
 
 export function isDTMFResponse(msg: unknown): msg is DTMFResponse {
-  if (!msg) {
+  if (!msg || typeof msg !== 'object') {
     return false;
   }
-  const temp: Partial<DTMFResponse> = msg;
-  return temp.result?.message === 'SENT' && Boolean(temp.result?.sessid);
+  const temp = msg as Partial<DTMFResponse>;
+  // A DTMF ack is any JSON-RPC success response for a `telnyx_rtc.info` request
+  // that echoes back the session id. The Android SDK's `Call.dtmf()` doesn't
+  // validate the response at all (fire-and-forget); this check is just enough
+  // to distinguish the success ack from a JSON-RPC error frame.
+  return Boolean(temp.result?.sessid);
 }

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@telnyx/react-native-voice-sdk",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Telnyx React Native Voice SDK - A complete WebRTC voice calling solution",
   "main": "lib/index.ts",
   "module": "lib/index.ts",

--- a/react-voice-commons-sdk/CHANGELOG.md
+++ b/react-voice-commons-sdk/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - **Fixed `IllegalArgumentException: Could not find @ReactModule annotation in VoicePnBridgeModule` crash** on Android when the app is cold-started by a push notification action (Answer/Decline). React Native 0.79+ requires `@ReactModule(name = …)` on native modules that are looked up by class via `ReactContext.getNativeModule(Class)`. The annotation has been added to `VoicePnBridgeModule`, and the module name is now sourced from a single `NAME` constant.
 
+### Dependencies
+
+- Now requires `@telnyx/react-native-voice-sdk >= 0.4.2`, which fixes a bug where every `Call.dtmf()` invocation threw `Invalid DTMF response received` even though the tone was delivered. See the [voice-sdk 0.4.2 changelog](../package/CHANGELOG.md#042-2026-04-19) for details.
+
 ## [0.3.1] (2026-04-16)
 
 ### Bug Fixing

--- a/react-voice-commons-sdk/CHANGELOG.md
+++ b/react-voice-commons-sdk/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG.md
 
+## [0.4.0] (2026-04-19)
+
+### Enhancement
+
+- **DTMF support.** Added `Call.dtmf(digits: string): Promise<void>` — sends DTMF tones on the current call as Verto `INFO` messages. Accepts a single digit (e.g. `"5"`) or a whole string (e.g. `"1234#"`). Valid characters are `0-9`, `A-D`, `*`, and `#`; anything else is silently dropped by the underlying SDK. Call state must be `ACTIVE` — will throw otherwise.
+
+### Bug Fixing
+
+- **Fixed `IllegalArgumentException: Could not find @ReactModule annotation in VoicePnBridgeModule` crash** on Android when the app is cold-started by a push notification action (Answer/Decline). React Native 0.79+ requires `@ReactModule(name = …)` on native modules that are looked up by class via `ReactContext.getNativeModule(Class)`. The annotation has been added to `VoicePnBridgeModule`, and the module name is now sourced from a single `NAME` constant.
+
 ## [0.3.1] (2026-04-16)
 
 ### Bug Fixing

--- a/react-voice-commons-sdk/README.md
+++ b/react-voice-commons-sdk/README.md
@@ -198,7 +198,13 @@ await call.answer();
 await call.mute();
 await call.hold();
 await call.hangup();
+
+// Send DTMF tones (for IVRs, conference pins, etc.)
+await call.dtmf('1'); // single digit
+await call.dtmf('1234#'); // whole string
 ```
+
+**DTMF:** `call.dtmf(digits)` sends each character as a Verto `INFO` message to the Telnyx platform. Valid characters are `0-9`, `A-D`, `*`, and `#`; any other characters are silently dropped by the underlying SDK. The call must be in the `ACTIVE` state — calling `dtmf()` in any other state throws. Safe to call with a single digit for dialpad presses or with a whole string for pre-recorded sequences.
 
 ### Push Notification Flow
 

--- a/react-voice-commons-sdk/android/src/main/java/com/telnyx/react_voice_commons/VoicePnBridgeModule.kt
+++ b/react-voice-commons-sdk/android/src/main/java/com/telnyx/react_voice_commons/VoicePnBridgeModule.kt
@@ -9,17 +9,18 @@ import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.bridge.Arguments
+import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.modules.core.DeviceEventManagerModule
 
+@ReactModule(name = VoicePnBridgeModule.NAME)
 class VoicePnBridgeModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaModule(reactContext) {
     
     companion object {
+        const val NAME = "VoicePnBridge"
         private const val TAG = "VoicePnBridgeModule"
     }
-    
-    override fun getName(): String {
-        return "VoicePnBridge"
-    }
+
+    override fun getName(): String = NAME
     
     @ReactMethod
     fun getPendingPushAction(promise: Promise) {

--- a/react-voice-commons-sdk/lib/models/call.d.ts
+++ b/react-voice-commons-sdk/lib/models/call.d.ts
@@ -172,6 +172,18 @@ export declare class Call {
    */
   toggleMute(): Promise<void>;
   /**
+   * Send DTMF tones on this call.
+   *
+   * Each character in `digits` is sent as a Verto INFO message to the Telnyx
+   * platform. Valid characters are `0-9`, `A-D`, `*`, and `#`; any other
+   * characters are silently dropped by the underlying SDK.
+   *
+   * Only valid while the call is `ACTIVE` — will throw otherwise. Safe to call
+   * with a single digit (e.g. for IVR dialpad presses) or a whole string
+   * (e.g. `"123#"`).
+   */
+  dtmf(digits: string): Promise<void>;
+  /**
    * Set the call to connecting state (used for push notification calls when answered via CallKit)
    * @internal
    */

--- a/react-voice-commons-sdk/lib/models/call.js
+++ b/react-voice-commons-sdk/lib/models/call.js
@@ -375,6 +375,28 @@ class Call {
     }
   }
   /**
+   * Send DTMF tones on this call.
+   *
+   * Each character in `digits` is sent as a Verto INFO message to the Telnyx
+   * platform. Valid characters are `0-9`, `A-D`, `*`, and `#`; any other
+   * characters are silently dropped by the underlying SDK.
+   *
+   * Only valid while the call is `ACTIVE` — will throw otherwise. Safe to call
+   * with a single digit (e.g. for IVR dialpad presses) or a whole string
+   * (e.g. `"123#"`).
+   */
+  async dtmf(digits) {
+    if (this.currentState !== call_state_1.TelnyxCallState.ACTIVE) {
+      throw new Error(`Cannot send DTMF in state: ${this.currentState}`);
+    }
+    try {
+      await this._telnyxCall.dtmf(digits);
+    } catch (error) {
+      console.error('Failed to send DTMF:', error);
+      throw error;
+    }
+  }
+  /**
    * Set the call to connecting state (used for push notification calls when answered via CallKit)
    * @internal
    */

--- a/react-voice-commons-sdk/package.json
+++ b/react-voice-commons-sdk/package.json
@@ -39,7 +39,7 @@
     "android": "expo run:android",
     "ios": "expo run:ios",
     "dev:local": "npm pkg set dependencies.@telnyx/react-native-voice-sdk=file:../package",
-    "dev:published": "npm pkg set \"dependencies.@telnyx/react-native-voice-sdk\"=\">=0.4.1\"",
+    "dev:published": "npm pkg set \"dependencies.@telnyx/react-native-voice-sdk\"=\">=0.4.2\"",
     "prepublishOnly": "npm run dev:published && npm install --legacy-peer-deps",
     "postpublish": "npm run dev:local && npm install --legacy-peer-deps"
   },

--- a/react-voice-commons-sdk/package.json
+++ b/react-voice-commons-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@telnyx/react-voice-commons-sdk",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "A high-level, state-agnostic, drop-in module for the Telnyx React Native SDK that simplifies WebRTC voice calling integration",
   "main": "lib/index.js",
   "module": "lib/index.js",

--- a/react-voice-commons-sdk/src/models/call.ts
+++ b/react-voice-commons-sdk/src/models/call.ts
@@ -354,6 +354,30 @@ export class Call {
   }
 
   /**
+   * Send DTMF tones on this call.
+   *
+   * Each character in `digits` is sent as a Verto INFO message to the Telnyx
+   * platform. Valid characters are `0-9`, `A-D`, `*`, and `#`; any other
+   * characters are silently dropped by the underlying SDK.
+   *
+   * Only valid while the call is `ACTIVE` — will throw otherwise. Safe to call
+   * with a single digit (e.g. for IVR dialpad presses) or a whole string
+   * (e.g. `"123#"`).
+   */
+  async dtmf(digits: string): Promise<void> {
+    if (this.currentState !== TelnyxCallState.ACTIVE) {
+      throw new Error(`Cannot send DTMF in state: ${this.currentState}`);
+    }
+
+    try {
+      await this._telnyxCall.dtmf(digits);
+    } catch (error) {
+      console.error('Failed to send DTMF:', error);
+      throw error;
+    }
+  }
+
+  /**
    * Set the call to connecting state (used for push notification calls when answered via CallKit)
    * @internal
    */


### PR DESCRIPTION
## Summary

This PR bundles two coordinated releases:

- **`@telnyx/react-native-voice-sdk`**: `0.4.1` → **`0.4.2`** (patch — DTMF ack validator fix)
- **`@telnyx/react-voice-commons-sdk`**: `0.3.1` → **`0.4.0`** (minor — adds DTMF, Android `@ReactModule` fix)

The commons SDK's `dev:published` script now pins `@telnyx/react-native-voice-sdk >= 0.4.2` so published consumers pick up the DTMF ack fix automatically.

---

## `@telnyx/react-native-voice-sdk` v0.4.2 (patch)

### Bug fix — DTMF ack validator

Every `Call.dtmf()` call threw `Invalid DTMF response received` even though the tone was delivered. Root cause: `isDTMFResponse` required `result.message === 'SENT'`, but the Telnyx gateway acks DTMF INFO requests with just `{ sessid }` — no `message` field. The validator now accepts any JSON-RPC `result` frame that echoes back the session id (matching the Android SDK's fire-and-forget semantics).

`DTMFResponse.result.message` kept as optional so older gateway builds that still emit `{ message: 'SENT', sessid }` continue to type-check.

Also fixed a misleading JSDoc on `dtmf()` — it previously claimed the resolved value was the string `'SENT'`; it's actually the gateway ack object.

---

## `@telnyx/react-voice-commons-sdk` v0.4.0 (minor)

### New feature — DTMF

`Call.dtmf(digits: string): Promise<void>` — sends DTMF tones on the current call as Verto `INFO` messages. Accepts a single digit (`"5"`) or a whole string (`"1234#"`). Valid characters: `0-9`, `A-D`, `*`, `#` — anything else is silently dropped by the underlying SDK. Throws if called outside the `ACTIVE` state.

Pass-through to the underlying voice SDK's `Call.dtmf()`. No native bridge work required. Naming matches the [Telnyx Android WebRTC SDK](https://github.com/team-telnyx/telnyx-webrtc-android)'s `fun dtmf(callId, tone)`.

### Bug fix — `@ReactModule` annotation on Android

Fixes `IllegalArgumentException: Could not find @ReactModule annotation in VoicePnBridgeModule` crash on cold start from a push action (Answer / Decline). Stack trace terminates in `TelnyxMainActivity.notifyReactNativeOfCallAction`, where `reactContext.getNativeModule(VoicePnBridgeModule::class.java)` requires the class to carry `@ReactModule(name = …)` under RN 0.79+. Added the annotation and centralized the name on `VoicePnBridgeModule.NAME` so the `getName()` return and the annotation can't drift.

### Bug fix — navigation-before-mount crash (demo app)

Fixes `Attempted to navigate before mounting the Root Layout component` in `app/_layout.tsx` on cold start. `voipClient.connectionState$` is a BehaviorSubject, so `subscribe()` fires synchronously with the current value (`DISCONNECTED` at boot), calling `router.replace('/')` before expo-router had finished initializing. Fixed by gating on `useRootNavigationState()` and skipping the initial BehaviorSubject emission.

### Demo — DTMF test dialpad

`components/ActiveCall.tsx` now renders a 4×3 DTMF dialpad (1-9, `*`, 0, `#`) with a 20-char digit log so DTMF can be tested in-app during an active call. Keys auto-disable when the call isn't `ACTIVE`. `components/CallModal.tsx` gains an optional `extraContent` slot between description and buttons to host the dialpad without restructuring the modal.

### Docs

- New guide: [docs-markdown/call-features/dtmf.md](./docs-markdown/call-features/dtmf.md)
- Root `README.md` and `react-voice-commons-sdk/README.md` Call Management sections updated
- `docs-markdown/README.md` Guides index

---

## Release sequencing after merge

The publish workflow triggers on GitHub release tags:

1. Create release `voice-sdk-v0.4.2` **first** — publishes `@telnyx/react-native-voice-sdk@0.4.2` to npm.
2. Create release `commons-sdk-v0.4.0` — `prepublishOnly` swaps its file dep to `>=0.4.2` and publishes `@telnyx/react-voice-commons-sdk@0.4.0`, which will now resolve to the freshly-published voice-sdk.

Alternatively a single unprefixed `vX.Y.Z` tag publishes both in order via the existing job-dependency chain in `.github/workflows/publish.yml`.

## Test plan

- [x] DTMF round-trip verified on device: pressing `8` on the dialpad emits `telnyx_rtc.info` with `{dtmf: "8"}`, gateway acks with `{sessid}`, no more `Invalid DTMF response received` in logs, remote IVR responds.
- [ ] DTMF state guard: `call.dtmf('1')` on a `RINGING` call throws `Cannot send DTMF in state: RINGING`.
- [ ] Android annotation fix: release build, terminated-app push, tap Answer/Decline — no `Could not find @ReactModule annotation` crash.
- [ ] Nav-ready fix: cold-start demo (not from push), no `Attempted to navigate before mounting the Root Layout component` error.
- [x] Prettier: `npx prettier --check "**/*.{js,jsx,ts,tsx,json,md}"` passes.
- [ ] Consumer verification: install `@telnyx/react-voice-commons-sdk@0.4.0` in a scratch Expo app, import `call.dtmf`, confirm no type errors.