### PR TITLE
release(voice-commons): 0.4.2 — pull in voice-sdk 0.4.4 (DTMF dialogParams)

### DIFF
--- a/react-voice-commons-sdk/CHANGELOG.md
+++ b/react-voice-commons-sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG.md
 
+## [0.4.2] (2026-04-27)
+
+### Bug Fixing
+
+- `Call.dtmf()` now sends the full `dialogParams` payload on `telnyx_rtc.info` to match the Android Voice SDK's wire format (via `@telnyx/react-native-voice-sdk@0.4.4`).
+
 ## [0.4.1] (2026-04-27)
 
 ### Bug Fixing

--- a/react-voice-commons-sdk/package.json
+++ b/react-voice-commons-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@telnyx/react-voice-commons-sdk",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "A high-level, state-agnostic, drop-in module for the Telnyx React Native SDK that simplifies WebRTC voice calling integration",
   "main": "lib/index.js",
   "module": "lib/index.js",


### PR DESCRIPTION
## Summary

Bumps `@telnyx/react-voice-commons-sdk` from 0.4.1 → **0.4.2** to ship the `Call.dtmf()` Android-alignment fix that landed in `@telnyx/react-native-voice-sdk@0.4.4` (PR #61).

No commons-side API changes — `Call.dtmf()` is exposed as-is from the underlying SDK; the wire-format update is internal to voice-sdk.

## What ships to consumers

When this merges and CI publishes:

- The released `package.json` will declare `@telnyx/react-native-voice-sdk: >=0.4.4` (auto-derived from the sibling at publish time by the `set-voice-sdk-floor.mjs` helper added in #62 — no manual range bump needed).
- Apps installing `@telnyx/react-voice-commons-sdk@0.4.2` will resolve voice-sdk to its latest matching version (≥0.4.4), getting both the DTMF fix and the stale-socket recovery from 0.4.3.

## Test plan

- [x] `npx prettier --check` passes for changelog and package.json.
- [ ] CI publish run produces a tarball whose `package.json` declares `@telnyx/react-native-voice-sdk: >=0.4.4`.
- [ ] Manual smoke after publish: install commons 0.4.2 in the demo, verify `npm ls @telnyx/react-native-voice-sdk` resolves to 0.4.4.