### PR TITLE
feat: add Trickle ICE support

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -eu
+
+echo "Running Prettier check before commit..."
+npm run lint

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "ios": "expo start -c --ios",
     "web": "expo start -c --web",
     "clean": "rm -rf .expo node_modules",
+    "prepare": "git config core.hooksPath .githooks || true",
+    "hooks:install": "git config core.hooksPath .githooks",
     "postinstall": "npx tailwindcss -i ./global.css -o ./node_modules/.cache/nativewind/global.css",
     "lint": "prettier --check \"**/*.{js,jsx,ts,tsx,json,md}\"",
     "lint:fix": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md}\"",

--- a/package/__tests__/trickle-ice-call-flow.test.ts
+++ b/package/__tests__/trickle-ice-call-flow.test.ts
@@ -97,4 +97,45 @@ describe('Trickle ICE call lifecycle', () => {
     });
     expect(call.handleRemoteEndOfCandidates).toHaveBeenCalledTimes(1);
   });
+
+  it('queues remote trickle events until the matching call is tracked', () => {
+    const client = new TelnyxRTC({ logLevel: 'error' });
+    const call = {
+      callId: 'call-123',
+      state: 'active',
+      on: jest.fn(),
+      off: jest.fn(),
+      handleRemoteCandidate: jest.fn(),
+      handleRemoteEndOfCandidates: jest.fn(),
+    } as any;
+
+    (client as any).onSocketMessage({
+      method: TelnyxRTCMethod.CANDIDATE,
+      params: {
+        candidate: 'candidate:1 1 UDP 2122252543 192.0.2.1 54400 typ host',
+        sdpMid: '0',
+        sdpMLineIndex: 0,
+        dialogParams: { callID: 'call-123' },
+      },
+    });
+
+    (client as any).onSocketMessage({
+      method: TelnyxRTCMethod.END_OF_CANDIDATES,
+      params: {
+        dialogParams: { callID: 'call-123' },
+      },
+    });
+
+    expect(call.handleRemoteCandidate).not.toHaveBeenCalled();
+    expect(call.handleRemoteEndOfCandidates).not.toHaveBeenCalled();
+
+    (client as any).addCall(call);
+
+    expect(call.handleRemoteCandidate).toHaveBeenCalledWith({
+      candidate: 'candidate:1 1 UDP 2122252543 192.0.2.1 54400 typ host',
+      sdpMid: '0',
+      sdpMLineIndex: 0,
+    });
+    expect(call.handleRemoteEndOfCandidates).toHaveBeenCalledTimes(1);
+  });
 });

--- a/package/__tests__/trickle-ice-call-flow.test.ts
+++ b/package/__tests__/trickle-ice-call-flow.test.ts
@@ -1,0 +1,100 @@
+import { Call } from '../lib/call';
+import { TelnyxRTC } from '../lib/client';
+import { TelnyxRTCMethod } from '../lib/messages/methods';
+
+jest.mock('../lib/connection');
+jest.mock('../lib/peer');
+
+const trickleSdp = [
+  'v=0',
+  'o=- 46117317 2 IN IP4 127.0.0.1',
+  's=-',
+  't=0 0',
+  'm=audio 9 UDP/TLS/RTP/SAVPF 111',
+  'a=mid:0',
+  'a=candidate:1 1 UDP 2122252543 192.0.2.1 54400 typ host',
+  'a=end-of-candidates',
+  '',
+].join('\r\n');
+
+describe('Trickle ICE call lifecycle', () => {
+  it('answers immediately without waiting for ICE gathering and strips SDP candidate lines', async () => {
+    const sendAndWait = jest.fn().mockResolvedValue({});
+    const connection = {
+      sendAndWait,
+      send: jest.fn(),
+      addListener: jest.fn(),
+    } as any;
+    const peer = {
+      attachLocalStream: jest.fn().mockResolvedValue(undefined),
+      createAnswer: jest.fn().mockResolvedValue(undefined),
+      waitForIceGatheringComplete: jest.fn().mockResolvedValue(undefined),
+      localDescription: { sdp: trickleSdp },
+      flushPendingLocalCandidates: jest.fn(),
+      close: jest.fn(),
+    } as any;
+    peer.attachLocalStream.mockResolvedValue(peer);
+    peer.createAnswer.mockResolvedValue(peer);
+
+    const call = new Call({
+      connection,
+      options: {
+        destinationNumber: '+15551234567',
+        peerConnectionOptions: { useTrickleIce: true },
+      },
+      sessionId: 'session-123',
+      direction: 'inbound',
+      telnyxSessionId: 'telnyx-session-123',
+      telnyxLegId: 'telnyx-leg-123',
+      callId: 'call-123',
+    });
+    (call as any).peer = peer;
+
+    await call.answer();
+
+    expect(peer.waitForIceGatheringComplete).not.toHaveBeenCalled();
+    const answerMessage = sendAndWait.mock.calls[0][0];
+    expect(answerMessage.params.sdp).toContain('a=ice-options:trickle');
+    expect(answerMessage.params.sdp).not.toContain('a=candidate:');
+    expect(answerMessage.params.sdp).not.toContain('a=end-of-candidates');
+    expect(peer.flushPendingLocalCandidates).toHaveBeenCalled();
+  });
+
+  it('routes incoming candidate and end-of-candidates messages to the matching call', () => {
+    const client = new TelnyxRTC({ logLevel: 'error' });
+    const call = {
+      callId: 'call-123',
+      state: 'active',
+      on: jest.fn(),
+      off: jest.fn(),
+      handleRemoteCandidate: jest.fn(),
+      handleRemoteEndOfCandidates: jest.fn(),
+    } as any;
+
+    (client as any).addCall(call);
+
+    (client as any).onSocketMessage({
+      method: TelnyxRTCMethod.CANDIDATE,
+      params: {
+        candidate: 'candidate:1 1 UDP 2122252543 192.0.2.1 54400 typ host',
+        sdpMid: '0',
+        sdpMLineIndex: 0,
+        dialogParams: { callID: 'call-123' },
+      },
+    });
+
+    (client as any).onSocketMessage({
+      method: TelnyxRTCMethod.END_OF_CANDIDATES,
+      params: {
+        dialogParams: { callID: 'call-123' },
+      },
+    });
+
+    expect(call.handleRemoteCandidate).toHaveBeenCalledWith({
+      candidate: 'candidate:1 1 UDP 2122252543 192.0.2.1 54400 typ host',
+      sdpMid: '0',
+      sdpMLineIndex: 0,
+    });
+    expect(call.handleRemoteEndOfCandidates).toHaveBeenCalledTimes(1);
+  });
+});

--- a/package/__tests__/trickle-ice-messages.test.ts
+++ b/package/__tests__/trickle-ice-messages.test.ts
@@ -145,8 +145,6 @@ describe('Trickle ICE SDP utilities', () => {
       cleanCandidateString(
         'candidate:2 1 UDP 1686052607 203.0.113.1 54000 typ srflx raddr 10.0.0.1 rport 54000 generation 0 ufrag xyz'
       )
-    ).toBe(
-      'candidate:2 1 UDP 1686052607 203.0.113.1 54000 typ srflx raddr 10.0.0.1 rport 54000'
-    );
+    ).toBe('candidate:2 1 UDP 1686052607 203.0.113.1 54000 typ srflx raddr 10.0.0.1 rport 54000');
   });
 });

