### PR TITLE
Add missed call notification support

### DIFF
--- a/react-voice-commons-sdk/android/src/main/java/com/telnyx/react_voice_commons/TelnyxFirebaseMessagingService.kt
+++ b/react-voice-commons-sdk/android/src/main/java/com/telnyx/react_voice_commons/TelnyxFirebaseMessagingService.kt
@@ -1,5 +1,6 @@
 package com.telnyx.react_voice_commons
 
+import android.content.Intent
 import android.util.Log
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
@@ -86,7 +87,20 @@ open class TelnyxFirebaseMessagingService : FirebaseMessagingService() {
             
             // Show missed call notification (this will hide any existing incoming call notification)
             val notificationHelper = TelnyxNotificationHelper(this)
-            notificationHelper.showMissedCallNotification(callerName, callerNumber, callId)
+            notificationHelper.hideIncomingCallNotification()
+            notificationHelper.hideOngoingCallNotification()
+
+            try {
+                stopService(Intent(this, CallForegroundService::class.java))
+            } catch (e: Exception) {
+                Log.e(tag, "Failed to stop CallForegroundService for missed call", e)
+            }
+
+            if (VoicePnManager.getMissedCallNotificationsEnabled(this)) {
+                notificationHelper.showMissedCallNotification(callerName, callerNumber, callId)
+            } else {
+                Log.d(tag, "Missed call notification display disabled")
+            }
             
             Log.d(tag, "Telnyx missed call notification processed successfully")
         } catch (e: Exception) {

--- a/react-voice-commons-sdk/android/src/main/java/com/telnyx/react_voice_commons/VoicePnBridgeModule.kt
+++ b/react-voice-commons-sdk/android/src/main/java/com/telnyx/react_voice_commons/VoicePnBridgeModule.kt
@@ -222,6 +222,30 @@ class VoicePnBridgeModule(reactContext: ReactApplicationContext) : ReactContextB
             promise.reject("HIDE_INCOMING_NOTIFICATION_ERROR", e.message, e)
         }
     }
