### PR TITLE
Add release process workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,6 @@
 name: Publish to npm
 
-# Trigger on GitHub Releases only — no manual npm publish allowed.
+# Trigger on GitHub Releases and from the release workflow.
 # Use release tag prefixes to control which package(s) to publish:
 #   voice-sdk-v0.4.1   → publishes @telnyx/react-native-voice-sdk only
 #   commons-sdk-v0.2.0 → publishes @telnyx/react-voice-commons-sdk only
@@ -8,6 +8,12 @@ name: Publish to npm
 on:
   release:
     types: [published]
+  workflow_call:
+    inputs:
+      tag_name:
+        description: 'Release tag to publish'
+        required: true
+        type: string
 
 # OIDC: Grant the workflow a short-lived identity token that npm uses to
 # verify this publish came from this repo. No stored secrets on any machine.
@@ -16,9 +22,27 @@ permissions:
   id-token: write
 
 jobs:
+  resolve-release:
+    name: Resolve release tag
+    runs-on: ubuntu-latest
+    outputs:
+      tag_name: ${{ steps.release.outputs.tag_name }}
+    steps:
+      - name: Resolve tag name
+        id: release
+        env:
+          TAG_NAME: ${{ inputs.tag_name || github.event.release.tag_name }}
+        run: |
+          if [ -z "$TAG_NAME" ]; then
+            echo "::error::Release tag was not provided"
+            exit 1
+          fi
+          echo "tag_name=$TAG_NAME" >> "$GITHUB_OUTPUT"
+
   publish-voice-sdk:
     name: Publish @telnyx/react-native-voice-sdk
-    if: startsWith(github.event.release.tag_name, 'voice-sdk-v') || (startsWith(github.event.release.tag_name, 'v') && !contains(github.event.release.tag_name, '-sdk-'))
+    needs: resolve-release
+    if: startsWith(needs.resolve-release.outputs.tag_name, 'voice-sdk-v') || (startsWith(needs.resolve-release.outputs.tag_name, 'v') && !contains(needs.resolve-release.outputs.tag_name, '-sdk-'))
     runs-on: ubuntu-latest
     environment: npm-pub
     steps:
@@ -34,7 +58,7 @@ jobs:
       - name: Verify tag version matches package.json
         working-directory: package
         run: |
-          TAG="${{ github.event.release.tag_name }}"
+          TAG="${{ needs.resolve-release.outputs.tag_name }}"
           # Extract version: voice-sdk-v0.4.1 → 0.4.1, commons-sdk-v0.2.0 → 0.2.0, v0.2.0 → 0.2.0
           TAG_VERSION=$(echo "$TAG" | sed 's/.*-v//' | sed 's/^v//')
           PKG_VERSION=$(node -p "require('./package.json').version")
@@ -54,11 +78,11 @@ jobs:
   publish-commons-sdk:
     name: Publish @telnyx/react-voice-commons-sdk
     runs-on: ubuntu-latest
-    needs: publish-voice-sdk
+    needs: [resolve-release, publish-voice-sdk]
     # Run if: tag targets commons-sdk or both, AND voice-sdk either succeeded or was skipped
     if: |
       always() &&
-      (startsWith(github.event.release.tag_name, 'commons-sdk-v') || (startsWith(github.event.release.tag_name, 'v') && !contains(github.event.release.tag_name, '-sdk-'))) &&
+      (startsWith(needs.resolve-release.outputs.tag_name, 'commons-sdk-v') || (startsWith(needs.resolve-release.outputs.tag_name, 'v') && !contains(needs.resolve-release.outputs.tag_name, '-sdk-'))) &&
       (needs.publish-voice-sdk.result == 'success' || needs.publish-voice-sdk.result == 'skipped')
     environment: npm-pub
     steps:
@@ -74,7 +98,7 @@ jobs:
       - name: Verify tag version matches package.json
         working-directory: react-voice-commons-sdk
         run: |
