### PR TITLE
fix: recover from stale WebSocket on incoming VoIP push

### DIFF
--- a/package/CHANGELOG.md
+++ b/package/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG.md
 
+## [0.4.3](https://github.com/team-telnyx/react-native-voice-commons/releases/tag/voice-sdk-v0.4.3) (2026-04-26)
+
+### Bug Fixing
+
+- **Recover from stale WebSocket after iOS app freeze.** `Connection` now stamps `lastActivityAt` on open / successful send / receive and exposes it via `Connection.idleMs`. `TelnyxRTC.isFresh(maxIdleMs = 30_000)` and `TelnyxRTC.connectionIdleMs` let callers detect a socket that _appears_ connected but has been silent past the server's keep-alive cadence — typical when iOS thaws a frozen app and the kernel has already reaped the TLS session without notifying the JS WebSocket wrapper.
+- **Auto-reconnect on socket error/close after login.** `telnyx.socket.error` and `telnyx.socket.close` now trigger the existing network-loss recovery path (`onNetworkUnavailable()` + `attemptReconnection()`). Previously these events were only logged, so a silent kernel-level abort during freeze left the client believing it was still connected indefinitely.
+
 ## [0.4.2](https://github.com/team-telnyx/react-native-voice-commons/releases/tag/voice-sdk-v0.4.2) (2026-04-19)
 
 ### Bug Fixing

