### PR TITLE
feat(vsdk-227): add speaker controls

### DIFF
--- a/react-voice-commons-sdk/__tests__/internal/voice-pn-bridge.test.ts
+++ b/react-voice-commons-sdk/__tests__/internal/voice-pn-bridge.test.ts
@@ -1,4 +1,12 @@
 describe('VoicePnBridge speaker controls', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   const loadBridge = async () => {
     jest.resetModules();
     const { NativeModules } = require('react-native');
@@ -30,5 +38,38 @@ describe('VoicePnBridge speaker controls', () => {
 
     await expect(VoicePnBridge.toggleSpeaker()).resolves.toBe(true);
     expect(nativeBridge.setSpeakerEnabled).toHaveBeenCalledWith(true);
+  });
+
+  it('toggles the native speaker route off when currently enabled', async () => {
+    const { VoicePnBridge, nativeBridge } = await loadBridge();
+    nativeBridge.isSpeakerEnabled.mockResolvedValue(true);
+
+    await expect(VoicePnBridge.toggleSpeaker()).resolves.toBe(true);
+    expect(nativeBridge.setSpeakerEnabled).toHaveBeenCalledWith(false);
+  });
+
+  it('rejects when setting the native speaker route fails', async () => {
+    const { VoicePnBridge, nativeBridge } = await loadBridge();
+    const error = new Error('native set failed');
+    nativeBridge.setSpeakerEnabled.mockRejectedValue(error);
+
+    await expect(VoicePnBridge.setSpeakerEnabled(true)).rejects.toThrow('native set failed');
+  });
+
+  it('rejects when reading the native speaker route fails', async () => {
+    const { VoicePnBridge, nativeBridge } = await loadBridge();
+    const error = new Error('native read failed');
+    nativeBridge.isSpeakerEnabled.mockRejectedValue(error);
+
+    await expect(VoicePnBridge.isSpeakerEnabled()).rejects.toThrow('native read failed');
+  });
+
+  it('rejects when toggling cannot read the current speaker route', async () => {
+    const { VoicePnBridge, nativeBridge } = await loadBridge();
+    const error = new Error('native toggle read failed');
+    nativeBridge.isSpeakerEnabled.mockRejectedValue(error);
+
+    await expect(VoicePnBridge.toggleSpeaker()).rejects.toThrow('native toggle read failed');
+    expect(nativeBridge.setSpeakerEnabled).not.toHaveBeenCalled();
   });
 });

--- a/react-voice-commons-sdk/__tests__/internal/voice-pn-bridge.test.ts
+++ b/react-voice-commons-sdk/__tests__/internal/voice-pn-bridge.test.ts
@@ -1,0 +1,34 @@
+describe('VoicePnBridge speaker controls', () => {
+  const loadBridge = async () => {
+    jest.resetModules();
+    const { NativeModules } = require('react-native');
+    NativeModules.VoicePnBridge = {
+      setSpeakerEnabled: jest.fn().mockResolvedValue(true),
+      isSpeakerEnabled: jest.fn().mockResolvedValue(false),
+    };
+
+    const { VoicePnBridge } = await import('../../src/internal/voice-pn-bridge');
+    return { VoicePnBridge, nativeBridge: NativeModules.VoicePnBridge };
+  };
+
+  it('sets the native speaker route', async () => {
+    const { VoicePnBridge, nativeBridge } = await loadBridge();
+
+    await expect(VoicePnBridge.setSpeakerEnabled(true)).resolves.toBe(true);
+    expect(nativeBridge.setSpeakerEnabled).toHaveBeenCalledWith(true);
+  });
+
+  it('reads the native speaker route', async () => {
+    const { VoicePnBridge, nativeBridge } = await loadBridge();
+    nativeBridge.isSpeakerEnabled.mockResolvedValue(true);
+
+    await expect(VoicePnBridge.isSpeakerEnabled()).resolves.toBe(true);
+  });
+
+  it('toggles the native speaker route', async () => {
+    const { VoicePnBridge, nativeBridge } = await loadBridge();
+
+    await expect(VoicePnBridge.toggleSpeaker()).resolves.toBe(true);
+    expect(nativeBridge.setSpeakerEnabled).toHaveBeenCalledWith(true);
+  });
+});

