### PR TITLE
fix(voice-sdk): Call.dtmf() sends full dialogParams to match Android SDK

### DIFF
--- a/package/CHANGELOG.md
+++ b/package/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG.md
 
+## [0.4.4](https://github.com/team-telnyx/react-native-voice-commons/releases/tag/voice-sdk-v0.4.4) (2026-04-27)
+
+### Bug Fixing
+
+- **`Call.dtmf()` now sends a full `dialogParams` object on the `telnyx_rtc.info` request to match the Android Voice SDK.** Previously only `{ sessid, dtmf }` was sent. The new payload mirrors Android exactly — `attach`, `audio`, `callID`, `caller_id_name`, `caller_id_number`, `clientState`, `custom_headers`, `destination_number`, `remote_caller_id_name`, `screenShare`, `useStereo`, `userVariables`, `video` — populated from the call's `CallOptions` where available and empty-but-present defaults (`""`, `[]`, `false`) for fields we don't track. Fields not represented in `CallOptions` (`screenShare`, `useStereo`, `userVariables`, `video`) are always sent as their Android-equivalent defaults.
+
 ## [0.4.3](https://github.com/team-telnyx/react-native-voice-commons/releases/tag/voice-sdk-v0.4.3) (2026-04-27)
 
 ### Bug Fixing

--- a/package/lib/call.ts
+++ b/package/lib/call.ts
@@ -531,6 +531,12 @@ export class Call extends EventEmitter<CallEvents> {
       digits,
       sessionId: this.sessionId,
       callId: this.callId,
+      callerIdName: this.options.callerIdName,
+      callerIdNumber: this.options.callerIdNumber,
+      clientState: this.options.clientState,
+      customHeaders: this.options.customHeaders,
+      destinationNumber: this.options.destinationNumber,
+      remoteCallerIdName: this.options.remoteCallerIdName,
     });
 
     const response = await this.connection.sendAndWait(DTMFRequest);

--- a/package/lib/messages/call.ts
+++ b/package/lib/messages/call.ts
@@ -346,6 +346,13 @@ export function isModifyCallAnswer(msg: unknown): msg is ModifyCallAnswer {
   );
 }
 
+/**
+ * Verto `telnyx_rtc.info` request used to send DTMF tones.
+ *
+ * Mirrors the shape produced by the Android Voice SDK so the gateway sees a
+ * consistent payload across platforms — including the full `dialogParams`
+ * object with empty-but-present defaults for fields we don't track.
+ */
 type DTMFRequest = {
   jsonrpc: '2.0';
   id: string;
@@ -353,11 +360,20 @@ type DTMFRequest = {
   params: {
     sessid: string;
     dtmf: string;
-    dialogParams?: {
-      telnyxLegId: string;
-      telnyxSessionId: string;
+    dialogParams: {
+      attach: boolean;
+      audio: boolean;
       callID: string;
+      caller_id_name: string;
+      caller_id_number: string;
+      clientState: string;
+      custom_headers: { name: string; value: string }[];
       destination_number: string;
+      remote_caller_id_name: string;
+      screenShare: boolean;
+      useStereo: boolean;
+      userVariables: unknown[];
+      video: boolean;
     };
   };
 };
@@ -365,20 +381,38 @@ type DTMFRequest = {
 type CreateDTMFRequestParams = {
   digits: string;
   sessionId: string;
-  telnyxLegId?: string;
-  telnyxSessionId?: string;
-  callId?: string;
+  callId: string;
+  callerIdName?: string;
+  callerIdNumber?: string;
+  clientState?: string;
+  customHeaders?: { name: string; value: string }[];
   destinationNumber?: string;
+  remoteCallerIdName?: string;
 };
 
-export function createDTMFRequest({ digits, sessionId }: CreateDTMFRequestParams): DTMFRequest {
+export function createDTMFRequest(params: CreateDTMFRequestParams): DTMFRequest {
   return {
     id: uuid(),
     jsonrpc: '2.0',
     method: TelnyxRTCMethod.INFO,
     params: {
-      sessid: sessionId,
-      dtmf: digits,
+      sessid: params.sessionId,
+      dtmf: params.digits,
+      dialogParams: {
+        attach: false,
+        audio: true,
+        callID: params.callId,
+        caller_id_name: params.callerIdName ?? '',
+        caller_id_number: params.callerIdNumber ?? '',
+        clientState: params.clientState ?? '',
+        custom_headers: params.customHeaders ?? [],
+        destination_number: params.destinationNumber ?? '',
+        remote_caller_id_name: params.remoteCallerIdName ?? '',
+        screenShare: false,
+        useStereo: false,
+        userVariables: [],
+        video: false,
+      },
     },
   };
 }

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@telnyx/react-native-voice-sdk",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Telnyx React Native Voice SDK - A complete WebRTC voice calling solution",
   "main": "lib/index.ts",
   "module": "lib/index.ts",


### PR DESCRIPTION
## Summary

Aligns the React Native Voice SDK's DTMF wire format with the Android Voice SDK. Previously `Call.dtmf()` sent only `{ sessid, dtmf }` in the `telnyx_rtc.info` params; Android sends a full `dialogParams` object alongside, even when many fields are empty.

This PR makes the RN SDK send exactly the same shape Android does, populated from the call's `CallOptions` where available and with empty/false defaults for fields not tracked on the RN side.

## What Android sends today

```json
{
  "id": "b99f9cca-ffbe-4a4a-999b-60649842c531",
  "jsonrpc": "2.0",
  "method": "telnyx_rtc.info",
  "params": {
    "dialogParams": {
      "attach": false,
      "audio": true,
      "callID": "35280021-80f8-42ae-9843-8626cf35d6dd",
      "caller_id_name": "",
      "caller_id_number": "",
      "clientState": "",
      "custom_headers": [],
      "destination_number": "",
      "remote_caller_id_name": "",
      "screenShare": false,
      "useStereo": false,
      "userVariables": [],
      "video": false
    },
    "dtmf": "1",
    "sessid": "a012938a-ed1f-4e95-9e92-2bd6b0fef5fe"
  }
}
```

The RN SDK now sends exactly this set of `dialogParams` keys.

## Implementation

- `package/lib/messages/call.ts` — `DTMFRequest` type now requires the full `dialogParams` object; `createDTMFRequest` accepts the optional call fields and fills sensible defaults that mirror Android.
- `package/lib/call.ts` — `Call.dtmf()` passes through `callerIdName`, `callerIdNumber`, `clientState`, `customHeaders`, `destinationNumber`, and `remoteCallerIdName` from `this.options` so they end up in the wire payload.
- Bumps `@telnyx/react-native-voice-sdk` 0.4.3 → 0.4.4.
- Adds a changelog entry.

## Reference

Android implementation: https://github.com/team-telnyx/telnyx-webrtc-android

## Test plan

- [x] `npx prettier --check` passes for the four touched files.
- [ ] Manual: trigger `Call.dtmf('1')` mid-call and capture the outbound frame; verify it matches the Android-shaped JSON above.
- [ ] Manual: verify the gateway still acks (`isDTMFResponse` validation continues to pass — ack semantics unchanged from 0.4.3).