--- a/package/lib/client.ts
+++ b/package/lib/client.ts
@@ -1241,12 +1241,16 @@ export class TelnyxRTC extends EventEmitter<TelnyxRTCEvents> {
    * network changes so we recover when iOS thaws the app and kills the old
    * TCP/TLS session ("Software caused connection abort").
    *
-   * No-op if we haven't finished initial login yet (let the initial connect
-   * promise own its own error handling) or if a reconnect is already in flight.
+   * No-op if we haven't finished login yet (let the initial connect
+   * promise own its own error handling) or if a reconnect is already in
+   * flight. We use `sessionId` as the marker because it's only assigned
+   * after `loginHandler.login()` resolves successfully — `loginHandler`
+   * itself is constructed before login runs and would let socket errors
+   * during the initial login attempt tear down the in-flight connect.
    */
   private handleUnexpectedSocketFailure(reason: 'error' | 'close', error?: Error) {
-    if (!this.loginHandler) {
-      // Initial connect promise owns its own error handling.
+    if (!this.sessionId) {
+      // Initial connect/login has not completed; let connect() own the error.
       return;
     }
     if (this.reconnecting) {

--- a/package/lib/client.ts
+++ b/package/lib/client.ts
@@ -608,9 +608,11 @@ export class TelnyxRTC extends EventEmitter<TelnyxRTCEvents> {
     this.connection.addListener('telnyx.socket.message', this.onSocketMessage);
     this.connection.addListener('telnyx.socket.error', (error) => {
       log.error('[TelnyxRTC] WebSocket connection error:', error);
+      this.handleUnexpectedSocketFailure('error', error as any);
     });
     this.connection.addListener('telnyx.socket.close', () => {
       log.debug('[TelnyxRTC] WebSocket connection closed');
+      this.handleUnexpectedSocketFailure('close');
     });
 
     // Wait for WebSocket connection to be established
@@ -793,6 +795,25 @@ export class TelnyxRTC extends EventEmitter<TelnyxRTCEvents> {
 
   public get connected() {
     return this.connection !== null && this.connection.isConnected;
+  }
+
+  /**
+   * Returns true only if the socket both claims to be connected AND has seen
+   * live traffic within `maxIdleMs`. A socket that's idle longer than that
+   * cannot be trusted after an iOS app freeze — the kernel may have killed
+   * the TLS session without notifying the JS layer. Callers should treat a
+   * non-fresh connection as dead and force a reconnect.
+   */
+  public isFresh(maxIdleMs: number = 30000): boolean {
+    if (!this.connection || !this.connection.isConnected) return false;
+    return this.connection.idleMs < maxIdleMs;
+  }
+
+  /**
+   * Exposes the socket's idle duration for diagnostics / logging.
+   */
+  public get connectionIdleMs(): number {
+    return this.connection ? this.connection.idleMs : Infinity;
   }
 
   private onSocketMessage = (msg: unknown) => {
@@ -1212,6 +1233,40 @@ export class TelnyxRTC extends EventEmitter<TelnyxRTCEvents> {
         this.onNetworkAvailable();
       }, 1500); // 1.5 seconds delay
     }
+  }
+
+  /**
+   * Handles an unexpected socket failure (error/close) after the initial
+   * connect+login has completed. Triggers the same reconnect path used for
+   * network changes so we recover when iOS thaws the app and kills the old
+   * TCP/TLS session ("Software caused connection abort").
+   *
+   * No-op if we haven't finished initial login yet (let the initial connect
+   * promise own its own error handling) or if a reconnect is already in flight.
+   */
+  private handleUnexpectedSocketFailure(reason: 'error' | 'close', error?: Error) {
+    if (!this.loginHandler) {
+      // Initial connect promise owns its own error handling.
+      return;
+    }
+    if (this.reconnecting) {
+      return;
+    }
+    log.warn(`[TelnyxRTC] Unexpected socket ${reason} after login — starting reconnect`);
+    try {
+      this.emit(
+        'telnyx.client.error',
+        error ?? new Error(`WebSocket ${reason}: reconnecting`)
+      );
+    } catch {
+      /* consumers may not be subscribed */
+    }
+    this.onNetworkUnavailable();
+    setTimeout(() => {
+      if (this.reconnecting) {
+        this.attemptReconnection();
+      }
+    }, 500);
   }
 
   /**

--- a/package/lib/connection.ts
+++ b/package/lib/connection.ts
@@ -134,8 +134,10 @@ export class Connection extends EventEmitter<ConnectionEvents> {
 
     try {
       log.debug('Sending message to gateway', msg);
-      this._lastActivityAt = Date.now();
       this.socket.send(JSON.stringify(msg));
+      // Only stamp activity AFTER a successful send so a throwing/queued
+      // send doesn't make a dead socket look fresh to isFresh() callers.
+      this._lastActivityAt = Date.now();
     } catch (error) {
       log.error(
         '[Connection]: Failed to send WebSocket message - bridge may be disconnected:',

--- a/package/lib/connection.ts
+++ b/package/lib/connection.ts
@@ -23,6 +23,12 @@ export class Connection extends EventEmitter<ConnectionEvents> {
   private reconnectAttempts: number = 0;
   private reconnectTimer: any = null;
 
+  // Track last time we observed live traffic in either direction. Used by
+  // callers to decide whether the socket is trustworthy after the app has
+  // been frozen by iOS (which can leave the JS side thinking it's still
+  // connected while the kernel has already discarded the TLS session).
+  private _lastActivityAt: number = 0;
+
   private transactions: Map<string, DeferredPromise<unknown>>;
   private messageQueue: unknown[];
 
@@ -45,6 +51,7 @@ export class Connection extends EventEmitter<ConnectionEvents> {
     this.socket.onOpen(() => {
       log.debug('[Connection]: WebSocket connection opened');
       this.isSocketConnected = true;
+      this._lastActivityAt = Date.now();
       if (this.reconnectTimer) {
         clearTimeout(this.reconnectTimer);
         this.reconnectTimer = null;
@@ -89,6 +96,7 @@ export class Connection extends EventEmitter<ConnectionEvents> {
     this.socket.onMessage((message: string) => {
       const parsedMessage = this.safeParseMessage(message);
       log.debug('Received message:', parsedMessage);
+      this._lastActivityAt = Date.now();
 
       if (isMessage(parsedMessage)) {
         const transaction = this.transactions.get(parsedMessage.id);
@@ -126,6 +134,7 @@ export class Connection extends EventEmitter<ConnectionEvents> {
 
     try {
       log.debug('Sending message to gateway', msg);
+      this._lastActivityAt = Date.now();
       this.socket.send(JSON.stringify(msg));
     } catch (error) {
       log.error(
@@ -161,6 +170,16 @@ export class Connection extends EventEmitter<ConnectionEvents> {
   };
   public get isConnected() {
     return this.isSocketConnected;
+  }
+
+  /**
+   * Milliseconds since the last observed traffic on the socket (open, send,
+   * or receive). Returns `Infinity` if we've never seen traffic. Used to
+   * detect silently-dead sockets when iOS thaws the app after a freeze.
+   */
+  public get idleMs(): number {
+    if (this._lastActivityAt === 0) return Infinity;
+    return Date.now() - this._lastActivityAt;
   }
 
   private buildWebsocketURL = () => {

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@telnyx/react-native-voice-sdk",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Telnyx React Native Voice SDK - A complete WebRTC voice calling solution",
   "main": "lib/index.ts",
   "module": "lib/index.ts",

--- a/react-voice-commons-sdk/CHANGELOG.md
+++ b/react-voice-commons-sdk/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG.md
 
+## [0.4.1] (2026-04-26)
+
+### Bug Fixing
+
+- **Recover from stale TelnyxRTC client on incoming VoIP push.** `SessionManager.handlePushNotification` now calls `client.isFresh(30_000)` before reusing an existing client. If the socket has been silent past the threshold (typical after an iOS app freeze), the client is disposed, state is flipped to `DISCONNECTED`, and the push falls through to the full `_connect()` path so login runs with the new push's `voice_sdk_id`. This resolves the case where an answered call would hang on "connecting" until CallKit timed out, because `processVoIPNotification()` was being called on a socket that had silently died.
+- Widened the reconnect-trigger state check in `handlePushNotification` to include `ERROR`, not only `DISCONNECTED`, so a push that arrives after a failed session re-establishes the connection instead of being dropped.
+
+### Dependencies
+
+- Now requires `@telnyx/react-native-voice-sdk >= 0.4.3`, which adds the `isFresh()` / `connectionIdleMs` API and auto-reconnects on unexpected socket errors. See the [voice-sdk 0.4.3 changelog](../package/CHANGELOG.md#043-2026-04-26) for details.
+
 ## [0.4.0] (2026-04-19)
 
 ### Enhancement

--- a/react-voice-commons-sdk/lib/internal/session/session-manager.js
+++ b/react-voice-commons-sdk/lib/internal/session/session-manager.js
@@ -202,6 +202,39 @@ class SessionManager {
     );
     // Store the push notification payload for when the client is created
     this._pendingPushPayload = payload;
+    // If we have a TelnyxRTC instance but its socket isn't fresh — either not
+    // connected at all, or connected but with no traffic for longer than the
+    // threshold — dispose it so we go through the full _connect() path below
+    // instead of calling processVoIPNotification on a stale client.
+    //
+    // This handles two cases iOS gives us with the same code path:
+    //   1. Terminated-then-cold-launched: a client exists (constructed at
+    //      app boot) but its connection was never opened (idleMs=Infinity).
+    //   2. Suspended-then-thawed: a client exists with `connected=true`,
+    //      but the kernel killed the TLS session during freeze without
+    //      notifying the JS WebSocket wrapper, so no error event fired.
+    //
+    // 30s threshold matches the server's keep-alive ping cadence (~20s),
+    // so a live session always remains fresh.
+    const STALE_THRESHOLD_MS = 30000;
+    if (this._telnyxClient) {
+      const client = this._telnyxClient;
+      const isFresh =
+        typeof client.isFresh === 'function'
+          ? client.isFresh(STALE_THRESHOLD_MS)
+          : !!client.connected;
+      if (!isFresh) {
+        try {
+          await this._telnyxClient.disconnect();
+        } catch (err) {
+          console.warn('SessionManager: disconnect of stale client threw:', err);
+        }
+        this._telnyxClient = undefined;
+        if (this.currentState !== connection_state_1.TelnyxConnectionState.DISCONNECTED) {
+          this._connectionState.next(connection_state_1.TelnyxConnectionState.DISCONNECTED);
+        }
+      }
+    }
     // If we don't have a config yet but we're processing a push notification,
     // attempt to load stored config first (for terminated app startup)
     if (!this._currentConfig && !this._telnyxClient) {
@@ -269,11 +302,16 @@ class SessionManager {
       console.log(
         'SessionManager: RELEASE DEBUG - No client available, checking if we can trigger immediate connection'
       );
-      // If we have config (either existing or newly loaded from storage) and are disconnected, trigger immediate connection
-      // The _connect() method will process the pending push payload BEFORE calling connect()
+      // If we have config (either existing or newly loaded from storage) and
+      // are not currently connected/connecting, trigger immediate connection.
+      // We accept DISCONNECTED and ERROR (a socket failure bumps state to
+      // ERROR) so a push after a failed session still re-establishes the
+      // connection. The _connect() method will process the pending push
+      // payload BEFORE calling connect().
       if (
         this._currentConfig &&
-        this.currentState === connection_state_1.TelnyxConnectionState.DISCONNECTED
+        (this.currentState === connection_state_1.TelnyxConnectionState.DISCONNECTED ||
+          this.currentState === connection_state_1.TelnyxConnectionState.ERROR)
       ) {
         console.log(
           'SessionManager: RELEASE DEBUG - Triggering immediate connection for push notification with config type:',

--- a/react-voice-commons-sdk/package.json
+++ b/react-voice-commons-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@telnyx/react-voice-commons-sdk",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "A high-level, state-agnostic, drop-in module for the Telnyx React Native SDK that simplifies WebRTC voice calling integration",
   "main": "lib/index.js",
   "module": "lib/index.js",

--- a/react-voice-commons-sdk/src/internal/session/session-manager.ts
+++ b/react-voice-commons-sdk/src/internal/session/session-manager.ts
@@ -178,6 +178,40 @@ export class SessionManager {
     // Store the push notification payload for when the client is created
     (this as any)._pendingPushPayload = payload;
 
+    // If we have a TelnyxRTC instance but its socket isn't fresh — either not
+    // connected at all, or connected but with no traffic for longer than the
+    // threshold — dispose it so we go through the full _connect() path below
+    // instead of calling processVoIPNotification on a stale client.
+    //
+    // This handles two cases iOS gives us with the same code path:
+    //   1. Terminated-then-cold-launched: a client exists (constructed at
+    //      app boot) but its connection was never opened (idleMs=Infinity).
+    //   2. Suspended-then-thawed: a client exists with `connected=true`,
+    //      but the kernel killed the TLS session during freeze without
+    //      notifying the JS WebSocket wrapper, so no error event fired.
+    //
+    // 30s threshold matches the server's keep-alive ping cadence (~20s),
+    // so a live session always remains fresh.
+    const STALE_THRESHOLD_MS = 30000;
+    if (this._telnyxClient) {
+      const client = this._telnyxClient as any;
+      const isFresh =
+        typeof client.isFresh === 'function'
+          ? client.isFresh(STALE_THRESHOLD_MS)
+          : !!client.connected;
+      if (!isFresh) {
+        try {
+          await this._telnyxClient.disconnect();
+        } catch (err) {
+          console.warn('SessionManager: disconnect of stale client threw:', err);
+        }
+        this._telnyxClient = undefined;
+        if (this.currentState !== TelnyxConnectionState.DISCONNECTED) {
+          this._connectionState.next(TelnyxConnectionState.DISCONNECTED);
+        }
+      }
+    }
+
     // If we don't have a config yet but we're processing a push notification,
     // attempt to load stored config first (for terminated app startup)
     if (!this._currentConfig && !this._telnyxClient) {
@@ -255,9 +289,17 @@ export class SessionManager {
         'SessionManager: RELEASE DEBUG - No client available, checking if we can trigger immediate connection'
       );
 
-      // If we have config (either existing or newly loaded from storage) and are disconnected, trigger immediate connection
-      // The _connect() method will process the pending push payload BEFORE calling connect()
-      if (this._currentConfig && this.currentState === TelnyxConnectionState.DISCONNECTED) {
+      // If we have config (either existing or newly loaded from storage) and
+      // are not currently connected/connecting, trigger immediate connection.
+      // We accept DISCONNECTED and ERROR (a socket failure bumps state to
+      // ERROR) so a push after a failed session still re-establishes the
+      // connection. The _connect() method will process the pending push
+      // payload BEFORE calling connect().
+      if (
+        this._currentConfig &&
+        (this.currentState === TelnyxConnectionState.DISCONNECTED ||
+          this.currentState === TelnyxConnectionState.ERROR)
+      ) {
         console.log(
           'SessionManager: RELEASE DEBUG - Triggering immediate connection for push notification with config type:',
           (this._currentConfig as any).type || 'credential'


### PR DESCRIPTION
## Summary

- Adds liveness tracking + freshness gate so an incoming VoIP push never lands on a TelnyxRTC instance whose socket has died silently during an iOS app freeze.
- Wires `telnyx.socket.error` / `telnyx.socket.close` into the existing reconnect path; previously these events were only logged, so a kernel-level abort while the app was suspended left the client believing it was still connected.
- Bumps `@telnyx/react-native-voice-sdk` 0.4.2 → 0.4.3 and `@telnyx/react-voice-commons-sdk` 0.4.0 → 0.4.1.

## The bug

Reproduced reliably with: kill app → lock phone → wait → place a call → end remotely before answer → place a second call → answer it.

What was happening:

1. iOS freezes the app during the idle window. While frozen, the kernel reaps the TLS session backing the WebSocket — sometimes with an event the JS layer sees, sometimes silently (after the OS-level idle timeout).
2. On the next push, the SDK sees `hasClient=true, state=CONNECTED` and takes the happy path: `processVoIPNotification(...)` is called on the existing client. That method only flips in-memory flags; the actual signaling (login → INVITE → SDP exchange → peer connection) has to flow over the socket.
3. The socket is dead. Nothing goes out, nothing comes in. CallKit has already shown the answer UI and is holding a deferred `CXAnswerCallAction`. It never gets fulfilled. Call hangs on "connecting" until CallKit times out.

The native `WebSocketSelfSigned` wrapper does not always fire `onClose`/`onError` when iOS kills the socket during freeze, and the SDK had no idle/timeout-based liveness check, so the stale state could persist for the entire lifetime of the suspended process.

## The fix

Two-layer change:

**`@telnyx/react-native-voice-sdk` (`package/lib`)**
- `Connection` now tracks `_lastActivityAt` on open/send/receive and exposes `idleMs`.
- `TelnyxRTC` exposes `isFresh(maxIdleMs = 30_000)` and `connectionIdleMs`.
- New `handleUnexpectedSocketFailure(reason)` — fires on `telnyx.socket.error`/`close` after initial login and triggers the existing `onNetworkUnavailable()` + `attemptReconnection()` flow (with a 500ms delay to let teardown settle).

**`@telnyx/react-voice-commons-sdk` (`react-voice-commons-sdk/src`)**
- `SessionManager.handlePushNotification` now checks `client.isFresh(30_000)` before reusing an existing client. If not fresh, it disconnects, drops the reference, flips state to `DISCONNECTED`, and falls through to `_connect()` so login runs with the push's `voice_sdk_id`.
- Reconnect trigger after the no-client branch now also fires from `ERROR` state, not only `DISCONNECTED`.

## Why 30 seconds

The server pings every ~20s; the keep-alive handler acks them. During a live session `lastActivityAt` is always under that ceiling, so `isFresh()` returns `true` and the existing client is reused as before. The check only tears down when the socket has actually been silent past the server's keep-alive cadence — i.e. it's almost certainly dead.

## Test plan

- [x] Build passes (`npm run build` in `react-voice-commons-sdk/`).
- [x] Prettier clean for the three changed source files.
- [x] Verified end-to-end on device (iPhone, release build): kill → freeze → push → answer → INVITE → SDP exchange → CallKit `reportCallConnected` fulfills the deferred answer action in <1s. Call goes active.
- [x] Verified happy path on device with a fresh socket: freshness check passes, existing client is reused, no extra reconnect.
- [ ] Manual smoke: outbound call from foreground (no behavior change expected).
- [ ] Manual smoke: foreground incoming call (no behavior change expected).

## Notes / non-goals

- Doesn't add a client-initiated keep-alive ping. The freshness check is reactive (only on push), which is sufficient for the reported scenario; a proactive ping is a larger change worth a separate PR.
- Doesn't touch `WebSocketSelfSigned` itself. The freshness gate works around the missing-callback issue without depending on changes to the native wrapper.