-          TAG="${{ github.event.release.tag_name }}"
+          TAG="${{ needs.resolve-release.outputs.tag_name }}"
           TAG_VERSION=$(echo "$TAG" | sed 's/.*-v//' | sed 's/^v//')
           PKG_VERSION=$(node -p "require('./package.json').version")
           if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then

--- a/.github/workflows/release-01-create-pull-request.yml
+++ b/.github/workflows/release-01-create-pull-request.yml
@@ -1,0 +1,157 @@
+name: release-01-create-pull-request
+
+on:
+  workflow_dispatch:
+    inputs:
+      package:
+        description: 'Package to release'
+        required: true
+        default: 'commons-sdk'
+        type: choice
+        options:
+          - voice-sdk
+          - commons-sdk
+          - both
+      version:
+        description: 'Release version without prefix, for example 0.4.6'
+        required: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: release-pr-${{ github.event.inputs.package }}-${{ github.event.inputs.version }}
+  cancel-in-progress: false
+
+jobs:
+  create-release-pr:
+    name: Create release pull request
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository with full history
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Validate version
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          if ! echo "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+            echo "::error::Version must be semver without a leading v, for example 0.4.6"
+            exit 1
+          fi
+
+      - name: Resolve release metadata
+        id: release
+        run: |
+          PACKAGE="${{ github.event.inputs.package }}"
+          VERSION="${{ github.event.inputs.version }}"
+
+          case "$PACKAGE" in
+            voice-sdk)
+              TAG="voice-sdk-v$VERSION"
+              PACKAGE_DIRS="package"
+              ;;
+            commons-sdk)
+              TAG="commons-sdk-v$VERSION"
+              PACKAGE_DIRS="react-voice-commons-sdk"
+              ;;
+            both)
+              TAG="v$VERSION"
+              PACKAGE_DIRS="package react-voice-commons-sdk"
+              ;;
+            *)
+              echo "::error::Unsupported package: $PACKAGE"
+              exit 1
+              ;;
+          esac
+
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "package_dirs=$PACKAGE_DIRS" >> "$GITHUB_OUTPUT"
+          echo "branch=release/$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Find previous release tag
+        id: previous_tag
+        run: |
+          PACKAGE="${{ github.event.inputs.package }}"
+          case "$PACKAGE" in
+            voice-sdk)
+              PATTERN='^voice-sdk-v[0-9]+\.[0-9]+\.[0-9]+'
+              ;;
+            commons-sdk)
+              PATTERN='^commons-sdk-v[0-9]+\.[0-9]+\.[0-9]+'
+              ;;
+            both)
+              PATTERN='^v[0-9]+\.[0-9]+\.[0-9]+'
+              ;;
+          esac
+
+          PREVIOUS_TAG="$(git tag --sort=-v:refname | grep -E "$PATTERN" | head -n 1 || true)"
+          echo "previous_tag=$PREVIOUS_TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Generate changelog from merged pull requests
+        id: changelog
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PREVIOUS_TAG="${{ steps.previous_tag.outputs.previous_tag }}"
+          if [ -n "$PREVIOUS_TAG" ]; then
+            RANGE="$PREVIOUS_TAG..HEAD"
+            git log --pretty=format:"%H" "$RANGE" > commits.txt
+          else
+            git log --pretty=format:"%H" > commits.txt
+          fi
+
+          gh pr list --state merged --base main --limit 200 --json title,number,mergeCommit \
+            --jq ".[] | [.title, .number, .mergeCommit.oid] | @tsv" > pr_data.tsv
+
+          > changelog.txt
+          while IFS=$'\t' read -r title number commit; do
+            if [ -n "$commit" ] && grep -q "$commit" commits.txt; then
+              echo "- PR #$number: $title" >> changelog.txt
+            fi
+          done < pr_data.tsv
+
+          if [ ! -s changelog.txt ]; then
+            echo "- No merged pull requests found in this range." > changelog.txt
+          fi
+
+          {
+            echo "body<<EOF"
+            cat changelog.txt
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Update package versions
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          for dir in ${{ steps.release.outputs.package_dirs }}; do
+            npm --prefix "$dir" version "$VERSION" --no-git-tag-version --allow-same-version
+          done
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ github.token }}
+          branch: ${{ steps.release.outputs.branch }}
+          base: main
+          delete-branch: true
+          commit-message: "chore: release ${{ steps.release.outputs.tag }}"
+          title: "Release ${{ steps.release.outputs.tag }}"
+          body: |
+            Auto-created release pull request for `${{ steps.release.outputs.tag }}`.
+
+            Package scope: `${{ github.event.inputs.package }}`
+            Previous tag: `${{ steps.previous_tag.outputs.previous_tag || 'none' }}`
+
+            Note: this PR is created with `GITHUB_TOKEN`, so GitHub will not automatically
+            trigger `pull_request` workflows for it. Run any required checks manually before merge.
+
+            Changes since previous release:
+            ${{ steps.changelog.outputs.body }}
+          add-paths: |
+            package/package.json
+            react-voice-commons-sdk/package.json
+          labels: auto-generated