+
+    @ReactMethod
+    fun setMissedCallNotificationsEnabled(enabled: Boolean, promise: Promise) {
+        try {
+            val result = VoicePnManager.setMissedCallNotificationsEnabled(
+                reactApplicationContext,
+                enabled
+            )
+            promise.resolve(result)
+        } catch (e: Exception) {
+            Log.e(TAG, "Error setting missed call notifications", e)
+            promise.reject("SET_MISSED_CALL_NOTIFICATIONS_ERROR", e.message, e)
+        }
+    }
+
+    @ReactMethod
+    fun getMissedCallNotificationsEnabled(promise: Promise) {
+        try {
+            promise.resolve(VoicePnManager.getMissedCallNotificationsEnabled(reactApplicationContext))
+        } catch (e: Exception) {
+            Log.e(TAG, "Error getting missed call notifications", e)
+            promise.reject("GET_MISSED_CALL_NOTIFICATIONS_ERROR", e.message, e)
+        }
+    }
     
     /**
      * Emit call action event to React Native (for immediate notification)

--- a/react-voice-commons-sdk/android/src/main/java/com/telnyx/react_voice_commons/VoicePnManager.kt
+++ b/react-voice-commons-sdk/android/src/main/java/com/telnyx/react_voice_commons/VoicePnManager.kt
@@ -8,6 +8,7 @@ object VoicePnManager {
     
     private const val TAG = "VoicePnManager"
     private const val PREFS_NAME = "telnyx_voice_prefs"
+    private const val MISSED_CALL_NOTIFICATIONS_ENABLED = "telnyx_enable_missed_call_notifications"
     
     private fun getSharedPreferences(context: Context): SharedPreferences {
         return context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
@@ -76,6 +77,21 @@ object VoicePnManager {
         editor.remove("pending_voip_action")
         editor.apply()
         return true
+    }
+
+    fun setMissedCallNotificationsEnabled(context: Context, enabled: Boolean): Boolean {
+        Log.d(TAG, "setMissedCallNotificationsEnabled called with: $enabled")
+        getSharedPreferences(context)
+            .edit()
+            .putBoolean(MISSED_CALL_NOTIFICATIONS_ENABLED, enabled)
+            .apply()
+        return true
+    }
+
+    fun getMissedCallNotificationsEnabled(context: Context): Boolean {
+        Log.d(TAG, "getMissedCallNotificationsEnabled called")
+        return getSharedPreferences(context)
+            .getBoolean(MISSED_CALL_NOTIFICATIONS_ENABLED, true)
     }
 
     // PnModule functions

--- a/react-voice-commons-sdk/ios/CallKitBridge.swift
+++ b/react-voice-commons-sdk/ios/CallKitBridge.swift
@@ -6,6 +6,7 @@ import React
     import AVFoundation
     import UIKit
     import PushKit
+    import UserNotifications
     import WebRTC
 
     @objc(CallKitBridge)
@@ -291,6 +292,120 @@ import React
         }
     }
 
+    private enum TelnyxMissedCallPush {
+        static let notificationsEnabledKey = "telnyx_enable_missed_call_notifications"
+
+        static func isMissedCallPayload(_ payload: [AnyHashable: Any]) -> Bool {
+            return containsMissedCallMarker(payload)
+        }
+
+        static func callId(from payload: [AnyHashable: Any]) -> String? {
+            return stringValue(for: ["call_id", "callId"], in: payload)
+        }
+
+        static func callerName(from payload: [AnyHashable: Any]) -> String {
+            return stringValue(for: ["caller_name", "caller", "from"], in: payload)
+                ?? callerNumber(from: payload)
+        }
+
+        static func callerNumber(from payload: [AnyHashable: Any]) -> String {
+            return stringValue(for: ["caller_number", "caller", "from"], in: payload)
+                ?? "Unknown Caller"
+        }
+
+        static func missedCallNotificationsEnabled() -> Bool {
+            guard UserDefaults.standard.object(forKey: notificationsEnabledKey) != nil else {
+                return true
+            }
+            return UserDefaults.standard.bool(forKey: notificationsEnabledKey)
+        }
+
+        private static func stringValue(for keys: [String], in payload: [AnyHashable: Any]) -> String? {
+            if let metadata = payload["metadata"] as? [AnyHashable: Any],
+                let value = firstStringValue(for: keys, in: metadata)
+            {
+                return value
+            }
+
+            if let metadata = payload["metadata"] as? [String: Any],
+                let value = firstStringValue(for: keys, in: metadata)
+            {
+                return value
+            }
+
+            return firstStringValue(for: keys, in: payload)
+        }
+
+        private static func firstStringValue(for keys: [String], in dictionary: [AnyHashable: Any])
+            -> String?
+        {
+            for key in keys {
+                if let value = dictionary[key] as? String, !value.isEmpty {
+                    return value
+                }
+            }
+            return nil
+        }
+
+        private static func firstStringValue(for keys: [String], in dictionary: [String: Any])
+            -> String?
+        {
+            for key in keys {
+                if let value = dictionary[key] as? String, !value.isEmpty {
+                    return value
+                }
+            }
+            return nil
+        }
+
+        private static func containsMissedCallMarker(_ value: Any, key: String? = nil) -> Bool {
+            if let key = key?.lowercased(), key.contains("missed") {
+                if let boolValue = value as? Bool {
+                    return boolValue
+                }
+
+                if let stringValue = value as? String {
+                    let normalized = normalizedMissedCallValue(stringValue)
+                    return !["false", "0", "no", "none"].contains(normalized)
+                }
+            }
+
+            if let stringValue = value as? String {
+                let normalized = normalizedMissedCallValue(stringValue)
+                if normalized.contains("missed call") || normalized == "missed" {
+                    return true
+                }
+            }
+
+            if let dictionary = value as? [AnyHashable: Any] {
+                return dictionary.contains { rawKey, nestedValue in
+                    containsMissedCallMarker(nestedValue, key: String(describing: rawKey))
+                }
+            }
+
+            if let dictionary = value as? [String: Any] {
+                return dictionary.contains { key, nestedValue in
+                    containsMissedCallMarker(nestedValue, key: key)
+                }
+            }
+
+            if let array = value as? [Any] {
+                return array.contains { containsMissedCallMarker($0) }
+            }
+
+            return false
+        }
+
+        private static func normalizedMissedCallValue(_ value: String) -> String {
+            return value
+                .lowercased()
+                .replacingOccurrences(of: "_", with: " ")
+                .replacingOccurrences(of: "-", with: " ")
+                .replacingOccurrences(of: "!", with: "")
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+    }
+
     // MARK: - TelnyxCallKitManager
     /// TelnyxCallKitManager - Automatically handles CallKit integration for Telnyx Voice
     /// This class sets up CallKit and VoIP push notifications automatically when the app starts
@@ -404,6 +519,120 @@ import React
                 setupCallKit()
             }
         }
+
+        @discardableResult
+        public func handleMissedCallPushIfNeeded(
+            _ payload: [AnyHashable: Any],
+            completion: (() -> Void)? = nil
+        ) -> Bool {
+            guard TelnyxMissedCallPush.isMissedCallPayload(payload) else {
+                return false
+            }
+
+            NSLog("TelnyxVoice: Missed call VoIP push received: \(payload)")
+            setupSynchronously()
+
+            let callId = TelnyxMissedCallPush.callId(from: payload)
+            let callUUID = callId.flatMap { UUID(uuidString: $0) } ?? UUID()
+            let callerName = TelnyxMissedCallPush.callerName(from: payload)
+            let callerNumber = TelnyxMissedCallPush.callerNumber(from: payload)
+
+            let finishMissedCall = {
+                self.callKitProvider?.reportCall(with: callUUID, endedAt: Date(), reason: .remoteEnded)
+                self.activeCalls.removeValue(forKey: callUUID)
+
+                if self.pendingAnswerAction?.callUUID == callUUID {
+                    self.pendingAnswerAction?.fail()
+                    self.pendingAnswerAction = nil
+                }
+
+                NSLog("TelnyxVoice: Ended stale CallKit call for missed call UUID: \(callUUID)")
+                self.clearPendingPushData()
+                self.showMissedCallNotification(
+                    callerName: callerName,
+                    callerNumber: callerNumber,
+                    callId: callId
+                )
+                completion?()
+            }
+
+            if activeCalls[callUUID] != nil {
+                finishMissedCall()
+                return true
+            }
+
+            activeCalls[callUUID] = [
+                "caller": callerName,
+                "handle": callerNumber,
+                "payload": payload,
+                "uuid": callUUID.uuidString,
+                "direction": "incoming",
+                "source": "missed_call_push",
+            ]
+
+            let handle = CXHandle(type: .phoneNumber, value: callerNumber)
+            let callUpdate = CXCallUpdate()
+            callUpdate.remoteHandle = handle
+            callUpdate.hasVideo = false
+            callUpdate.localizedCallerName = callerName
+
+            callKitProvider?.reportNewIncomingCall(with: callUUID, update: callUpdate) { error in
+                if let error = error {
+                    NSLog("TelnyxVoice: Missed call CallKit report failed: \(error.localizedDescription)")
+                    self.activeCalls.removeValue(forKey: callUUID)
+                    self.clearPendingPushData()
+                    completion?()
+                    return
+                }
+
+                finishMissedCall()
+            }
+
+            return true
+        }
+
+        private func clearPendingPushData() {
+            UserDefaults.standard.removeObject(forKey: "pending_push_action")
+            UserDefaults.standard.removeObject(forKey: "pending_push_metadata")
+            UserDefaults.standard.removeObject(forKey: "pending_voip_push")
+            UserDefaults.standard.removeObject(forKey: "pending_voip_action")
+            UserDefaults.standard.removeObject(forKey: "@pending_callkit_uuid")
+            UserDefaults.standard.synchronize()
+        }
+
+        private func showMissedCallNotification(
+            callerName: String, callerNumber: String, callId: String?
+        ) {
+            guard TelnyxMissedCallPush.missedCallNotificationsEnabled() else {
+                NSLog("TelnyxVoice: Missed call local notification disabled")
+                return
+            }
+
+            let content = UNMutableNotificationContent()
+            content.title = "Missed Call"
+            content.body = "You missed a call from \(callerName)"
+            content.sound = .default
+            content.userInfo = [
+                "call_id": callId ?? "",
+                "caller_name": callerName,
+                "caller_number": callerNumber,
+            ]
+
+            let identifier = "telnyx.missed-call.\(callId ?? UUID().uuidString)"
+            let request = UNNotificationRequest(
+                identifier: identifier,
+                content: content,
+                trigger: nil
+            )
+
+            UNUserNotificationCenter.current().add(request) { error in
+                if let error = error {
+                    NSLog("TelnyxVoice: Failed to show missed call notification: \(error)")
+                } else {
+                    NSLog("TelnyxVoice: Missed call notification scheduled")
+                }
+            }
+        }
     }
 
     // MARK: - PKPushRegistryDelegate
@@ -457,6 +686,10 @@ import React
             for type: PKPushType, completion: @escaping () -> Void
         ) {
             NSLog("TelnyxVoice: Received VoIP push notification: \(payload.dictionaryPayload)")
+
+            if handleMissedCallPushIfNeeded(payload.dictionaryPayload, completion: completion) {
+                return
+            }
 
             // Store the VoIP push data for VoicePnBridge (same format as AppDelegate was using)
             do {
@@ -697,6 +930,13 @@ import React
         ) {
             NSLog("[TelnyxVoipPushHandler] VoIP push received for type: \(type.rawValue)")
             NSLog("[TelnyxVoipPushHandler] VoIP payload: \(payload.dictionaryPayload)")
+
+            if TelnyxCallKitManager.shared.handleMissedCallPushIfNeeded(
+                payload.dictionaryPayload,
+                completion: completion
+            ) {
+                return
+            }
 
             // Configure audio session early for VoIP call
             let audioSession = AVAudioSession.sharedInstance()

--- a/react-voice-commons-sdk/ios/VoicePnBridge.m
+++ b/react-voice-commons-sdk/ios/VoicePnBridge.m
@@ -28,4 +28,11 @@ RCT_EXTERN_METHOD(getPendingVoipAction:(RCTPromiseResolveBlock)resolve
 RCT_EXTERN_METHOD(clearPendingVoipAction:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(setMissedCallNotificationsEnabled:(BOOL)enabled
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(getMissedCallNotificationsEnabled:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
 @end

--- a/react-voice-commons-sdk/ios/VoicePnBridge.swift
+++ b/react-voice-commons-sdk/ios/VoicePnBridge.swift
@@ -84,4 +84,22 @@ class VoicePnBridge: NSObject {
         NSLog("[VoicePnBridge] clearPendingVoipAction called. Cleared key pending_voip_action")
         resolve(true)
     }
+
+    @objc
+    func setMissedCallNotificationsEnabled(_ enabled: Bool, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
+        UserDefaults.standard.set(enabled, forKey: "telnyx_enable_missed_call_notifications")
+        UserDefaults.standard.synchronize()
+        NSLog("[VoicePnBridge] setMissedCallNotificationsEnabled called. enabled=\(enabled)")
+        resolve(true)
+    }
+
+    @objc
+    func getMissedCallNotificationsEnabled(_ resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
+        if UserDefaults.standard.object(forKey: "telnyx_enable_missed_call_notifications") == nil {
+            resolve(true)
+            return
+        }
+
+        resolve(UserDefaults.standard.bool(forKey: "telnyx_enable_missed_call_notifications"))
+    }
 }

--- a/react-voice-commons-sdk/lib/index.d.ts
+++ b/react-voice-commons-sdk/lib/index.d.ts
@@ -41,4 +41,5 @@ export {
 export type { Config, CredentialConfig, TokenConfig } from './models/config';
 export type { Call as TelnyxCall } from '@telnyx/react-native-voice-sdk';
 export * from './callkit';
+export { VoicePnBridge } from './internal/voice-pn-bridge';
 export { useAppReadyNotifier } from './hooks/useAppReadyNotifier';

--- a/react-voice-commons-sdk/lib/index.js
+++ b/react-voice-commons-sdk/lib/index.js
@@ -38,6 +38,7 @@ var __exportStar =
   };
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.useAppReadyNotifier =
+  exports.VoicePnBridge =
   exports.createTokenConfig =
   exports.createCredentialConfig =
   exports.validateTokenConfig =
@@ -215,6 +216,14 @@ Object.defineProperty(exports, 'createTokenConfig', {
 });
 // Export CallKit functionality
 __exportStar(require('./callkit'), exports);
+// Native push notification helpers
+var voice_pn_bridge_1 = require('./internal/voice-pn-bridge');
+Object.defineProperty(exports, 'VoicePnBridge', {
+  enumerable: true,
+  get: function () {
+    return voice_pn_bridge_1.VoicePnBridge;
+  },
+});
 // Export hooks
 var useAppReadyNotifier_1 = require('./hooks/useAppReadyNotifier');
 Object.defineProperty(exports, 'useAppReadyNotifier', {

--- a/react-voice-commons-sdk/lib/internal/voice-pn-bridge.d.ts
+++ b/react-voice-commons-sdk/lib/internal/voice-pn-bridge.d.ts
@@ -30,6 +30,8 @@ export interface VoicePnBridgeInterface {
   clearPendingVoipPush(): Promise<boolean>;
   getPendingVoipAction(): Promise<string | null>;
   clearPendingVoipAction(): Promise<boolean>;
+  setMissedCallNotificationsEnabled(enabled: boolean): Promise<boolean>;
+  getMissedCallNotificationsEnabled(): Promise<boolean>;
 }
 declare const NativeBridge: VoicePnBridgeInterface;
 /**
@@ -107,6 +109,15 @@ export declare class VoicePnBridge {
    * Clear pending VoIP action from native storage (iOS only)
    */
   static clearPendingVoipAction(): Promise<boolean>;
