### PR TITLE
chore(release): auto-derive voice-sdk floor from sibling package.json

### DIFF
--- a/react-voice-commons-sdk/package.json
+++ b/react-voice-commons-sdk/package.json
@@ -39,7 +39,7 @@
     "android": "expo run:android",
     "ios": "expo run:ios",
     "dev:local": "npm pkg set dependencies.@telnyx/react-native-voice-sdk=file:../package",
-    "dev:published": "npm pkg set \"dependencies.@telnyx/react-native-voice-sdk\"=\">=$(node -p \"require('../package/package.json').version\")\"",
+    "dev:published": "node ./scripts/set-voice-sdk-floor.mjs",
     "prepublishOnly": "npm run dev:published && npm install --legacy-peer-deps",
     "postpublish": "npm run dev:local && npm install --legacy-peer-deps"
   },

--- a/react-voice-commons-sdk/package.json
+++ b/react-voice-commons-sdk/package.json
@@ -39,7 +39,7 @@
     "android": "expo run:android",
     "ios": "expo run:ios",
     "dev:local": "npm pkg set dependencies.@telnyx/react-native-voice-sdk=file:../package",
-    "dev:published": "npm pkg set \"dependencies.@telnyx/react-native-voice-sdk\"=\">=0.4.2\"",
+    "dev:published": "npm pkg set \"dependencies.@telnyx/react-native-voice-sdk\"=\">=$(node -p \"require('../package/package.json').version\")\"",
     "prepublishOnly": "npm run dev:published && npm install --legacy-peer-deps",
     "postpublish": "npm run dev:local && npm install --legacy-peer-deps"
   },

--- a/react-voice-commons-sdk/scripts/set-voice-sdk-floor.mjs
+++ b/react-voice-commons-sdk/scripts/set-voice-sdk-floor.mjs
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+// Rewrites this package's `@telnyx/react-native-voice-sdk` dependency
+// constraint to ">=<sibling version>" right before publishing.
+//
+// Used by the `dev:published` npm script. Implemented in Node (not POSIX
+// shell substitution) so it works on both POSIX runners and Windows, where
+// npm scripts execute under `cmd.exe`.
+
+import { readFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const siblingPkgPath = path.resolve(__dirname, '..', '..', 'package', 'package.json');
+
+let version;
+try {
+  const sibling = JSON.parse(readFileSync(siblingPkgPath, 'utf8'));
+  version = sibling.version;
+} catch (err) {
+  console.error(`[set-voice-sdk-floor] Failed to read ${siblingPkgPath}:`, err.message);
+  process.exit(1);
+}
+
+if (typeof version !== 'string' || version.length === 0) {
+  console.error(`[set-voice-sdk-floor] Missing or invalid "version" in ${siblingPkgPath}`);
+  process.exit(1);
+}
+
+const range = `>=${version}`;
+console.log(`[set-voice-sdk-floor] Setting @telnyx/react-native-voice-sdk to "${range}"`);
+
+execSync(`npm pkg set "dependencies.@telnyx/react-native-voice-sdk"="${range}"`, {
+  stdio: 'inherit',
+});


### PR DESCRIPTION
## Summary

Removes a release-time footgun: every time `@telnyx/react-native-voice-sdk` is bumped, the `dev:published` script in `react-voice-commons-sdk/package.json` had to be manually updated to point at the new minimum, otherwise the published commons SDK would declare a stale floor for the underlying voice-sdk dependency.

This PR replaces the hardcoded version with a lookup that reads from the sibling package's `package.json`.

## Background

The current `prepublishOnly` flow rewrites `dependencies."@telnyx/react-native-voice-sdk"` from `file:../package` (used in local development) to a published range right before `npm publish`:

```json
"dev:local":     "npm pkg set dependencies.@telnyx/react-native-voice-sdk=file:../package",
"dev:published": "npm pkg set \"dependencies.@telnyx/react-native-voice-sdk\"=\">=0.4.2\"",
"prepublishOnly": "npm run dev:published && npm install --legacy-peer-deps",
"postpublish":    "npm run dev:local && npm install --legacy-peer-deps"
```

The hardcoded `">=0.4.2"` had drifted: the latest published voice-sdk is `0.4.3`, the changelog for `react-voice-commons-sdk@0.4.1` said it required `>=0.4.3`, but the published `package.json` would have declared `>=0.4.2`.

## Change

```diff
- "dev:published": "npm pkg set \"dependencies.@telnyx/react-native-voice-sdk\"=\">=0.4.2\"",
+ "dev:published": "npm pkg set \"dependencies.@telnyx/react-native-voice-sdk\"=\">=$(node -p \"require('../package/package.json').version\")\"",
```

The shell substitution executes Node and reads the sibling package's current version. So the published floor always matches whatever voice-sdk version exists in the same merge.

## Verified locally

```
$ cd react-voice-commons-sdk
$ npm run dev:published
> npm pkg set "dependencies.@telnyx/react-native-voice-sdk"=">=$(node -p "require('../package/package.json').version")"

$ grep '@telnyx/react-native-voice-sdk' package.json
"@telnyx/react-native-voice-sdk": ">=0.4.3",   # ← derived from sibling, not hardcoded

$ npm run dev:local
$ grep '@telnyx/react-native-voice-sdk' package.json
"@telnyx/react-native-voice-sdk": "file:../package",   # ← restored for local dev
```

## Test plan

- [x] `npm run dev:published` writes the current sibling version into `package.json`.
- [x] `npm run dev:local` restores the `file:../package` entry afterwards.
- [ ] CI publish run on a future merge produces a tarball whose `package.json` declares the expected floor (verify on next release).