--- a/.github/workflows/release-02-generate-docs.yml
+++ b/.github/workflows/release-02-generate-docs.yml
@@ -1,0 +1,59 @@
+name: release-02-generate-docs
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_branch:
+        description: 'Base branch for the documentation PR'
+        required: true
+        default: 'main'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: release-docs-${{ github.event.inputs.base_branch }}
+  cancel-in-progress: false
+
+jobs:
+  generate-docs:
+    name: Generate documentation pull request
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout base branch
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.inputs.base_branch }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '24'
+
+      - name: Install dependencies
+        working-directory: react-voice-commons-sdk
+        run: npm install --legacy-peer-deps
+
+      - name: Generate documentation
+        working-directory: react-voice-commons-sdk
+        run: npm run docs:all
+
+      - name: Create documentation pull request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ github.token }}
+          branch: docs/${{ github.event.inputs.base_branch }}-${{ github.run_id }}
+          base: ${{ github.event.inputs.base_branch }}
+          delete-branch: true
+          commit-message: "docs: regenerate API documentation"
+          title: "Update generated API documentation"
+          body: |
+            This pull request updates generated API documentation.
+
+            Base branch: `${{ github.event.inputs.base_branch }}`
+          add-paths: |
+            docs/
+            docs-markdown/
+          labels: "documentation, auto-generated"

