### PR TITLE
fix: handle peer close ICE rejection

### DIFF
--- a/package/lib/peer.ts
+++ b/package/lib/peer.ts
@@ -74,6 +74,8 @@ export class Peer {
       this.instance = null;
     }
     if (this.iceGatheringComplete) {
+      // Inbound pre-accept flows may never await ICE completion. Attach a handler
+      // before rejecting so close() is marked handled while awaited callers still reject.
       this.iceGatheringComplete.promise.catch(() => {});
       this.iceGatheringComplete.reject(new Error('Peer connection closed'));
       this.iceGatheringComplete = null;

--- a/package/lib/peer.ts
+++ b/package/lib/peer.ts
@@ -73,8 +73,11 @@ export class Peer {
       this.instance.close();
       this.instance = null;
     }
-    this.iceGatheringComplete?.reject(new Error('Peer connection closed'));
-    this.iceGatheringComplete = null;
+    if (this.iceGatheringComplete) {
+      this.iceGatheringComplete.promise.catch(() => {});
+      this.iceGatheringComplete.reject(new Error('Peer connection closed'));
+      this.iceGatheringComplete = null;
+    }
     this.options.localStream?.getTracks().forEach((track) => {
       track.stop();
     });


### PR DESCRIPTION
## Summary
- mark the ICE-gathering deferred promise rejection as handled before closing a peer
- preserve the existing rejection for callers awaiting `waitForIceGatheringComplete()`

Fixes #67.

## Validation
- `node /tmp/verify-peer-close.js` — passed; verifies no `unhandledRejection` is emitted for an unawaited close and awaited callers still reject with `Peer connection closed`
- `npm test -- --runInBand --testPathPatterns="integration-custom-headers|media-events-simple"` — fails on existing `integration-custom-headers` User-Agent expectation (`ReactNative-0.4.5` does not match `/react-native-/`); unrelated `media-events-simple` passed
- `npx tsc --noEmit` — fails with existing package `tsconfig.json` issue: no inputs found because it includes `src/**/*` while excluding `lib`