+  /**
+   * Enable or disable local missed call notifications on iOS.
+   * Missed-call VoIP pushes are still handled through CallKit either way.
+   */
+  static setMissedCallNotificationsEnabled(enabled: boolean): Promise<boolean>;
+  /**
+   * Returns true by default, matching the sample-app behavior for missed calls.
+   */
+  static getMissedCallNotificationsEnabled(): Promise<boolean>;
   /**
    * Android → React Native: Listen for immediate call action events from notification buttons
    * Use this for active calls where immediate response is needed (e.g., ending ongoing calls)

--- a/react-voice-commons-sdk/lib/internal/voice-pn-bridge.js
+++ b/react-voice-commons-sdk/lib/internal/voice-pn-bridge.js
@@ -185,6 +185,29 @@ class VoicePnBridge {
     }
   }
   /**
+   * Enable or disable local missed call notifications on iOS.
+   * Missed-call VoIP pushes are still handled through CallKit either way.
+   */
+  static async setMissedCallNotificationsEnabled(enabled) {
+    try {
+      return await NativeBridge.setMissedCallNotificationsEnabled(enabled);
+    } catch (error) {
+      console.error('VoicePnBridge: Error setting missed call notifications:', error);
+      return false;
+    }
+  }
+  /**
+   * Returns true by default, matching the sample-app behavior for missed calls.
+   */
+  static async getMissedCallNotificationsEnabled() {
+    try {
+      return await NativeBridge.getMissedCallNotificationsEnabled();
+    } catch (error) {
+      console.error('VoicePnBridge: Error getting missed call notifications setting:', error);
+      return true;
+    }
+  }
+  /**
    * Android → React Native: Listen for immediate call action events from notification buttons
    * Use this for active calls where immediate response is needed (e.g., ending ongoing calls)
    */