--- a/.github/workflows/release-03-create-gh-release.yml
+++ b/.github/workflows/release-03-create-gh-release.yml
@@ -1,0 +1,153 @@
+name: release-03-create-gh-release
+
+on:
+  workflow_dispatch:
+    inputs:
+      package:
+        description: 'Package to release'
+        required: true
+        default: 'commons-sdk'
+        type: choice
+        options:
+          - voice-sdk
+          - commons-sdk
+          - both
+      version:
+        description: 'Release version without prefix, for example 0.4.6'
+        required: true
+
+permissions:
+  contents: write
+  id-token: write
+  pull-requests: read
+
+concurrency:
+  group: release-publish-${{ github.event.inputs.package }}-${{ github.event.inputs.version }}
+  cancel-in-progress: false
+
+jobs:
+  create-release:
+    name: Create GitHub release
+    runs-on: ubuntu-latest
+    outputs:
+      tag_name: ${{ steps.release.outputs.tag }}
+
+    steps:
+      - name: Checkout main branch
+        uses: actions/checkout@v5
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Resolve release metadata
+        id: release
+        run: |
+          PACKAGE="${{ github.event.inputs.package }}"
+          VERSION="${{ github.event.inputs.version }}"
+
+          if ! echo "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+            echo "::error::Version must be semver without a leading v, for example 0.4.6"
+            exit 1
+          fi
+
+          case "$PACKAGE" in
+            voice-sdk)
+              TAG="voice-sdk-v$VERSION"
+              PACKAGE_DIR="package"
+              PATTERN='^voice-sdk-v[0-9]+\.[0-9]+\.[0-9]+'
+              ;;
+            commons-sdk)
+              TAG="commons-sdk-v$VERSION"
+              PACKAGE_DIR="react-voice-commons-sdk"
+              PATTERN='^commons-sdk-v[0-9]+\.[0-9]+\.[0-9]+'
+              ;;
+            both)
+              TAG="v$VERSION"
+              PACKAGE_DIR="package react-voice-commons-sdk"
+              PATTERN='^v[0-9]+\.[0-9]+\.[0-9]+'
+              ;;
+            *)
+              echo "::error::Unsupported package: $PACKAGE"
+              exit 1
+              ;;
+          esac
+
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "package_dirs=$PACKAGE_DIR" >> "$GITHUB_OUTPUT"
+          echo "pattern=$PATTERN" >> "$GITHUB_OUTPUT"
+
+      - name: Verify package version matches release version
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          for dir in ${{ steps.release.outputs.package_dirs }}; do
+            PACKAGE_VERSION="$(node -p "require('./$dir/package.json').version")"
+            if [ "$PACKAGE_VERSION" != "$VERSION" ]; then
+              echo "::error::$dir package version ($PACKAGE_VERSION) does not match release version ($VERSION)"
+              exit 1
+            fi
+          done
+
+      - name: Find previous release tag
+        id: previous_tag
+        run: |
+          PREVIOUS_TAG="$(git tag --sort=-v:refname | grep -E "${{ steps.release.outputs.pattern }}" | head -n 1 || true)"
+          echo "previous_tag=$PREVIOUS_TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Generate changelog from merged pull requests
+        id: changelog
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PREVIOUS_TAG="${{ steps.previous_tag.outputs.previous_tag }}"
+          if [ -n "$PREVIOUS_TAG" ]; then
+            git log --pretty=format:"%H" "$PREVIOUS_TAG..HEAD" > commits.txt
+          else
+            git log --pretty=format:"%H" > commits.txt
+          fi
+
+          gh pr list --state merged --base main --limit 200 --json title,number,mergeCommit \
+            --jq ".[] | [.title, .number, .mergeCommit.oid] | @tsv" > pr_data.tsv
+
+          > changelog.txt
+          while IFS=$'\t' read -r title number commit; do
+            if [ -n "$commit" ] && grep -q "$commit" commits.txt; then
+              echo "- PR #$number: $title" >> changelog.txt
+            fi
+          done < pr_data.tsv
+
+          if [ ! -s changelog.txt ]; then
+            echo "- No merged pull requests found in this range." > changelog.txt
+          fi
+
+          {
+            echo "body<<EOF"
+            cat changelog.txt
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.release.outputs.tag }}
+          name: Release ${{ steps.release.outputs.tag }}
+          body: |
+            Package scope: `${{ github.event.inputs.package }}`
+            Previous tag: `${{ steps.previous_tag.outputs.previous_tag || 'none' }}`
+
+            Changes since previous release:
+            ${{ steps.changelog.outputs.body }}
+          draft: false
+          prerelease: ${{ contains(github.event.inputs.version, '-') }}
+
+  publish:
+    name: Publish to npm
+    needs: create-release
+    # The GitHub release is created with GITHUB_TOKEN, which does not trigger
+    # release:published workflows. Call publish.yml directly so npm publishing
+    # still uses OIDC trusted publishing without a PAT.
+    uses: ./.github/workflows/publish.yml
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      tag_name: ${{ needs.create-release.outputs.tag_name }}


### PR DESCRIPTION
## Summary
- Add manual release PR workflow for voice-sdk, commons-sdk, or both package scopes
- Add manual docs PR workflow for generated API docs
- Add manual GitHub Release workflow that creates tags compatible with existing npm trusted publishing

## Release flow
1. Run release-01-create-pull-request and merge the version bump PR
2. Optionally run release-02-generate-docs
3. Run release-03-create-gh-release
4. Existing publish.yml runs on release published and uses npm trusted publishing/provenance

## Validation
- Parsed new release workflow YAML files and existing publish.yml with Ruby YAML loader
- Prettier check passed via commit hook