--- a/package/__tests__/trickle-ice-messages.test.ts
+++ b/package/__tests__/trickle-ice-messages.test.ts
@@ -7,6 +7,7 @@ import {
 import { TelnyxRTCMethod } from '../lib/messages/methods';
 import {
   addTrickleIceCapability,
+  cleanCandidateString,
   removeCandidateLines,
   normalizeRemoteCandidateString,
 } from '../lib/sdp-utils';
@@ -59,6 +60,8 @@ describe('Trickle ICE signaling messages', () => {
         method: TelnyxRTCMethod.CANDIDATE,
         params: {
           candidate: 'candidate:1 1 UDP 2122252543 192.0.2.1 54400 typ host',
+          sdpMid: '0',
+          sdpMLineIndex: 0,
           dialogParams: { callID: 'call-123' },
         },
       })
@@ -98,6 +101,25 @@ describe('Trickle ICE SDP utilities', () => {
     expect(twice.match(/a=ice-options:trickle/g)).toHaveLength(1);
   });
 
+  it('inserts ice-options after origin and normalizes existing ICE options', () => {
+    const withTrickle = addTrickleIceCapability(sdp);
+    const lines = withTrickle.split(/\r\n|\n|\r/);
+    const originIndex = lines.findIndex((line) => line.startsWith('o='));
+
+    expect(lines[originIndex + 1]).toBe('a=ice-options:trickle');
+
+    expect(
+      addTrickleIceCapability(
+        [
+          'v=0',
+          'o=- 46117317 2 IN IP4 127.0.0.1',
+          'a=ice-options:trickle renomination',
+          's=-',
+        ].join('\r\n')
+      )
+    ).toContain('a=ice-options:trickle\r\ns=-');
+  });
+
   it('removes candidate and end-of-candidates lines from initial SDP', () => {
     const stripped = removeCandidateLines(sdp);
 
@@ -110,5 +132,21 @@ describe('Trickle ICE SDP utilities', () => {
     expect(
       normalizeRemoteCandidateString('a=candidate:1 1 UDP 2122252543 192.0.2.1 54400 typ host')
     ).toBe('candidate:1 1 UDP 2122252543 192.0.2.1 54400 typ host');
+  });
+
+  it('cleans local candidates before signaling to match Android', () => {
+    expect(
+      cleanCandidateString(
+        'a=candidate:1 1 UDP 2122252543 192.0.2.1 54400 typ host generation 0 ufrag abc network-id 3 network-cost 10'
+      )
+    ).toBe('candidate:1 1 UDP 2122252543 192.0.2.1 54400 typ host');
+
+    expect(
+      cleanCandidateString(
+        'candidate:2 1 UDP 1686052607 203.0.113.1 54000 typ srflx raddr 10.0.0.1 rport 54000 generation 0 ufrag xyz'
+      )
+    ).toBe(
+      'candidate:2 1 UDP 1686052607 203.0.113.1 54000 typ srflx raddr 10.0.0.1 rport 54000'
+    );
   });
 });

--- a/package/__tests__/trickle-ice-messages.test.ts
+++ b/package/__tests__/trickle-ice-messages.test.ts
@@ -1,0 +1,114 @@
+import {
+  createCandidateMessage,
+  createEndOfCandidatesMessage,
+  isCandidateEvent,
+  isEndOfCandidatesEvent,
+} from '../lib/messages/call';
+import { TelnyxRTCMethod } from '../lib/messages/methods';
+import {
+  addTrickleIceCapability,
+  removeCandidateLines,
+  normalizeRemoteCandidateString,
+} from '../lib/sdp-utils';
+
+describe('Trickle ICE signaling messages', () => {
+  it('creates a telnyx_rtc.candidate message with call and ICE metadata', () => {
+    const message = createCandidateMessage({
+      sessionId: 'session-123',
+      callId: 'call-123',
+      candidate: 'candidate:1 1 UDP 2122252543 192.0.2.1 54400 typ host',
+      sdpMid: '0',
+      sdpMLineIndex: 0,
+    });
+
+    expect(message).toEqual({
+      id: expect.any(String),
+      jsonrpc: '2.0',
+      method: TelnyxRTCMethod.CANDIDATE,
+      params: {
+        sessid: 'session-123',
+        candidate: 'candidate:1 1 UDP 2122252543 192.0.2.1 54400 typ host',
+        sdpMid: '0',
+        sdpMLineIndex: 0,
+        dialogParams: {
+          callID: 'call-123',
+        },
+      },
+    });
+  });
+
+  it('creates a telnyx_rtc.endOfCandidates message scoped to the call', () => {
+    const message = createEndOfCandidatesMessage({ sessionId: 'session-123', callId: 'call-123' });
+
+    expect(message).toEqual({
+      id: expect.any(String),
+      jsonrpc: '2.0',
+      method: TelnyxRTCMethod.END_OF_CANDIDATES,
+      params: {
+        sessid: 'session-123',
+        dialogParams: {
+          callID: 'call-123',
+        },
+      },
+    });
+  });
+
+  it('identifies incoming candidate and end-of-candidates events', () => {
+    expect(
+      isCandidateEvent({
+        method: TelnyxRTCMethod.CANDIDATE,
+        params: {
+          candidate: 'candidate:1 1 UDP 2122252543 192.0.2.1 54400 typ host',
+          dialogParams: { callID: 'call-123' },
+        },
+      })
+    ).toBe(true);
+
+    expect(
+      isEndOfCandidatesEvent({
+        method: TelnyxRTCMethod.END_OF_CANDIDATES,
+        params: {
+          dialogParams: { callID: 'call-123' },
+        },
+      })
+    ).toBe(true);
+  });
+});
+
+describe('Trickle ICE SDP utilities', () => {
+  const sdp = [
+    'v=0',
+    'o=- 46117317 2 IN IP4 127.0.0.1',
+    's=-',
+    't=0 0',
+    'a=group:BUNDLE 0',
+    'm=audio 9 UDP/TLS/RTP/SAVPF 111',
+    'a=mid:0',
+    'a=rtcp-mux',
+    'a=candidate:1 1 UDP 2122252543 192.0.2.1 54400 typ host',
+    'a=end-of-candidates',
+    '',
+  ].join('\r\n');
+
+  it('adds ice-options:trickle once', () => {
+    const once = addTrickleIceCapability(sdp);
+    const twice = addTrickleIceCapability(once);
+
+    expect(once).toContain('a=ice-options:trickle');
+    expect(twice.match(/a=ice-options:trickle/g)).toHaveLength(1);
+  });
+
+  it('removes candidate and end-of-candidates lines from initial SDP', () => {
+    const stripped = removeCandidateLines(sdp);
+
+    expect(stripped).not.toContain('a=candidate:');
+    expect(stripped).not.toContain('a=end-of-candidates');
+    expect(stripped).toContain('m=audio');
+  });
+
+  it('normalizes incoming candidate strings for RTCIceCandidate', () => {
+    expect(normalizeRemoteCandidateString('a=candidate:1 1 UDP 2122252543 192.0.2.1 54400 typ host')).toBe(
+      'candidate:1 1 UDP 2122252543 192.0.2.1 54400 typ host'
+    );
+  });
+});

--- a/package/__tests__/trickle-ice-messages.test.ts
+++ b/package/__tests__/trickle-ice-messages.test.ts
@@ -107,8 +107,8 @@ describe('Trickle ICE SDP utilities', () => {
   });
 
   it('normalizes incoming candidate strings for RTCIceCandidate', () => {
-    expect(normalizeRemoteCandidateString('a=candidate:1 1 UDP 2122252543 192.0.2.1 54400 typ host')).toBe(
-      'candidate:1 1 UDP 2122252543 192.0.2.1 54400 typ host'
-    );
+    expect(
+      normalizeRemoteCandidateString('a=candidate:1 1 UDP 2122252543 192.0.2.1 54400 typ host')
+    ).toBe('candidate:1 1 UDP 2122252543 192.0.2.1 54400 typ host');
   });
 });