--- a/react-voice-commons-sdk/src/index.ts
+++ b/react-voice-commons-sdk/src/index.ts
@@ -55,5 +55,8 @@ export type { Call as TelnyxCall } from '@telnyx/react-native-voice-sdk';
 // Export CallKit functionality
 export * from './callkit';
 
+// Native push notification helpers
+export { VoicePnBridge } from './internal/voice-pn-bridge';
+
 // Export hooks
 export { useAppReadyNotifier } from './hooks/useAppReadyNotifier';

--- a/react-voice-commons-sdk/src/internal/voice-pn-bridge.ts
+++ b/react-voice-commons-sdk/src/internal/voice-pn-bridge.ts
@@ -38,6 +38,8 @@ export interface VoicePnBridgeInterface {
   clearPendingVoipPush(): Promise<boolean>;
   getPendingVoipAction(): Promise<string | null>;
   clearPendingVoipAction(): Promise<boolean>;
+  setMissedCallNotificationsEnabled(enabled: boolean): Promise<boolean>;
+  getMissedCallNotificationsEnabled(): Promise<boolean>;
 }
 
 const NativeBridge: VoicePnBridgeInterface = NativeModules.VoicePnBridge;
@@ -241,6 +243,31 @@ export class VoicePnBridge {
     } catch (error) {
       console.error('VoicePnBridge: Error clearing pending VoIP action:', error);
       return false;
+    }
+  }
+
+  /**
+   * Enable or disable local missed call notifications on iOS.
+   * Missed-call VoIP pushes are still handled through CallKit either way.
+   */
+  static async setMissedCallNotificationsEnabled(enabled: boolean): Promise<boolean> {
+    try {
+      return await NativeBridge.setMissedCallNotificationsEnabled(enabled);
+    } catch (error) {
+      console.error('VoicePnBridge: Error setting missed call notifications:', error);
+      return false;
+    }
+  }
+
+  /**
+   * Returns true by default, matching the sample-app behavior for missed calls.
+   */
+  static async getMissedCallNotificationsEnabled(): Promise<boolean> {
+    try {
+      return await NativeBridge.getMissedCallNotificationsEnabled();
+    } catch (error) {
+      console.error('VoicePnBridge: Error getting missed call notifications setting:', error);
+      return true;
     }
   }
 


### PR DESCRIPTION
## Summary
- handle missed-call VoIP pushes on iOS by reporting then immediately ending a transient CallKit call
- add enable/disable missed-call notification bridge APIs for iOS and Android
- update Android missed-call handling to stop active call notifications and respect the missed-call notification setting
- export VoicePnBridge helpers from the SDK package

## Validation
- npm run build (react-voice-commons-sdk)
- xcodebuild Debug iphonesimulator build
- ./gradlew assembleDebug
- npx jest --watchman=false