--- a/react-voice-commons-sdk/android/src/main/java/com/telnyx/react_voice_commons/VoicePnBridgeModule.kt
+++ b/react-voice-commons-sdk/android/src/main/java/com/telnyx/react_voice_commons/VoicePnBridgeModule.kt
@@ -253,11 +253,13 @@ class VoicePnBridgeModule(reactContext: ReactApplicationContext) : ReactContextB
     fun setSpeakerEnabled(enabled: Boolean, promise: Promise) {
         try {
             val audioManager = reactApplicationContext.getSystemService(Context.AUDIO_SERVICE) as AudioManager
-            audioManager.mode = AudioManager.MODE_IN_COMMUNICATION
+            // The active call flow owns AudioManager.mode. This bridge only requests the speaker route.
+            // Connected Bluetooth or wired accessories may still take precedence over speakerphone.
             audioManager.isSpeakerphoneOn = enabled
+            val actualEnabled = audioManager.isSpeakerphoneOn
 
-            Log.d(TAG, "setSpeakerEnabled called from React Native: enabled=$enabled")
-            promise.resolve(true)
+            Log.d(TAG, "setSpeakerEnabled called from React Native: requested=$enabled actual=$actualEnabled")
+            promise.resolve(actualEnabled)
         } catch (e: Exception) {
             Log.e(TAG, "Error setting speaker route", e)
             promise.reject("SET_SPEAKER_ENABLED_ERROR", e.message, e)

--- a/react-voice-commons-sdk/android/src/main/java/com/telnyx/react_voice_commons/VoicePnBridgeModule.kt
+++ b/react-voice-commons-sdk/android/src/main/java/com/telnyx/react_voice_commons/VoicePnBridgeModule.kt
@@ -1,6 +1,8 @@
 package com.telnyx.react_voice_commons
 
 import android.content.Intent
+import android.content.Context
+import android.media.AudioManager
 import android.os.Build
 import android.util.Log
 import com.facebook.react.bridge.ReactApplicationContext
@@ -244,6 +246,32 @@ class VoicePnBridgeModule(reactContext: ReactApplicationContext) : ReactContextB
         } catch (e: Exception) {
             Log.e(TAG, "Error getting missed call notifications", e)
             promise.reject("GET_MISSED_CALL_NOTIFICATIONS_ERROR", e.message, e)
+        }
+    }
+
+    @ReactMethod
+    fun setSpeakerEnabled(enabled: Boolean, promise: Promise) {
+        try {
+            val audioManager = reactApplicationContext.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+            audioManager.mode = AudioManager.MODE_IN_COMMUNICATION
+            audioManager.isSpeakerphoneOn = enabled
+
+            Log.d(TAG, "setSpeakerEnabled called from React Native: enabled=$enabled")
+            promise.resolve(true)
+        } catch (e: Exception) {
+            Log.e(TAG, "Error setting speaker route", e)
+            promise.reject("SET_SPEAKER_ENABLED_ERROR", e.message, e)
+        }
+    }
+
+    @ReactMethod
+    fun isSpeakerEnabled(promise: Promise) {
+        try {
+            val audioManager = reactApplicationContext.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+            promise.resolve(audioManager.isSpeakerphoneOn)
+        } catch (e: Exception) {
+            Log.e(TAG, "Error getting speaker route", e)
+            promise.reject("GET_SPEAKER_ENABLED_ERROR", e.message, e)
         }
     }
     