--- a/package/lib/call-options.ts
+++ b/package/lib/call-options.ts
@@ -82,6 +82,14 @@ export interface CallOptions {
   peerConnectionOptions?: {
     prefetchIceCandidates?: boolean;
     /**
+     * Enable Trickle ICE for this call.
+     *
+     * When true, the SDK sends the initial SDP immediately and trickles ICE
+     * candidates through telnyx_rtc.candidate / telnyx_rtc.endOfCandidates.
+     * Defaults to false to preserve legacy full-ICE-gathering behavior.
+     */
+    useTrickleIce?: boolean;
+    /**
      * The ICE servers to use for the WebRTC connection.
      * This can include STUN and TURN servers.
      * @example

--- a/package/lib/call.ts
+++ b/package/lib/call.ts
@@ -22,7 +22,7 @@ import {
 import { createAttachMessage } from './messages/attach';
 import { Peer } from './peer';
 import type { TrickleIceCandidate } from './peer';
-import { prepareTrickleSdp, normalizeRemoteCandidateString } from './sdp-utils';
+import { prepareTrickleSdp, normalizeRemoteCandidateString, cleanCandidateString } from './sdp-utils';
 import { WebRTCReporter } from './webrtc-reporter';
 import { CallReportCollector } from './call-report-collector';
 import type { CallReportConfig, CallReportSummary } from './call-report-models';
@@ -751,23 +751,28 @@ export class Call extends EventEmitter<CallEvents> {
     // Store the custom headers we're sending with the invite
     this.inviteCustomHeaders = this.options.customHeaders || null;
 
-    const msg = await this.connection.sendAndWait(
-      createInviteMessage({
-        attach: false,
-        callOptions: this.options,
-        sessionId: this.sessionId,
-        callId: this.callId,
-        sdp: this.getLocalSdpForSignaling(),
-      })
-    );
+    try {
+      const msg = await this.connection.sendAndWait(
+        createInviteMessage({
+          attach: false,
+          callOptions: this.options,
+          sessionId: this.sessionId,
+          callId: this.callId,
+          sdp: this.getLocalSdpForSignaling(),
+        })
+      );
 
-    if (!isInviteACKMessage(msg)) {
-      throw new Error(`[Call] Invalid invite ACK message received: ${JSON.stringify(msg)}`);
-    }
-    this.callId = msg.result.callID;
+      if (!isInviteACKMessage(msg)) {
+        throw new Error(`[Call] Invalid invite ACK message received: ${JSON.stringify(msg)}`);
+      }
+      this.callId = msg.result.callID;
 
-    if (this.isTrickleIceEnabled()) {
-      this.peer.flushPendingLocalCandidates();
+      if (this.isTrickleIceEnabled()) {
+        this.peer.flushPendingLocalCandidates();
+      }
+    } catch (error) {
+      this.peer.clearPendingLocalCandidates();
+      throw error;
     }
   };
 
@@ -802,7 +807,7 @@ export class Call extends EventEmitter<CallEvents> {
       createCandidateMessage({
         sessionId: this.sessionId,
         callId: this.callId,
-        candidate: candidate.candidate,
+        candidate: cleanCandidateString(candidate.candidate),
         sdpMid: candidate.sdpMid,
         sdpMLineIndex: candidate.sdpMLineIndex,
       })

--- a/package/lib/call.ts
+++ b/package/lib/call.ts
@@ -6,7 +6,9 @@ import { Connection } from './connection';
 import type { AnswerEvent, ByeEvent, RingingEvent } from './messages/call';
 import {
   createAnswerMessage,
+  createCandidateMessage,
   createDTMFRequest,
+  createEndOfCandidatesMessage,
   createHangupRequest,
   createInviteMessage,
   createModifyCallRequest,
@@ -19,6 +21,8 @@ import {
 } from './messages/call';
 import { createAttachMessage } from './messages/attach';
 import { Peer } from './peer';
+import type { TrickleIceCandidate } from './peer';
+import { prepareTrickleSdp, normalizeRemoteCandidateString } from './sdp-utils';
 import { WebRTCReporter } from './webrtc-reporter';
 import { CallReportCollector } from './call-report-collector';
 import type { CallReportConfig, CallReportSummary } from './call-report-models';
@@ -177,6 +181,7 @@ export class Call extends EventEmitter<CallEvents> {
     }
 
     call.peer = new Peer(options);
+    call.setupTrickleIceCallbacks();
     call.peer.createPeerConnection();
     call.peer.setRemoteDescription({ type: 'offer', sdp: remoteSDP });
 
@@ -346,22 +351,27 @@ export class Call extends EventEmitter<CallEvents> {
     log.debug('[Call] Setting state to connecting before answering');
     this.setState('connecting');
 
-    await this.peer
-      .attachLocalStream({ audio: true, video: false })
-      .then((peer) => peer.createAnswer())
-      .then((peer) => peer.waitForIceGatheringComplete());
+    await this.peer.attachLocalStream({ audio: true, video: false }).then((peer) => peer.createAnswer());
+
+    if (!this.isTrickleIceEnabled()) {
+      await this.peer.waitForIceGatheringComplete();
+    }
 
     await this.connection.sendAndWait(
       createAnswerMessage({
         callId: this.callId,
         dialogParams: {},
-        sdp: this.peer.localDescription!.sdp,
+        sdp: this.getLocalSdpForSignaling(),
         telnyxLegId: this.telnyxLegId!,
         telnyxSessionId: this.telnyxSessionId!,
         sessionId: this.sessionId,
         customHeaders,
       })
     );
+
+    if (this.isTrickleIceEnabled()) {
+      this.peer.flushPendingLocalCandidates();
+    }
 
     this.setState('active');
   };
@@ -384,18 +394,17 @@ export class Call extends EventEmitter<CallEvents> {
 
     try {
       log.debug('[Call] Attaching local stream and creating answer for reattachment');
-      await this.peer
-        .attachLocalStream({ audio: true, video: false })
-        .then((peer) => {
-          log.debug('[Call] Local stream attached, creating answer');
-          return peer.createAnswer();
-        })
-        .then((peer) => {
-          log.debug('[Call] Answer created, waiting for ICE gathering');
-          return peer.waitForIceGatheringComplete();
-        });
+      await this.peer.attachLocalStream({ audio: true, video: false }).then((peer) => {
+        log.debug('[Call] Local stream attached, creating answer');
+        return peer.createAnswer();
+      });
 
-      log.debug('[Call] ICE gathering complete, preparing answer message');
+      if (!this.isTrickleIceEnabled()) {
+        log.debug('[Call] Answer created, waiting for ICE gathering');
+        await this.peer.waitForIceGatheringComplete();
+      }
+
+      log.debug('[Call] Preparing answer attach message');
 
       if (!this.peer.localDescription?.sdp) {
         log.error('[Call] No local SDP available for answer message');
@@ -405,7 +414,7 @@ export class Call extends EventEmitter<CallEvents> {
       const attachMessage = createAttachMessage({
         callId: this.callId,
         sessionId: this.sessionId,
-        sdp: this.peer.localDescription.sdp,
+        sdp: this.getLocalSdpForSignaling(),
         customHeaders: this.inviteCustomHeaders || [],
         destinationNumber: this.options.destinationNumber || '',
         callerIdName: this.options.callerIdName || '',
@@ -422,6 +431,10 @@ export class Call extends EventEmitter<CallEvents> {
 
       // Send attach message for call reattachment (critical for WebRTC media flow)
       await this.connection.sendAndWait(attachMessage);
+
+      if (this.isTrickleIceEnabled()) {
+        this.peer.flushPendingLocalCandidates();
+      }
 
       log.debug('[Call] Attach message sent successfully, setting call to active');
       this.setState('active');
@@ -728,6 +741,7 @@ export class Call extends EventEmitter<CallEvents> {
   }
   public invite = async () => {
     this.peer = await Peer.createOffer(this.options);
+    this.setupTrickleIceCallbacks();
 
     // Initialize WebRTC reporter if debug mode is enabled
     if (this.debugEnabled) {
@@ -743,7 +757,7 @@ export class Call extends EventEmitter<CallEvents> {
         callOptions: this.options,
         sessionId: this.sessionId,
         callId: this.callId,
-        sdp: this.peer.localDescription!.sdp,
+        sdp: this.getLocalSdpForSignaling(),
       })
     );
 
@@ -751,6 +765,79 @@ export class Call extends EventEmitter<CallEvents> {
       throw new Error(`[Call] Invalid invite ACK message received: ${JSON.stringify(msg)}`);
     }
     this.callId = msg.result.callID;
+
+    if (this.isTrickleIceEnabled()) {
+      this.peer.flushPendingLocalCandidates();
+    }
+  };
+
+  private isTrickleIceEnabled = () => Boolean(this.options.peerConnectionOptions?.useTrickleIce);
+
+  private getLocalSdpForSignaling = () => {
+    const sdp = this.peer?.localDescription?.sdp;
+    if (!sdp) {
+      throw new Error('[Call] Local SDP not available');
+    }
+    return this.isTrickleIceEnabled() ? prepareTrickleSdp(sdp) : sdp;
+  };
+
+  private setupTrickleIceCallbacks = () => {
+    if (!this.peer || !this.isTrickleIceEnabled()) {
+      return;
+    }
+
+    this.peer.onLocalCandidate = (candidate) => {
+      this.sendLocalCandidate(candidate);
+    };
+    this.peer.onLocalEndOfCandidates = () => {
+      this.sendLocalEndOfCandidates();
+    };
+  };
+
+  private sendLocalCandidate = (candidate: TrickleIceCandidate) => {
+    if (!this.isTrickleIceEnabled()) {
+      return;
+    }
+    this.connection.send(
+      createCandidateMessage({
+        sessionId: this.sessionId,
+        callId: this.callId,
+        candidate: candidate.candidate,
+        sdpMid: candidate.sdpMid,
+        sdpMLineIndex: candidate.sdpMLineIndex,
+      })
+    );
+  };
+
+  private sendLocalEndOfCandidates = () => {
+    if (!this.isTrickleIceEnabled()) {
+      return;
+    }
+    this.connection.send(
+      createEndOfCandidatesMessage({
+        sessionId: this.sessionId,
+        callId: this.callId,
+      })
+    );
+  };
+
+  public handleRemoteCandidate = (candidate: TrickleIceCandidate) => {
+    if (!this.peer) {
+      log.warn('[Call] No peer connection available for remote ICE candidate');
+      return;
+    }
+    this.peer.addRemoteCandidate({
+      ...candidate,
+      candidate: normalizeRemoteCandidateString(candidate.candidate),
+    });
+  };
+
+  public handleRemoteEndOfCandidates = () => {
+    if (!this.peer) {
+      log.warn('[Call] No peer connection available for remote end-of-candidates');
+      return;
+    }
+    this.peer.addRemoteEndOfCandidates();
   };
 
   private setState = (state: CallState) => {

--- a/package/lib/client-options.ts
+++ b/package/lib/client-options.ts
@@ -24,6 +24,12 @@ export interface ClientOptions {
    */
   prefetchIceCandidates?: boolean;
   /**
+   * Enable Trickle ICE by default for inbound calls created by this client.
+   * Outbound calls can override this per call with peerConnectionOptions.useTrickleIce.
+   * @default false
+   */
+  useTrickleIce?: boolean;
+  /**
    * The push notification device token, used for receiving push notifications on a specific device.
    * This is typically used for mobile applications to receive incoming call notifications.
    */

--- a/package/lib/client.ts
+++ b/package/lib/client.ts
@@ -14,10 +14,12 @@ import { setSDKVersion } from './env';
 import { KeepAliveHandler } from './keep-alive-handler';
 import { eventBus } from './legacy-event-bus';
 import { LoginHandler } from './login-handler';
-import type { InviteEvent, AnswerEvent } from './messages/call';
+import type { InviteEvent, AnswerEvent, CandidateEvent, EndOfCandidatesEvent } from './messages/call';
 import {
   isInviteEvent,
   isAnswerEvent,
+  isCandidateEvent,
+  isEndOfCandidatesEvent,
 } from './messages/call';
 import { TelnyxRTCMethod } from './messages/methods';
 import { createAttachCallMessage } from './messages/attach';
@@ -879,6 +881,16 @@ export class TelnyxRTC extends EventEmitter<TelnyxRTCEvents> {
       return this.handleCallAnswer(msg);
     }
 
+    if (isCandidateEvent(msg)) {
+      log.debug('[TelnyxRTC] Detected ICE candidate event, processing...');
+      return this.handleCandidateEvent(msg);
+    }
+
+    if (isEndOfCandidatesEvent(msg)) {
+      log.debug('[TelnyxRTC] Detected end-of-candidates event, processing...');
+      return this.handleEndOfCandidatesEvent(msg);
+    }
+
     // Check if this is an invite message that's not being detected
     if (msg && typeof msg === 'object' && (msg as any).method === TelnyxRTCMethod.INVITE) {
       log.warn('[TelnyxRTC] Received invite message but isInviteEvent returned false:', msg);
@@ -948,7 +960,12 @@ export class TelnyxRTC extends EventEmitter<TelnyxRTCEvents> {
         callId: msg.params.callID,
         telnyxLegId: msg.params.telnyx_leg_id,
         telnyxSessionId: msg.params.telnyx_session_id,
-        options: { destinationNumber: msg.params.caller_id_number },
+        options: {
+          destinationNumber: msg.params.caller_id_number,
+          peerConnectionOptions: {
+            useTrickleIce: this.options.useTrickleIce,
+          },
+        },
         inviteCustomHeaders: msg.params.dialogParams?.custom_headers || null,
         debug: this.options.debug,
         callReportConfig: this.getCallReportConfig(),
@@ -1081,6 +1098,9 @@ export class TelnyxRTC extends EventEmitter<TelnyxRTCEvents> {
       telnyxSessionId: msg.params.telnyx_session_id,
       options: {
         destinationNumber: msg.params.caller_id_number,
+        peerConnectionOptions: {
+          useTrickleIce: this.options.useTrickleIce,
+        },
       },
       inviteCustomHeaders: msg.params.dialogParams?.custom_headers || null,
       initialState: 'connecting', // Set initial state to connecting
@@ -1221,6 +1241,50 @@ export class TelnyxRTC extends EventEmitter<TelnyxRTCEvents> {
   
 
     log.debug('[TelnyxRTC] ====== CALL ANSWER HANDLING COMPLETE ======');
+  };
+
+  private getCallIdFromTrickleParams(params: {
+    dialogParams?: { callID?: string; callId?: string };
+    callID?: string;
+    callId?: string;
+  }): string | undefined {
+    return params.dialogParams?.callID ?? params.dialogParams?.callId ?? params.callID ?? params.callId;
+  }
+
+  private handleCandidateEvent = (msg: CandidateEvent) => {
+    const callID = this.getCallIdFromTrickleParams(msg.params);
+    if (!callID) {
+      log.warn('[TelnyxRTC] Candidate event missing call ID');
+      return;
+    }
+
+    const targetCall = this.getCall(callID);
+    if (!targetCall) {
+      log.warn('[TelnyxRTC] No call found for ICE candidate event');
+      return;
+    }
+
+    targetCall.handleRemoteCandidate({
+      candidate: msg.params.candidate,
+      sdpMid: msg.params.sdpMid,
+      sdpMLineIndex: msg.params.sdpMLineIndex,
+    });
+  };
+
+  private handleEndOfCandidatesEvent = (msg: EndOfCandidatesEvent) => {
+    const callID = this.getCallIdFromTrickleParams(msg.params);
+    if (!callID) {
+      log.warn('[TelnyxRTC] End-of-candidates event missing call ID');
+      return;
+    }
+
+    const targetCall = this.getCall(callID);
+    if (!targetCall) {
+      log.warn('[TelnyxRTC] No call found for end-of-candidates event');
+      return;
+    }
+
+    targetCall.handleRemoteEndOfCandidates();
   };
 
   private onNetInfoStateChange = (state: NetInfoState) => {

--- a/package/lib/client.ts
+++ b/package/lib/client.ts
@@ -20,6 +20,7 @@ import {
   isAnswerEvent,
   isCandidateEvent,
   isEndOfCandidatesEvent,
+  getCallIdFromTrickleParams,
 } from './messages/call';
 import { TelnyxRTCMethod } from './messages/methods';
 import { createAttachCallMessage } from './messages/attach';
@@ -40,6 +41,10 @@ type TelnyxRTCEvents = {
   'telnyx.call.stateChanged': (call: Call, state: string) => void;
   'telnyx.call.removed': (callId: string) => void;
 };
+
+type PendingTrickleEvent =
+  | { type: 'candidate'; msg: CandidateEvent; receivedAt: number }
+  | { type: 'endOfCandidates'; msg: EndOfCandidatesEvent; receivedAt: number };
 
 export class TelnyxRTC extends EventEmitter<TelnyxRTCEvents> {
   public options: ClientOptions;
@@ -95,6 +100,8 @@ export class TelnyxRTC extends EventEmitter<TelnyxRTCEvents> {
 
   // Early media/ringback support
   private pendingMediaEvents: Map<string, MediaEvent> = new Map();
+  private pendingTrickleEvents: Map<string, PendingTrickleEvent[]> = new Map();
+  private static readonly PENDING_TRICKLE_TTL_MS = 30000;
 
   // Pending call actions (matching iOS SDK behavior)
   private pendingAnswerAction: boolean = false;
@@ -281,7 +288,79 @@ export class TelnyxRTC extends EventEmitter<TelnyxRTCEvents> {
     this.callStateListeners.set(callId, stateListener);
     call.on('telnyx.call.state', stateListener);
 
+    this.drainPendingTrickleEvents(callId);
+
     log.debug(`[TelnyxRTC] Total calls tracked: ${this.calls.size}`);
+  }
+
+  private updateTrackedCallId(previousCallId: string, call: Call): void {
+    if (previousCallId === call.callId) {
+      this.drainPendingTrickleEvents(call.callId);
+      return;
+    }
+
+    const previousListener = this.callStateListeners.get(previousCallId);
+    if (previousListener) {
+      call.off('telnyx.call.state', previousListener);
+      this.callStateListeners.delete(previousCallId);
+    }
+    this.calls.delete(previousCallId);
+    this.addCall(call);
+  }
+
+  private prunePendingTrickleEvents(): void {
+    const expiresBefore = Date.now() - TelnyxRTC.PENDING_TRICKLE_TTL_MS;
+
+    for (const [callId, events] of this.pendingTrickleEvents.entries()) {
+      const freshEvents = events.filter((event) => event.receivedAt >= expiresBefore);
+      if (freshEvents.length > 0) {
+        this.pendingTrickleEvents.set(callId, freshEvents);
+      } else {
+        this.pendingTrickleEvents.delete(callId);
+      }
+    }
+  }
+
+  private queuePendingTrickleEvent(
+    callId: string,
+    event: Omit<PendingTrickleEvent, 'receivedAt'>
+  ): void {
+    this.prunePendingTrickleEvents();
+
+    const pending = this.pendingTrickleEvents.get(callId) || [];
+    pending.push({ ...event, receivedAt: Date.now() });
+    this.pendingTrickleEvents.set(callId, pending);
+  }
+
+  private drainPendingTrickleEvents(callId: string): void {
+    const targetCall = this.getCall(callId);
+    if (!targetCall) {
+      return;
+    }
+
+    const pending = this.pendingTrickleEvents.get(callId);
+    if (!pending?.length) {
+      return;
+    }
+
+    this.pendingTrickleEvents.delete(callId);
+
+    const expiresBefore = Date.now() - TelnyxRTC.PENDING_TRICKLE_TTL_MS;
+    for (const event of pending) {
+      if (event.receivedAt < expiresBefore) {
+        continue;
+      }
+
+      if (event.type === 'candidate') {
+        targetCall.handleRemoteCandidate({
+          candidate: event.msg.params.candidate,
+          sdpMid: event.msg.params.sdpMid,
+          sdpMLineIndex: event.msg.params.sdpMLineIndex,
+        });
+      } else {
+        targetCall.handleRemoteEndOfCandidates();
+      }
+    }
   }
 
   /**
@@ -355,7 +434,9 @@ export class TelnyxRTC extends EventEmitter<TelnyxRTCEvents> {
     // Add to calls tracking (matches iOS SDK behavior)
     this.addCall(newCall);
 
+    const provisionalCallId = newCall.callId;
     await newCall.invite();
+    this.updateTrackedCallId(provisionalCallId, newCall);
     return newCall;
   };
 
@@ -1238,21 +1319,11 @@ export class TelnyxRTC extends EventEmitter<TelnyxRTCEvents> {
       log.warn('[TelnyxRTC] No call found for callID in answer event');
     }
 
-  
-
     log.debug('[TelnyxRTC] ====== CALL ANSWER HANDLING COMPLETE ======');
   };
 
-  private getCallIdFromTrickleParams(params: {
-    dialogParams?: { callID?: string; callId?: string };
-    callID?: string;
-    callId?: string;
-  }): string | undefined {
-    return params.dialogParams?.callID ?? params.dialogParams?.callId ?? params.callID ?? params.callId;
-  }
-
   private handleCandidateEvent = (msg: CandidateEvent) => {
-    const callID = this.getCallIdFromTrickleParams(msg.params);
+    const callID = getCallIdFromTrickleParams(msg.params);
     if (!callID) {
       log.warn('[TelnyxRTC] Candidate event missing call ID');
       return;
@@ -1260,7 +1331,8 @@ export class TelnyxRTC extends EventEmitter<TelnyxRTCEvents> {
 
     const targetCall = this.getCall(callID);
     if (!targetCall) {
-      log.warn('[TelnyxRTC] No call found for ICE candidate event');
+      log.debug('[TelnyxRTC] Queueing ICE candidate event until call is tracked');
+      this.queuePendingTrickleEvent(callID, { type: 'candidate', msg });
       return;
     }
 
@@ -1272,7 +1344,7 @@ export class TelnyxRTC extends EventEmitter<TelnyxRTCEvents> {
   };
 
   private handleEndOfCandidatesEvent = (msg: EndOfCandidatesEvent) => {
-    const callID = this.getCallIdFromTrickleParams(msg.params);
+    const callID = getCallIdFromTrickleParams(msg.params);
     if (!callID) {
       log.warn('[TelnyxRTC] End-of-candidates event missing call ID');
       return;
@@ -1280,7 +1352,8 @@ export class TelnyxRTC extends EventEmitter<TelnyxRTCEvents> {
 
     const targetCall = this.getCall(callID);
     if (!targetCall) {
-      log.warn('[TelnyxRTC] No call found for end-of-candidates event');
+      log.debug('[TelnyxRTC] Queueing end-of-candidates event until call is tracked');
+      this.queuePendingTrickleEvent(callID, { type: 'endOfCandidates', msg });
       return;
     }
 

--- a/package/lib/messages/call.ts
+++ b/package/lib/messages/call.ts
@@ -43,6 +43,8 @@ export function createInviteMessage({
         audio: callOptions.audio,
         prefetchIceCandidates: callOptions.peerConnectionOptions?.prefetchIceCandidates,
         useTrickleIce: callOptions.peerConnectionOptions?.useTrickleIce,
+        // Keep both keys for signaling compatibility. Android sends top-level
+        // `trickle`; existing RN consumers read `useTrickleIce` from dialogParams.
         trickle: callOptions.peerConnectionOptions?.useTrickleIce,
         destination_number: callOptions.destinationNumber,
         remote_caller_id_name: callOptions.remoteCallerIdName,
@@ -133,14 +135,33 @@ export type CandidateEvent = {
   voice_sdk_id?: string;
 };
 
+export function getCallIdFromTrickleParams(params: {
+  dialogParams?: { callID?: string; callId?: string };
+  callID?: string;
+  callId?: string;
+}): string | undefined {
+  return (
+    params.dialogParams?.callID ??
+    params.dialogParams?.callId ??
+    params.callID ??
+    params.callId
+  );
+}
+
 export function isCandidateEvent(msg: unknown): msg is CandidateEvent {
   if (!msg) {
     return false;
   }
   const temp = msg as Partial<CandidateEvent>;
   const params = temp.params;
-  const callId = params?.dialogParams?.callID ?? params?.dialogParams?.callId ?? params?.callID ?? params?.callId;
-  return temp.method === TelnyxRTCMethod.CANDIDATE && Boolean(params?.candidate) && Boolean(callId);
+  const callId = params ? getCallIdFromTrickleParams(params) : undefined;
+  return (
+    temp.method === TelnyxRTCMethod.CANDIDATE &&
+    typeof params?.candidate === 'string' &&
+    params.sdpMid != null &&
+    typeof params.sdpMLineIndex === 'number' &&
+    Boolean(callId)
+  );
 }
 
 type EndOfCandidatesMessage = {
@@ -199,7 +220,7 @@ export function isEndOfCandidatesEvent(msg: unknown): msg is EndOfCandidatesEven
   }
   const temp = msg as Partial<EndOfCandidatesEvent>;
   const params = temp.params;
-  const callId = params?.dialogParams?.callID ?? params?.dialogParams?.callId ?? params?.callID ?? params?.callId;
+  const callId = params ? getCallIdFromTrickleParams(params) : undefined;
   return temp.method === TelnyxRTCMethod.END_OF_CANDIDATES && Boolean(callId);
 }
 

--- a/package/lib/messages/call.ts
+++ b/package/lib/messages/call.ts
@@ -42,6 +42,8 @@ export function createInviteMessage({
         callID: callId,
         audio: callOptions.audio,
         prefetchIceCandidates: callOptions.peerConnectionOptions?.prefetchIceCandidates,
+        useTrickleIce: callOptions.peerConnectionOptions?.useTrickleIce,
+        trickle: callOptions.peerConnectionOptions?.useTrickleIce,
         destination_number: callOptions.destinationNumber,
         remote_caller_id_name: callOptions.remoteCallerIdName,
         remote_caller_id_number: callOptions.remoteCallerIdNumber,
@@ -64,6 +66,141 @@ export function isInviteACKMessage(msg: unknown): msg is InviteACKMessage {
     Boolean(temp.result?.sessid) &&
     temp.result?.message === 'CALL CREATED'
   );
+}
+
+type CandidateMessage = {
+  jsonrpc: '2.0';
+  id: string;
+  method: 'telnyx_rtc.candidate';
+  params: {
+    sessid: string;
+    candidate: string;
+    sdpMid?: string | null;
+    sdpMLineIndex?: number | null;
+    dialogParams: {
+      callID: string;
+    };
+  };
+};
+
+type CreateCandidateMessageParams = {
+  sessionId: string;
+  callId: string;
+  candidate: string;
+  sdpMid?: string | null;
+  sdpMLineIndex?: number | null;
+};
+
+export function createCandidateMessage({
+  sessionId,
+  callId,
+  candidate,
+  sdpMid,
+  sdpMLineIndex,
+}: CreateCandidateMessageParams): CandidateMessage {
+  return {
+    id: uuid(),
+    jsonrpc: '2.0',
+    method: TelnyxRTCMethod.CANDIDATE,
+    params: {
+      sessid: sessionId,
+      candidate,
+      sdpMid,
+      sdpMLineIndex,
+      dialogParams: {
+        callID: callId,
+      },
+    },
+  };
+}
+
+export type CandidateEvent = {
+  id?: string | number;
+  jsonrpc?: '2.0';
+  method: 'telnyx_rtc.candidate';
+  params: {
+    sessid?: string;
+    candidate: string;
+    sdpMid?: string | null;
+    sdpMLineIndex?: number | null;
+    dialogParams?: {
+      callID?: string;
+      callId?: string;
+    };
+    callID?: string;
+    callId?: string;
+  };
+  voice_sdk_id?: string;
+};
+
+export function isCandidateEvent(msg: unknown): msg is CandidateEvent {
+  if (!msg) {
+    return false;
+  }
+  const temp = msg as Partial<CandidateEvent>;
+  const params = temp.params;
+  const callId = params?.dialogParams?.callID ?? params?.dialogParams?.callId ?? params?.callID ?? params?.callId;
+  return temp.method === TelnyxRTCMethod.CANDIDATE && Boolean(params?.candidate) && Boolean(callId);
+}
+
+type EndOfCandidatesMessage = {
+  jsonrpc: '2.0';
+  id: string;
+  method: 'telnyx_rtc.endOfCandidates';
+  params: {
+    sessid: string;
+    dialogParams: {
+      callID: string;
+    };
+  };
+};
+
+type CreateEndOfCandidatesMessageParams = {
+  sessionId: string;
+  callId: string;
+};
+
+export function createEndOfCandidatesMessage({
+  sessionId,
+  callId,
+}: CreateEndOfCandidatesMessageParams): EndOfCandidatesMessage {
+  return {
+    id: uuid(),
+    jsonrpc: '2.0',
+    method: TelnyxRTCMethod.END_OF_CANDIDATES,
+    params: {
+      sessid: sessionId,
+      dialogParams: {
+        callID: callId,
+      },
+    },
+  };
+}
+
+export type EndOfCandidatesEvent = {
+  id?: string | number;
+  jsonrpc?: '2.0';
+  method: 'telnyx_rtc.endOfCandidates';
+  params: {
+    sessid?: string;
+    dialogParams?: {
+      callID?: string;
+      callId?: string;
+    };
+    callID?: string;
+    callId?: string;
+  };
+  voice_sdk_id?: string;
+};
+
+export function isEndOfCandidatesEvent(msg: unknown): msg is EndOfCandidatesEvent {
+  if (!msg) {
+    return false;
+  }
+  const temp = msg as Partial<EndOfCandidatesEvent>;
+  const params = temp.params;
+  const callId = params?.dialogParams?.callID ?? params?.dialogParams?.callId ?? params?.callID ?? params?.callId;
+  return temp.method === TelnyxRTCMethod.END_OF_CANDIDATES && Boolean(callId);
 }
 
 export type RingingEvent = {

--- a/package/lib/messages/methods.ts
+++ b/package/lib/messages/methods.ts
@@ -15,6 +15,8 @@ export const TelnyxRTCMethod = {
   PING: 'telnyx_rtc.ping',
   ATTACH: 'telnyx_rtc.attach',
   ATTACH_CALLS: 'telnyx_rtc.attachCalls',
+  CANDIDATE: 'telnyx_rtc.candidate',
+  END_OF_CANDIDATES: 'telnyx_rtc.endOfCandidates',
   CLIENT_READY: 'telnyx_rtc.clientReady',
   GATEWAY_STATE: 'telnyx_rtc.gatewayState',
   DISABLE_PUSH_NOTIFICATION: 'telnyx_rtc.disable_push_notification',

--- a/package/lib/peer.ts
+++ b/package/lib/peer.ts
@@ -231,6 +231,12 @@ export class Peer {
     return this;
   };
 
+  public clearPendingLocalCandidates = () => {
+    this.pendingLocalCandidates = [];
+    this.pendingLocalEndOfCandidates = false;
+    return this;
+  };
+
   public addRemoteCandidate = async (candidate: TrickleIceCandidate) => {
     if (!this.instance) {
       throw new Error('[Peer] Peer connection not created');
@@ -240,6 +246,8 @@ export class Peer {
       this.pendingRemoteCandidates.push(candidate);
       return this;
     }
+    // react-native-webrtc accepts RTCIceCandidateInit here, but its TS surface
+    // can lag the native implementation.
     await (this.instance as any).addIceCandidate(candidate).catch((error: unknown) => {
       log.error('[Peer] Error adding remote ICE candidate', error);
     });
@@ -254,6 +262,8 @@ export class Peer {
       return this;
     }
     if (typeof (this.instance as any).addIceCandidate === 'function') {
+      // Some RN WebRTC versions ignore or reject null end-of-candidates.
+      // Treat that as non-fatal because candidates have already been delivered.
       await (this.instance as any).addIceCandidate(null).catch((error: unknown) => {
         log.debug('[Peer] Remote end-of-candidates ignored by peer connection', error);
       });

--- a/package/lib/peer.ts
+++ b/package/lib/peer.ts
@@ -19,13 +19,22 @@ type MediaConstraints = {
   video?: boolean | MediaTrackConstraints;
 };
 
+export type TrickleIceCandidate = {
+  candidate: string;
+  sdpMid?: string | null;
+  sdpMLineIndex?: number | null;
+};
+
 export class Peer {
   public static createOffer = async (callOptions: CallOptions) => {
     const peer = await new Peer(callOptions)
       .createPeerConnection()
       .attachLocalStream({ audio: true, video: false })
-      .then((peer) => peer.createOffer())
-      .then((peer) => peer.waitForIceGatheringComplete());
+      .then((peer) => peer.createOffer());
+
+    if (!peer.useTrickleIce) {
+      await peer.waitForIceGatheringComplete();
+    }
 
     return peer;
   };
@@ -35,6 +44,16 @@ export class Peer {
   private options: CallOptions;
   private iceGatheringComplete: DeferredPromise<boolean> | null;
   private reporter: WebRTCReporter | null = null;
+  private pendingRemoteCandidates: TrickleIceCandidate[] = [];
+  private pendingLocalCandidates: TrickleIceCandidate[] = [];
+  private pendingLocalEndOfCandidates = false;
+  private localCandidateDispatchEnabled = false;
+
+  /** Callback for local Trickle ICE candidates. Call owns signaling transport. */
+  public onLocalCandidate: ((candidate: TrickleIceCandidate) => void) | null = null;
+
+  /** Callback for local ICE completion when Trickle ICE is enabled. */
+  public onLocalEndOfCandidates: (() => void) | null = null;
 
   /** Callback for logging peer events to call report collector */
   public onPeerEventLog: ((event: string, context: Record<string, unknown>) => void) | null = null;
@@ -83,6 +102,10 @@ export class Peer {
       track.stop();
     });
     this.options.remoteStream = undefined;
+    this.pendingRemoteCandidates = [];
+    this.pendingLocalCandidates = [];
+    this.pendingLocalEndOfCandidates = false;
+    this.localCandidateDispatchEnabled = false;
     return this;
   };
 
@@ -94,6 +117,7 @@ export class Peer {
     await this.instance.setRemoteDescription(new RTCSessionDescription(session)).catch((error) => {
       log.error('[Peer] Error setting remote description', error);
     });
+    await this.flushPendingRemoteCandidates();
     return this;
   };
   public get remoteDescription() {
@@ -190,6 +214,76 @@ export class Peer {
     return this;
   };
 
+  public get useTrickleIce(): boolean {
+    return Boolean(this.options.peerConnectionOptions?.useTrickleIce);
+  }
+
+  public flushPendingLocalCandidates = () => {
+    this.localCandidateDispatchEnabled = true;
+    while (this.pendingLocalCandidates.length > 0) {
+      const candidate = this.pendingLocalCandidates.shift()!;
+      this.onLocalCandidate?.(candidate);
+    }
+    if (this.pendingLocalEndOfCandidates) {
+      this.pendingLocalEndOfCandidates = false;
+      this.onLocalEndOfCandidates?.();
+    }
+    return this;
+  };
+
+  public addRemoteCandidate = async (candidate: TrickleIceCandidate) => {
+    if (!this.instance) {
+      throw new Error('[Peer] Peer connection not created');
+    }
+    if (!this.instance.remoteDescription) {
+      log.debug('[Peer] Queueing remote ICE candidate until remote description is set');
+      this.pendingRemoteCandidates.push(candidate);
+      return this;
+    }
+    await (this.instance as any).addIceCandidate(candidate).catch((error: unknown) => {
+      log.error('[Peer] Error adding remote ICE candidate', error);
+    });
+    return this;
+  };
+
+  public addRemoteEndOfCandidates = async () => {
+    if (!this.instance) {
+      throw new Error('[Peer] Peer connection not created');
+    }
+    if (!this.instance.remoteDescription) {
+      return this;
+    }
+    if (typeof (this.instance as any).addIceCandidate === 'function') {
+      await (this.instance as any).addIceCandidate(null).catch((error: unknown) => {
+        log.debug('[Peer] Remote end-of-candidates ignored by peer connection', error);
+      });
+    }
+    return this;
+  };
+
+  private flushPendingRemoteCandidates = async () => {
+    while (this.pendingRemoteCandidates.length > 0) {
+      const candidate = this.pendingRemoteCandidates.shift()!;
+      await this.addRemoteCandidate(candidate);
+    }
+  };
+
+  private emitOrQueueLocalCandidate(candidate: TrickleIceCandidate) {
+    if (this.localCandidateDispatchEnabled) {
+      this.onLocalCandidate?.(candidate);
+      return;
+    }
+    this.pendingLocalCandidates.push(candidate);
+  }
+
+  private emitOrQueueLocalEndOfCandidates() {
+    if (this.localCandidateDispatchEnabled) {
+      this.onLocalEndOfCandidates?.();
+      return;
+    }
+    this.pendingLocalEndOfCandidates = true;
+  }
+
   public setMediaStreamState = (stream: MediaStream, enabled: boolean) => {
     log.debug('[Peer] Setting media stream state', { enabled, stream });
     if (!stream) {
@@ -229,6 +323,21 @@ export class Peer {
     // Report to WebRTCReporter if available
     if (this.reporter && ev.candidate) {
       this.reporter.onIceCandidate(ev.candidate as unknown as RTCIceCandidate);
+    }
+
+    if (this.useTrickleIce) {
+      if (ev.candidate) {
+        const candidate = ev.candidate as unknown as TrickleIceCandidate;
+        this.emitOrQueueLocalCandidate({
+          candidate: candidate.candidate,
+          sdpMid: candidate.sdpMid,
+          sdpMLineIndex: candidate.sdpMLineIndex,
+        });
+      } else {
+        this.emitOrQueueLocalEndOfCandidates();
+        this.iceGatheringComplete?.resolve(true);
+      }
+      return;
     }
 
     this.iceGatheringComplete?.resolve(true);

--- a/package/lib/sdp-utils.ts
+++ b/package/lib/sdp-utils.ts
@@ -1,0 +1,55 @@
+const SDP_LINE_SEPARATOR = /\r\n|\n|\r/;
+
+function joinSdpLines(lines: string[], originalSdp: string): string {
+  const separator = originalSdp.includes('\r\n') ? '\r\n' : '\n';
+  const hasTrailingNewline = /(?:\r\n|\n|\r)$/.test(originalSdp);
+  const joined = lines.join(separator);
+  return hasTrailingNewline ? `${joined}${separator}` : joined;
+}
+
+/**
+ * Advertise Trickle ICE support in SDP.
+ *
+ * Native Telnyx SDKs add `a=ice-options:trickle` before sending the initial
+ * offer/answer when Trickle ICE is enabled. This helper is idempotent so it can
+ * safely be applied from multiple call paths.
+ */
+export function addTrickleIceCapability(sdp: string): string {
+  if (!sdp || /(^|\r?\n)a=ice-options:.*\btrickle\b/.test(sdp)) {
+    return sdp;
+  }
+
+  const lines = sdp.split(SDP_LINE_SEPARATOR);
+  const firstMediaLineIndex = lines.findIndex((line) => line.startsWith('m='));
+  const insertAt = firstMediaLineIndex >= 0 ? firstMediaLineIndex : lines.length;
+  lines.splice(insertAt, 0, 'a=ice-options:trickle');
+  return joinSdpLines(lines, sdp);
+}
+
+/**
+ * Remove already gathered ICE candidates from the initial SDP when Trickle ICE
+ * is enabled. Candidates are sent separately over `telnyx_rtc.candidate`, so
+ * keeping them in SDP can duplicate candidate delivery.
+ */
+export function removeCandidateLines(sdp: string): string {
+  if (!sdp) {
+    return sdp;
+  }
+
+  const lines = sdp
+    .split(SDP_LINE_SEPARATOR)
+    .filter((line) => !line.startsWith('a=candidate:') && line !== 'a=end-of-candidates');
+
+  return joinSdpLines(lines, sdp);
+}
+
+/**
+ * RTCIceCandidateInit expects `candidate:` without the SDP `a=` line prefix.
+ */
+export function normalizeRemoteCandidateString(candidate: string): string {
+  return candidate.replace(/^a=/, '');
+}
+
+export function prepareTrickleSdp(sdp: string): string {
+  return addTrickleIceCapability(removeCandidateLines(sdp));
+}

--- a/package/lib/sdp-utils.ts
+++ b/package/lib/sdp-utils.ts
@@ -10,18 +10,27 @@ function joinSdpLines(lines: string[], originalSdp: string): string {
 /**
  * Advertise Trickle ICE support in SDP.
  *
- * Native Telnyx SDKs add `a=ice-options:trickle` before sending the initial
- * offer/answer when Trickle ICE is enabled. This helper is idempotent so it can
- * safely be applied from multiple call paths.
+ * Native Telnyx SDKs add `a=ice-options:trickle` at the session level after
+ * the origin line. If WebRTC generated extra options, normalize the line to
+ * only `trickle` so the signaling payload matches Android.
  */
 export function addTrickleIceCapability(sdp: string): string {
-  if (!sdp || /(^|\r?\n)a=ice-options:.*\btrickle\b/.test(sdp)) {
+  if (!sdp) {
     return sdp;
   }
 
   const lines = sdp.split(SDP_LINE_SEPARATOR);
-  const firstMediaLineIndex = lines.findIndex((line) => line.startsWith('m='));
-  const insertAt = firstMediaLineIndex >= 0 ? firstMediaLineIndex : lines.length;
+  const existingIndex = lines.findIndex((line) => line.startsWith('a=ice-options:'));
+  if (existingIndex >= 0) {
+    if (lines[existingIndex] === 'a=ice-options:trickle') {
+      return sdp;
+    }
+    lines[existingIndex] = 'a=ice-options:trickle';
+    return joinSdpLines(lines, sdp);
+  }
+
+  const originIndex = lines.findIndex((line) => line.startsWith('o='));
+  const insertAt = originIndex >= 0 ? originIndex + 1 : lines.length;
   lines.splice(insertAt, 0, 'a=ice-options:trickle');
   return joinSdpLines(lines, sdp);
 }
@@ -48,6 +57,29 @@ export function removeCandidateLines(sdp: string): string {
  */
 export function normalizeRemoteCandidateString(candidate: string): string {
   return candidate.replace(/^a=/, '');
+}
+
+/**
+ * Match Android's candidate cleaning before signaling: keep the RFC candidate
+ * fields and drop WebRTC-specific extensions like generation, ufrag, network-id
+ * and network-cost.
+ */
+export function cleanCandidateString(candidate: string): string {
+  const normalized = normalizeRemoteCandidateString(candidate).trim();
+  const parts = normalized.split(/\s+/);
+  if (!parts[0]?.startsWith('candidate:') || parts.length < 8) {
+    return normalized;
+  }
+
+  const cleaned = parts.slice(0, 8);
+  for (let i = 8; i < parts.length; i++) {
+    const part = parts[i];
+    if ((part === 'raddr' || part === 'rport') && i + 1 < parts.length) {
+      cleaned.push(part, parts[i + 1]);
+      i++;
+    }
+  }
+  return cleaned.join(' ');
 }
 
 export function prepareTrickleSdp(sdp: string): string {


### PR DESCRIPTION
## Summary
- Adds optional Trickle ICE support behind `useTrickleIce`
- Sends `telnyx_rtc.candidate` and `telnyx_rtc.endOfCandidates` messages
- Handles inbound candidate/end-of-candidates routing and candidate queuing
- Preserves legacy full ICE gathering behavior by default

## Test Plan
- [x] `cd package && npm test -- --runTestsByPath __tests__/trickle-ice-messages.test.ts __tests__/trickle-ice-call-flow.test.ts --watchAll=false`