### PR TITLE
docs: align changelog publish dates with actual release

### DIFF
--- a/package/CHANGELOG.md
+++ b/package/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG.md
 
-## [0.4.3](https://github.com/team-telnyx/react-native-voice-commons/releases/tag/voice-sdk-v0.4.3) (2026-04-26)
+## [0.4.3](https://github.com/team-telnyx/react-native-voice-commons/releases/tag/voice-sdk-v0.4.3) (2026-04-27)
 
 ### Bug Fixing
 

--- a/react-voice-commons-sdk/CHANGELOG.md
+++ b/react-voice-commons-sdk/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG.md
 
-## [0.4.1] (2026-04-26)
+## [0.4.1] (2026-04-27)
 
 ### Bug Fixing
 
@@ -9,7 +9,7 @@
 
 ### Dependencies
 
-- Now requires `@telnyx/react-native-voice-sdk >= 0.4.3`, which adds the `isFresh()` / `connectionIdleMs` API and auto-reconnects on unexpected socket errors. See the [voice-sdk 0.4.3 changelog](../package/CHANGELOG.md#043-2026-04-26) for details.
+- Now requires `@telnyx/react-native-voice-sdk >= 0.4.3`, which adds the `isFresh()` / `connectionIdleMs` API and auto-reconnects on unexpected socket errors. See the [voice-sdk 0.4.3 changelog](../package/CHANGELOG.md#043-2026-04-27) for details.
 
 ## [0.4.0] (2026-04-19)
 


### PR DESCRIPTION
## Summary

- `voice-sdk@0.4.3` was published on 2026-04-27 (per the npm release notification), not 2026-04-26 as the changelog claimed at merge time.
- Updates the date for `voice-sdk@0.4.3` in `package/CHANGELOG.md` and the matching entry + cross-link anchor for `react-voice-commons-sdk@0.4.1` in `react-voice-commons-sdk/CHANGELOG.md`.

No code changes — purely a date alignment so the changelog reflects when the package actually shipped to npm.

## Test plan

- [x] `npx prettier --check` passes for both changelog files.
- [ ] Confirm the rendered cross-link `voice-sdk 0.4.3 changelog` resolves to the correct anchor on GitHub once merged.