--- a/react-voice-commons-sdk/ios/VoicePnBridge.m
+++ b/react-voice-commons-sdk/ios/VoicePnBridge.m
@@ -35,4 +35,11 @@ RCT_EXTERN_METHOD(setMissedCallNotificationsEnabled:(BOOL)enabled
 RCT_EXTERN_METHOD(getMissedCallNotificationsEnabled:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(setSpeakerEnabled:(BOOL)enabled
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(isSpeakerEnabled:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
 @end

--- a/react-voice-commons-sdk/ios/VoicePnBridge.swift
+++ b/react-voice-commons-sdk/ios/VoicePnBridge.swift
@@ -108,9 +108,15 @@ class VoicePnBridge: NSObject {
     func setSpeakerEnabled(_ enabled: Bool, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
         do {
             let audioSession = AVAudioSession.sharedInstance()
+            // The Telnyx/WebRTC call setup is expected to configure a .playAndRecord-compatible
+            // session. Passing .none clears only the speaker override; accessories/session options
+            // can still decide the resulting output route.
             try audioSession.overrideOutputAudioPort(enabled ? .speaker : .none)
-            NSLog("[VoicePnBridge] setSpeakerEnabled called. enabled=\(enabled)")
-            resolve(true)
+            let actualEnabled = audioSession.currentRoute.outputs.contains { output in
+                output.portType == .builtInSpeaker
+            }
+            NSLog("[VoicePnBridge] setSpeakerEnabled called. requested=\(enabled), actual=\(actualEnabled)")
+            resolve(actualEnabled)
         } catch {
             NSLog("[VoicePnBridge] setSpeakerEnabled failed. enabled=\(enabled), error=\(error)")
             reject("SET_SPEAKER_ENABLED_ERROR", error.localizedDescription, error)

--- a/react-voice-commons-sdk/ios/VoicePnBridge.swift
+++ b/react-voice-commons-sdk/ios/VoicePnBridge.swift
@@ -1,5 +1,6 @@
 import Foundation
 import React
+import AVFoundation
 
 @objc(VoicePnBridge)
 class VoicePnBridge: NSObject {
@@ -101,5 +102,26 @@ class VoicePnBridge: NSObject {
         }
 
         resolve(UserDefaults.standard.bool(forKey: TelnyxVoiceUserDefaultsKey.missedCallNotificationsEnabled))
+    }
+
+    @objc
+    func setSpeakerEnabled(_ enabled: Bool, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
+        do {
+            let audioSession = AVAudioSession.sharedInstance()
+            try audioSession.overrideOutputAudioPort(enabled ? .speaker : .none)
+            NSLog("[VoicePnBridge] setSpeakerEnabled called. enabled=\(enabled)")
+            resolve(true)
+        } catch {
+            NSLog("[VoicePnBridge] setSpeakerEnabled failed. enabled=\(enabled), error=\(error)")
+            reject("SET_SPEAKER_ENABLED_ERROR", error.localizedDescription, error)
+        }
+    }
+
+    @objc
+    func isSpeakerEnabled(_ resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
+        let isEnabled = AVAudioSession.sharedInstance().currentRoute.outputs.contains { output in
+            output.portType == .builtInSpeaker
+        }
+        resolve(isEnabled)
     }
 }

--- a/react-voice-commons-sdk/lib/internal/voice-pn-bridge.d.ts
+++ b/react-voice-commons-sdk/lib/internal/voice-pn-bridge.d.ts
@@ -32,6 +32,8 @@ export interface VoicePnBridgeInterface {
   clearPendingVoipAction(): Promise<boolean>;
   setMissedCallNotificationsEnabled(enabled: boolean): Promise<boolean>;
   getMissedCallNotificationsEnabled(): Promise<boolean>;
+  setSpeakerEnabled(enabled: boolean): Promise<boolean>;
+  isSpeakerEnabled(): Promise<boolean>;
 }
 declare const NativeBridge: VoicePnBridgeInterface;
 /**
@@ -118,6 +120,19 @@ export declare class VoicePnBridge {
    * Returns true by default, matching the sample-app behavior for missed calls.
    */
   static getMissedCallNotificationsEnabled(): Promise<boolean>;
+  /**
+   * Route call audio through the loudspeaker when enabled, or back to the
+   * platform default voice route when disabled.
+   */
+  static setSpeakerEnabled(enabled: boolean): Promise<boolean>;
+  /**
+   * Returns whether the current audio route is using the loudspeaker.
+   */
+  static isSpeakerEnabled(): Promise<boolean>;
+  /**
+   * Toggle between loudspeaker and the platform default voice route.
+   */
+  static toggleSpeaker(): Promise<boolean>;
   /**
    * Android → React Native: Listen for immediate call action events from notification buttons
    * Use this for active calls where immediate response is needed (e.g., ending ongoing calls)

--- a/react-voice-commons-sdk/lib/internal/voice-pn-bridge.js
+++ b/react-voice-commons-sdk/lib/internal/voice-pn-bridge.js
@@ -216,7 +216,7 @@ class VoicePnBridge {
       return await NativeBridge.setSpeakerEnabled(enabled);
     } catch (error) {
       console.error('VoicePnBridge: Error setting speaker route:', error);
-      return false;
+      throw error;
     }
   }
   /**
@@ -227,13 +227,15 @@ class VoicePnBridge {
       return await NativeBridge.isSpeakerEnabled();
     } catch (error) {
       console.error('VoicePnBridge: Error getting speaker route:', error);
-      return false;
+      throw error;
     }
   }
   /**
    * Toggle between loudspeaker and the platform default voice route.
    */
   static async toggleSpeaker() {
+    // This is intentionally read-then-write because route changes can also come from
+    // the OS, Bluetooth, wired accessories, or the active call session.
     const enabled = await VoicePnBridge.isSpeakerEnabled();
     return VoicePnBridge.setSpeakerEnabled(!enabled);
   }

--- a/react-voice-commons-sdk/lib/internal/voice-pn-bridge.js
+++ b/react-voice-commons-sdk/lib/internal/voice-pn-bridge.js
@@ -208,6 +208,36 @@ class VoicePnBridge {
     }
   }
   /**
+   * Route call audio through the loudspeaker when enabled, or back to the
+   * platform default voice route when disabled.
+   */
+  static async setSpeakerEnabled(enabled) {
+    try {
+      return await NativeBridge.setSpeakerEnabled(enabled);
+    } catch (error) {
+      console.error('VoicePnBridge: Error setting speaker route:', error);
+      return false;
+    }
+  }
+  /**
+   * Returns whether the current audio route is using the loudspeaker.
+   */
+  static async isSpeakerEnabled() {
+    try {
+      return await NativeBridge.isSpeakerEnabled();
+    } catch (error) {
+      console.error('VoicePnBridge: Error getting speaker route:', error);
+      return false;
+    }
+  }
+  /**
+   * Toggle between loudspeaker and the platform default voice route.
+   */
+  static async toggleSpeaker() {
+    const enabled = await VoicePnBridge.isSpeakerEnabled();
+    return VoicePnBridge.setSpeakerEnabled(!enabled);
+  }
+  /**
    * Android → React Native: Listen for immediate call action events from notification buttons
    * Use this for active calls where immediate response is needed (e.g., ending ongoing calls)
    */

--- a/react-voice-commons-sdk/src/internal/voice-pn-bridge.ts
+++ b/react-voice-commons-sdk/src/internal/voice-pn-bridge.ts
@@ -282,7 +282,7 @@ export class VoicePnBridge {
       return await NativeBridge.setSpeakerEnabled(enabled);
     } catch (error) {
       console.error('VoicePnBridge: Error setting speaker route:', error);
-      return false;
+      throw error;
     }
   }
 
@@ -294,7 +294,7 @@ export class VoicePnBridge {
       return await NativeBridge.isSpeakerEnabled();
     } catch (error) {
       console.error('VoicePnBridge: Error getting speaker route:', error);
-      return false;
+      throw error;
     }
   }
 
@@ -302,6 +302,8 @@ export class VoicePnBridge {
    * Toggle between loudspeaker and the platform default voice route.
    */
   static async toggleSpeaker(): Promise<boolean> {
+    // This is intentionally read-then-write because route changes can also come from
+    // the OS, Bluetooth, wired accessories, or the active call session.
     const enabled = await VoicePnBridge.isSpeakerEnabled();
     return VoicePnBridge.setSpeakerEnabled(!enabled);
   }

--- a/react-voice-commons-sdk/src/internal/voice-pn-bridge.ts
+++ b/react-voice-commons-sdk/src/internal/voice-pn-bridge.ts
@@ -40,6 +40,8 @@ export interface VoicePnBridgeInterface {
   clearPendingVoipAction(): Promise<boolean>;
   setMissedCallNotificationsEnabled(enabled: boolean): Promise<boolean>;
   getMissedCallNotificationsEnabled(): Promise<boolean>;
+  setSpeakerEnabled(enabled: boolean): Promise<boolean>;
+  isSpeakerEnabled(): Promise<boolean>;
 }
 
 const NativeBridge: VoicePnBridgeInterface = NativeModules.VoicePnBridge;
@@ -269,6 +271,39 @@ export class VoicePnBridge {
       console.error('VoicePnBridge: Error getting missed call notifications setting:', error);
       return true;
     }
+  }
+
+  /**
+   * Route call audio through the loudspeaker when enabled, or back to the
+   * platform default voice route when disabled.
+   */
+  static async setSpeakerEnabled(enabled: boolean): Promise<boolean> {
+    try {
+      return await NativeBridge.setSpeakerEnabled(enabled);
+    } catch (error) {
+      console.error('VoicePnBridge: Error setting speaker route:', error);
+      return false;
+    }
+  }
+
+  /**
+   * Returns whether the current audio route is using the loudspeaker.
+   */
+  static async isSpeakerEnabled(): Promise<boolean> {
+    try {
+      return await NativeBridge.isSpeakerEnabled();
+    } catch (error) {
+      console.error('VoicePnBridge: Error getting speaker route:', error);
+      return false;
+    }
+  }
+
+  /**
+   * Toggle between loudspeaker and the platform default voice route.
+   */
+  static async toggleSpeaker(): Promise<boolean> {
+    const enabled = await VoicePnBridge.isSpeakerEnabled();
+    return VoicePnBridge.setSpeakerEnabled(!enabled);
   }
 
   /**


### PR DESCRIPTION
## Summary
- add React Native bridge methods for enabling/disabling speaker output on Android and iOS
- expose typed VoicePnBridge helpers for set/read/toggle speaker state
- add wrapper tests for the speaker bridge API

## Ticket
https://linear.app/telnyx/issue/VSDK-227/speaker-control-implementation

## Verification
- npm run build
- npm test -- --runTestsByPath __tests__/internal/voice-pn-bridge.test.ts --runInBand --no-watchman