### PR TITLE
Match call reports with JS SDK stats

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -50,6 +50,7 @@ const voipClient = createTelnyxVoipClient({
   enableAppStateManagement: true,
   debug: true,
   useTrickleIce: true,
+  enableCallReports: true,
 });
 
 export default function RootLayout() {

--- a/components/TelnyxLoginForm.tsx
+++ b/components/TelnyxLoginForm.tsx
@@ -62,6 +62,7 @@ async function buildProfileConnectionConfig(
     debug: true,
     pushNotificationDeviceToken: pushToken || undefined,
     useTrickleIce: DEMO_USE_TRICKLE_ICE,
+    enableCallReports: true,
   };
 
   return nextProfile.loginMode === 'token'

--- a/package/__tests__/call-report-collector.test.ts
+++ b/package/__tests__/call-report-collector.test.ts
@@ -28,6 +28,7 @@ const MOCK_SUMMARY: CallReportSummary = {
 function createMockPeerConnection(statsMap: Map<string, any> = new Map()) {
   return {
     getStats: jest.fn().mockResolvedValue({
+      get: (id: string) => statsMap.get(id),
       forEach: (cb: (report: any) => void) => {
         statsMap.forEach((report) => cb(report));
       },
@@ -67,35 +68,39 @@ describe('CallReportCollector', () => {
   });
 
   describe('start / stop', () => {
-    it('starts periodic stats collection', () => {
+    it('starts periodic stats collection', async () => {
       const collector = new CallReportCollector(DEFAULT_CONFIG);
       const mockPC = createMockPeerConnection();
 
       collector.start(mockPC);
 
-      // Advance by one interval
-      jest.advanceTimersByTime(5000);
+      // JS SDK behavior: collect every second for the first 10 seconds.
+      jest.advanceTimersByTime(1000);
+      await Promise.resolve();
+      await Promise.resolve();
       expect(mockPC.getStats).toHaveBeenCalledTimes(1);
 
-      // Advance by another interval
-      jest.advanceTimersByTime(5000);
+      jest.advanceTimersByTime(1000);
+      await Promise.resolve();
+      await Promise.resolve();
       expect(mockPC.getStats).toHaveBeenCalledTimes(2);
 
       collector.stop();
     });
 
-    it('stops collection on stop()', () => {
+    it('stops collection on stop()', async () => {
       const collector = new CallReportCollector(DEFAULT_CONFIG);
       const mockPC = createMockPeerConnection();
 
       collector.start(mockPC);
-      jest.advanceTimersByTime(5000);
+      jest.advanceTimersByTime(1000);
+      await Promise.resolve();
       expect(mockPC.getStats).toHaveBeenCalledTimes(1);
 
-      collector.stop();
+      await collector.stop();
       jest.advanceTimersByTime(10000);
-      // No more calls after stop
-      expect(mockPC.getStats).toHaveBeenCalledTimes(1);
+      // stop() collects one final partial interval, then no more timer calls.
+      expect(mockPC.getStats).toHaveBeenCalledTimes(2);
     });
 
     it('does not start without a peer connection', () => {
@@ -105,14 +110,15 @@ describe('CallReportCollector', () => {
       jest.advanceTimersByTime(5000);
     });
 
-    it('only starts once (idempotent)', () => {
+    it('only starts once (idempotent)', async () => {
       const collector = new CallReportCollector(DEFAULT_CONFIG);
       const mockPC = createMockPeerConnection();
 
       collector.start(mockPC);
       collector.start(mockPC); // second call ignored
 
-      jest.advanceTimersByTime(5000);
+      jest.advanceTimersByTime(1000);
+      await Promise.resolve();
       expect(mockPC.getStats).toHaveBeenCalledTimes(1);
 
       collector.stop();
@@ -155,7 +161,7 @@ describe('CallReportCollector', () => {
       const mockPC = createMockPeerConnection(statsMap);
       collector.start(mockPC);
 
-      jest.advanceTimersByTime(5000);
+      jest.advanceTimersByTime(1000);
       // Let the async getStats resolve
       await Promise.resolve();
 
@@ -193,7 +199,7 @@ describe('CallReportCollector', () => {
       collector.log('info', 'pre-flush log');
       collector.start(mockPC);
 
-      jest.advanceTimersByTime(5000);
+      jest.advanceTimersByTime(1000);
       await Promise.resolve();
 
       const flushed = collector.flush(MOCK_SUMMARY);
@@ -335,7 +341,7 @@ describe('CallReportCollector', () => {
       collector.start(mockPC);
 
       // First interval - no bitrate (no previous data)
-      jest.advanceTimersByTime(5000);
+      jest.advanceTimersByTime(1000);
       await Promise.resolve();
 
       // Update stats for second interval
@@ -348,10 +354,10 @@ describe('CallReportCollector', () => {
       });
 
       // Second interval - should have bitrate
-      jest.advanceTimersByTime(5000);
+      jest.advanceTimersByTime(1000);
       await Promise.resolve();
 
-      collector.stop();
+      await collector.stop();
 
       const payload = collector.buildPayload(MOCK_SUMMARY);
       expect(payload.stats).toHaveLength(2);
@@ -376,10 +382,10 @@ describe('CallReportCollector', () => {
       const mockPC = createMockPeerConnection(statsMap);
       collector.start(mockPC);
 
-      jest.advanceTimersByTime(5000);
+      jest.advanceTimersByTime(1000);
       await Promise.resolve();
 
-      collector.stop();
+      await collector.stop();
 
       const payload = collector.buildPayload(MOCK_SUMMARY);
       const conn = payload.stats[0].connection;
@@ -387,6 +393,85 @@ describe('CallReportCollector', () => {
       expect(conn!.roundTripTimeAvg).toBe(0.05);
       expect(conn!.packetsSent).toBe(100);
       expect(conn!.packetsReceived).toBe(95);
+    });
+
+    it('includes selected ICE candidate pair and transport stats', async () => {
+      const statsMap = new Map();
+      statsMap.set('local-candidate', {
+        id: 'local-candidate',
+        type: 'local-candidate',
+        address: '192.168.1.10',
+        port: 5000,
+        candidateType: 'srflx',
+        protocol: 'udp',
+        networkType: 'wifi',
+      });
+      statsMap.set('remote-candidate', {
+        id: 'remote-candidate',
+        type: 'remote-candidate',
+        address: '50.114.148.33',
+        port: 28714,
+        candidateType: 'host',
+        protocol: 'udp',
+      });
+      statsMap.set('pair', {
+        id: 'candidate-pair',
+        type: 'candidate-pair',
+        nominated: true,
+        state: 'succeeded',
+        writable: true,
+        localCandidateId: 'local-candidate',
+        remoteCandidateId: 'remote-candidate',
+        requestsSent: 3,
+        responsesReceived: 3,
+      });
+      statsMap.set('transport', {
+        type: 'transport',
+        iceState: 'connected',
+        dtlsState: 'connected',
+        srtpCipher: 'AES_CM_128_HMAC_SHA1_80',
+        tlsVersion: 'FEFD',
+        selectedCandidatePairChanges: 1,
+      });
+
+      const collector = new CallReportCollector(DEFAULT_CONFIG);
+      const mockPC = createMockPeerConnection(statsMap);
+      collector.start(mockPC);
+
+      jest.advanceTimersByTime(1000);
+      await Promise.resolve();
+      await collector.stop();
+
+      const payload = collector.buildPayload(MOCK_SUMMARY);
+      const interval = payload.stats[0];
+      expect(interval.ice).toEqual({
+        id: 'candidate-pair',
+        state: 'succeeded',
+        nominated: true,
+        writable: true,
+        requestsSent: 3,
+        responsesReceived: 3,
+        local: {
+          address: '192.168.1.10',
+          port: 5000,
+          candidateType: 'srflx',
+          protocol: 'udp',
+          networkType: 'wifi',
+        },
+        remote: {
+          address: '50.114.148.33',
+          port: 28714,
+          candidateType: 'host',
+          protocol: 'udp',
+        },
+      });
+      expect(interval.transport).toEqual({
+        iceState: 'connected',
+        dtlsState: 'connected',
+        srtpCipher: 'AES_CM_128_HMAC_SHA1_80',
+        tlsVersion: 'FEFD',
+        selectedCandidatePairChanges: 1,
+      });
     });
   });
 });

--- a/package/__tests__/integration-custom-headers.test.ts
+++ b/package/__tests__/integration-custom-headers.test.ts
@@ -34,7 +34,7 @@ describe('Custom Headers Integration Tests', () => {
       expect(message.params.dialogParams.custom_headers).toEqual(customHeaders);
 
       // Verify User-Agent is set
-      expect(message.params['User-Agent']).toMatch(/react-native-/);
+      expect(message.params['User-Agent']).toMatch(/ReactNative-/);
     });
 
     it('should handle empty custom headers', () => {

--- a/package/lib/call-report-collector.ts
+++ b/package/lib/call-report-collector.ts
@@ -10,6 +10,12 @@ import type {
   AudioInboundStats,
   AudioOutboundStats,
   ConnectionStats,
+  IceCandidateInfo,
+  IceCandidatePairStats,
+  LocalAudioSourceStats,
+  LocalAudioTrackSnapshot,
+  TransportStats,
+  CallReportFlushReason,
 } from './call-report-models';
 
 const MAX_STATS_BUFFER = 360; // ~30 min at 5s intervals
@@ -17,6 +23,9 @@ const STATS_FLUSH_THRESHOLD = 300; // ~25 min
 const LOGS_FLUSH_THRESHOLD = 800;
 const MAX_RETRY_ATTEMPTS = 3;
 const RETRY_BASE_DELAY_MS = 1000;
+const INITIAL_COLLECTION_INTERVAL_SECONDS = 1;
+const INITIAL_COLLECTION_DURATION_MS = 10_000;
+const DEFAULT_INTERMEDIATE_REPORT_INTERVAL_MS = 180_000;
 
 function round4(val: number | null | undefined): number | null {
   if (val == null || isNaN(val)) return null;
@@ -28,17 +37,26 @@ export class CallReportCollector {
   private peerConnection: RTCPeerConnectionType | null = null;
   private logCollector: LogCollector;
   private statsBuffer: StatsInterval[] = [];
-  private statsTimer: ReturnType<typeof setInterval> | null = null;
+  private statsTimer: ReturnType<typeof setTimeout> | null = null;
   private intervalStart: Date | null = null;
+  private callStartTime: Date = new Date();
+  private callEndTime: Date | null = null;
   private segmentIndex = 0;
   private isFlushing = false;
   private started = false;
+  private stopped = false;
+  private lastIntermediateFlushTime: Date = this.callStartTime;
+  private lastLocalAudioTrackSnapshotJson: string | null = null;
 
   // Previous values for delta calculations
   private prevOutboundBytes = 0;
   private prevOutboundTimestamp = 0;
   private prevInboundBytes = 0;
   private prevInboundTimestamp = 0;
+  private prevInboundAudioEnergy: number | undefined;
+  private prevInboundSamplesDuration: number | undefined;
+  private prevOutboundAudioEnergy: number | undefined;
+  private prevOutboundSamplesDuration: number | undefined;
 
   // Sample accumulators for interval averages
   private outboundAudioLevels: number[] = [];
@@ -60,7 +78,11 @@ export class CallReportCollector {
   }
 
   /** Log a structured event */
-  log(level: 'debug' | 'info' | 'warn' | 'error', message: string, context?: Record<string, unknown>): void {
+  log(
+    level: 'debug' | 'info' | 'warn' | 'error',
+    message: string,
+    context?: Record<string, unknown>
+  ): void {
     this.logCollector.add(level, message, context);
   }
 
@@ -74,21 +96,29 @@ export class CallReportCollector {
 
     this.peerConnection = peerConnection;
     this.started = true;
+    this.stopped = false;
+    this.callStartTime = new Date();
     this.intervalStart = new Date();
+    this.lastIntermediateFlushTime = this.intervalStart;
 
     log.debug('[CallReportCollector] Starting stats collection');
 
-    this.statsTimer = setInterval(() => {
-      this.collectInterval();
-    }, this.config.callReportInterval * 1000);
+    this.scheduleNextCollection();
   }
 
   /** Stop collection and return final payload */
-  stop(): void {
+  async stop(): Promise<void> {
+    this.stopped = true;
     if (this.statsTimer) {
-      clearInterval(this.statsTimer);
+      clearTimeout(this.statsTimer);
       this.statsTimer = null;
     }
+
+    this.callEndTime = new Date();
+    if (this.peerConnection && this.intervalStart) {
+      await this.collectInterval(true);
+    }
+
     this.started = false;
   }
 
@@ -105,8 +135,11 @@ export class CallReportCollector {
     return payload;
   }
 
-  /** Build an intermediate flush payload (destructively drains buffers) */
-  flush(summary: CallReportSummary): CallReportPayload {
+  /**
+   * Build an intermediate flush payload and destructively drain buffers.
+   * Intermediate summaries are bounded to the flushed segment window.
+   */
+  flush(summary: CallReportSummary, flushReason?: CallReportFlushReason): CallReportPayload {
     const currentSegment = this.segmentIndex;
     this.segmentIndex++;
 
@@ -115,11 +148,20 @@ export class CallReportCollector {
 
     const logs = this.logCollector.drain();
 
+    const now = new Date();
+    this.lastIntermediateFlushTime = now;
+
     return {
-      summary,
+      summary: {
+        ...summary,
+        durationSeconds: (now.getTime() - this.callStartTime.getTime()) / 1000,
+        startTimestamp: this.callStartTime.toISOString(),
+        endTimestamp: now.toISOString(),
+      },
       stats,
       logs,
       segment: currentSegment,
+      ...(flushReason ? { flushReason } : {}),
     };
   }
 
@@ -167,7 +209,34 @@ export class CallReportCollector {
 
   // --- Private ---
 
-  private async collectInterval(): Promise<void> {
+  private scheduleNextCollection(): void {
+    if (this.stopped || !this.peerConnection || !this.intervalStart || this.statsTimer) {
+      return;
+    }
+
+    const intervalSeconds = this.collectionIntervalFor(this.intervalStart);
+    this.statsTimer = setTimeout(() => {
+      this.statsTimer = null;
+      this.collectInterval().finally(() => {
+        this.scheduleNextCollection();
+      });
+    }, intervalSeconds * 1000);
+  }
+
+  private collectionIntervalFor(intervalStart: Date): number {
+    const defaultInterval =
+      typeof this.config.callReportInterval === 'number' && this.config.callReportInterval > 0
+        ? this.config.callReportInterval
+        : 5;
+
+    if (intervalStart.getTime() - this.callStartTime.getTime() < INITIAL_COLLECTION_DURATION_MS) {
+      return Math.min(INITIAL_COLLECTION_INTERVAL_SECONDS, defaultInterval);
+    }
+
+    return defaultInterval;
+  }
+
+  private async collectInterval(isFinal: boolean = false): Promise<void> {
     if (!this.peerConnection) return;
 
     const intervalEnd = new Date();
@@ -177,6 +246,11 @@ export class CallReportCollector {
     try {
       const stats = await (this.peerConnection as any).getStats();
       const interval = this.processStats(stats, intervalStart, intervalEnd);
+
+      const elapsedMs = intervalEnd.getTime() - intervalStart.getTime();
+      if (!isFinal && elapsedMs < this.collectionIntervalFor(intervalStart) * 1000) {
+        return;
+      }
 
       if (this.statsBuffer.length >= MAX_STATS_BUFFER) {
         this.statsBuffer.shift();
@@ -193,6 +267,10 @@ export class CallReportCollector {
     let outbound: AudioOutboundStats | null = null;
     let inbound: AudioInboundStats | null = null;
     let connection: ConnectionStats | null = null;
+    let ice: IceCandidatePairStats | undefined;
+    let transport: TransportStats | undefined;
+    let selectedCandidatePair: any = null;
+    let outboundReport: any = null;
 
     // Accumulate samples during this interval
     const outAudioLevels = this.outboundAudioLevels;
@@ -204,6 +282,7 @@ export class CallReportCollector {
       switch (report.type) {
         case 'outbound-rtp':
           if (report.kind === 'audio') {
+            outboundReport = report;
             const now = report.timestamp;
             const bytes = report.bytesSent ?? 0;
             let bitrateAvg: number | null = null;
@@ -216,11 +295,22 @@ export class CallReportCollector {
             this.prevOutboundBytes = bytes;
             this.prevOutboundTimestamp = now;
 
+            const outboundAudioLevel = this.getOutboundAudioLevel(stats, report);
+            if (outboundAudioLevel != null) {
+              outAudioLevels.push(outboundAudioLevel);
+            }
+
+            const localTrack = this.getLocalAudioTrackSnapshot();
+            const mediaSource = this.getOutboundAudioSourceStats(stats, report);
+            this.logLocalAudioTrackSnapshot(localTrack, mediaSource);
+
             outbound = {
               packetsSent: report.packetsSent ?? 0,
               bytesSent: bytes,
               audioLevelAvg: round4(avg(outAudioLevels)),
               bitrateAvg: round4(bitrateAvg),
+              ...(localTrack ? { localTrack } : {}),
+              ...(mediaSource ? { mediaSource } : {}),
             };
           }
           break;
@@ -240,7 +330,8 @@ export class CallReportCollector {
             this.prevInboundTimestamp = now;
 
             if (report.jitter != null) inJitters.push(report.jitter * 1000); // sec → ms
-            if (report.audioLevel != null) inAudioLevels.push(report.audioLevel);
+            const inboundAudioLevel = this.getInboundAudioLevel(stats, report);
+            if (inboundAudioLevel != null) inAudioLevels.push(inboundAudioLevel);
 
             inbound = {
               packetsReceived: report.packetsReceived ?? 0,
@@ -261,6 +352,7 @@ export class CallReportCollector {
 
         case 'candidate-pair':
           if (report.nominated || report.state === 'succeeded') {
+            selectedCandidatePair = report;
             if (report.currentRoundTripTime != null) {
               rtts.push(report.currentRoundTripTime);
             }
@@ -274,13 +366,34 @@ export class CallReportCollector {
           }
           break;
 
+        case 'transport':
+          transport = this.buildTransportStats(report);
+          break;
+
         case 'media-source':
-          if (report.kind === 'audio' && report.audioLevel != null) {
+          if (!outboundReport && report.kind === 'audio' && report.audioLevel != null) {
             outAudioLevels.push(report.audioLevel);
           }
           break;
       }
     });
+
+    if (selectedCandidatePair) {
+      ice = {
+        id: selectedCandidatePair.id,
+        state: selectedCandidatePair.state,
+        nominated: selectedCandidatePair.nominated,
+        writable: selectedCandidatePair.writable,
+        requestsSent: selectedCandidatePair.requestsSent,
+        responsesReceived: selectedCandidatePair.responsesReceived,
+        ...(this.resolveCandidate(stats, selectedCandidatePair.localCandidateId)
+          ? { local: this.resolveCandidate(stats, selectedCandidatePair.localCandidateId) }
+          : {}),
+        ...(this.resolveCandidate(stats, selectedCandidatePair.remoteCandidateId)
+          ? { remote: this.resolveCandidate(stats, selectedCandidatePair.remoteCandidateId) }
+          : {}),
+      };
+    }
 
     // Clear accumulators for next interval
     this.outboundAudioLevels = [];
@@ -293,18 +406,24 @@ export class CallReportCollector {
       intervalEndUtc: intervalEnd.toISOString(),
       audio: { outbound, inbound },
       connection,
+      ...(ice ? { ice } : {}),
+      ...(transport ? { transport } : {}),
     };
   }
 
   private checkFlushThresholds(): void {
     if (this.isFlushing) return;
+    const now = new Date();
+    const msSinceLastFlush = now.getTime() - this.lastIntermediateFlushTime.getTime();
     if (
       this.statsBuffer.length >= STATS_FLUSH_THRESHOLD ||
-      this.logCollector.count >= LOGS_FLUSH_THRESHOLD
+      this.logCollector.count >= LOGS_FLUSH_THRESHOLD ||
+      msSinceLastFlush >= DEFAULT_INTERMEDIATE_REPORT_INTERVAL_MS
     ) {
       log.debug(
-        `[CallReportCollector] Flush threshold reached (stats: ${this.statsBuffer.length}/${STATS_FLUSH_THRESHOLD}, logs: ${this.logCollector.count}/${LOGS_FLUSH_THRESHOLD})`
+        `[CallReportCollector] Flush threshold reached (stats: ${this.statsBuffer.length}/${STATS_FLUSH_THRESHOLD}, logs: ${this.logCollector.count}/${LOGS_FLUSH_THRESHOLD}, msSinceLastFlush: ${msSinceLastFlush})`
       );
+      this.lastIntermediateFlushTime = now;
       this.isFlushing = true;
       try {
         this.onFlushNeeded?.();
@@ -314,12 +433,220 @@ export class CallReportCollector {
     }
   }
 
+  private resolveCandidate(stats: any, candidateId?: string): IceCandidateInfo | undefined {
+    if (!candidateId) return undefined;
+    const report = typeof stats.get === 'function' ? stats.get(candidateId) : undefined;
+    if (!report) return undefined;
+
+    const info = this.withoutUndefined({
+      address: report.address ?? report.ip,
+      port: report.port,
+      candidateType: report.candidateType,
+      protocol: report.protocol,
+      networkType: report.networkType,
+    });
+
+    return Object.keys(info).length > 0 ? info : undefined;
+  }
+
+  private buildTransportStats(report: any): TransportStats | undefined {
+    const transport = this.withoutUndefined({
+      iceState: report.iceState,
+      dtlsState: report.dtlsState,
+      srtpCipher: report.srtpCipher,
+      tlsVersion: report.tlsVersion,
+      selectedCandidatePairChanges: report.selectedCandidatePairChanges,
+    });
+
+    return Object.keys(transport).length > 0 ? transport : undefined;
+  }
+
+  private getOutboundMediaSource(stats: any, outboundAudio: any): any | undefined {
+    if (outboundAudio.mediaSourceId && typeof stats.get === 'function') {
+      const mediaSource = stats.get(outboundAudio.mediaSourceId);
+      if (mediaSource) return mediaSource;
+    }
+
+    let mediaSource: any | undefined;
+    stats.forEach((report: any) => {
+      if (!mediaSource && report.type === 'media-source' && report.kind === 'audio') {
+        mediaSource = report;
+      }
+    });
+    return mediaSource;
+  }
+
+  private getOutboundAudioSourceStats(
+    stats: any,
+    outboundAudio: any
+  ): LocalAudioSourceStats | undefined {
+    const mediaSource = this.getOutboundMediaSource(stats, outboundAudio);
+    if (!mediaSource) return undefined;
+
+    const snapshot = this.withoutUndefined({
+      id: mediaSource.id,
+      trackIdentifier: mediaSource.trackIdentifier,
+      audioLevel: mediaSource.audioLevel,
+      totalAudioEnergy: mediaSource.totalAudioEnergy,
+      totalSamplesDuration: mediaSource.totalSamplesDuration,
+      echoReturnLoss: mediaSource.echoReturnLoss,
+      echoReturnLossEnhancement: mediaSource.echoReturnLossEnhancement,
+    });
+
+    return Object.keys(snapshot).length > 0 ? snapshot : undefined;
+  }
+
+  private getLocalAudioTrackSnapshot(): LocalAudioTrackSnapshot | undefined {
+    try {
+      const sender = (this.peerConnection as any)
+        ?.getSenders?.()
+        ?.find((item: any) => item.track?.kind === 'audio');
+      const track = sender?.track;
+      if (!track) return undefined;
+
+      const settings = track.getSettings?.();
+      const settingsSnapshot = this.withoutUndefined({
+        deviceId: settings?.deviceId,
+        groupId: settings?.groupId,
+        channelCount: settings?.channelCount,
+        sampleRate: settings?.sampleRate,
+        sampleSize: settings?.sampleSize,
+        latency: settings?.latency,
+        echoCancellation: settings?.echoCancellation,
+        noiseSuppression: settings?.noiseSuppression,
+        autoGainControl: settings?.autoGainControl,
+      });
+
+      const snapshot = this.withoutUndefined({
+        id: track.id,
+        label: track.label,
+        enabled: track.enabled,
+        muted: track.muted,
+        readyState: track.readyState,
+        contentHint: track.contentHint,
+        ...(Object.keys(settingsSnapshot).length > 0 ? { settings: settingsSnapshot } : {}),
+      });
+
+      return Object.keys(snapshot).length > 0 ? snapshot : undefined;
+    } catch (error) {
+      log.debug('[CallReportCollector] Unable to snapshot local audio track:', error);
+      return undefined;
+    }
+  }
+
+  private getOutboundAudioLevel(stats: any, outboundAudio: any): number | null {
+    const mediaSource = this.getOutboundMediaSource(stats, outboundAudio);
+    if (mediaSource?.audioLevel != null) {
+      return mediaSource.audioLevel;
+    }
+
+    if (mediaSource) {
+      const level = this.computeAudioLevelFromEnergy(
+        mediaSource.totalAudioEnergy,
+        mediaSource.totalSamplesDuration,
+        'outbound'
+      );
+      if (level != null) return level;
+    }
+
+    return this.getTrackAudioLevel(stats, outboundAudio.trackId);
+  }
+
+  private getInboundAudioLevel(stats: any, inboundAudio: any): number | null {
+    if (inboundAudio.audioLevel != null) {
+      return inboundAudio.audioLevel;
+    }
+
+    const level = this.computeAudioLevelFromEnergy(
+      inboundAudio.totalAudioEnergy,
+      inboundAudio.totalSamplesDuration,
+      'inbound'
+    );
+    if (level != null) return level;
+
+    return this.getTrackAudioLevel(stats, inboundAudio.trackId);
+  }
+
+  private computeAudioLevelFromEnergy(
+    currentEnergy: number | undefined,
+    currentDuration: number | undefined,
+    direction: 'inbound' | 'outbound'
+  ): number | null {
+    if (currentEnergy == null || currentDuration == null) return null;
+
+    const prevEnergy =
+      direction === 'inbound' ? this.prevInboundAudioEnergy : this.prevOutboundAudioEnergy;
+    const prevDuration =
+      direction === 'inbound' ? this.prevInboundSamplesDuration : this.prevOutboundSamplesDuration;
+
+    if (direction === 'inbound') {
+      this.prevInboundAudioEnergy = currentEnergy;
+      this.prevInboundSamplesDuration = currentDuration;
+    } else {
+      this.prevOutboundAudioEnergy = currentEnergy;
+      this.prevOutboundSamplesDuration = currentDuration;
+    }
+
+    if (prevEnergy == null || prevDuration == null) return null;
+
+    const deltaEnergy = currentEnergy - prevEnergy;
+    const deltaDuration = currentDuration - prevDuration;
+    if (deltaDuration <= 0) return null;
+
+    return Math.min(1, Math.max(0, Math.sqrt(deltaEnergy / deltaDuration)));
+  }
+
+  private getTrackAudioLevel(stats: any, trackId?: string): number | null {
+    if (!trackId || typeof stats.get !== 'function') return null;
+    return stats.get(trackId)?.audioLevel ?? null;
+  }
+
+  private logLocalAudioTrackSnapshot(
+    localAudioTrack?: LocalAudioTrackSnapshot,
+    localAudioSource?: LocalAudioSourceStats
+  ): void {
+    if (!localAudioTrack || Object.keys(localAudioTrack).length === 0) return;
+    const snapshotJson = JSON.stringify(this.sortObjectKeys(localAudioTrack));
+    if (snapshotJson === this.lastLocalAudioTrackSnapshotJson) return;
+
+    this.lastLocalAudioTrackSnapshotJson = snapshotJson;
+    log.debug('[CallReportCollector] Local audio track snapshot', {
+      localTrack: localAudioTrack,
+      mediaSource: localAudioSource,
+    });
+  }
+
+  private withoutUndefined<T extends Record<string, unknown>>(obj: T): T {
+    return Object.keys(obj).reduce<Record<string, unknown>>((clean, key) => {
+      const value = obj[key];
+      if (value !== undefined) {
+        clean[key] = value;
+      }
+      return clean;
+    }, {}) as T;
+  }
+
+  private sortObjectKeys(value: unknown): unknown {
+    if (Array.isArray(value)) {
+      return value.map((item) => this.sortObjectKeys(item));
+    }
+
+    if (value && typeof value === 'object') {
+      return Object.keys(value as Record<string, unknown>)
+        .sort()
+        .reduce<Record<string, unknown>>((sorted, key) => {
+          sorted[key] = this.sortObjectKeys((value as Record<string, unknown>)[key]);
+          return sorted;
+        }, {});
+    }
+
+    return value;
+  }
+
   private buildEndpoint(host: string): string | null {
     try {
       // Convert ws(s) URL to http(s)
-      let httpHost = host
-        .replace(/^wss:\/\//, 'https://')
-        .replace(/^ws:\/\//, 'http://');
+      let httpHost = host.replace(/^wss:\/\//, 'https://').replace(/^ws:\/\//, 'http://');
 
       // If no protocol, default to https
       if (!httpHost.startsWith('http')) {
@@ -389,7 +716,9 @@ export class CallReportCollector {
     }
 
     const delay = RETRY_BASE_DELAY_MS * Math.pow(2, attempt - 1);
-    log.debug(`[CallReportCollector] Retrying in ${delay}ms (attempt ${attempt + 1}/${MAX_RETRY_ATTEMPTS})`);
+    log.debug(
+      `[CallReportCollector] Retrying in ${delay}ms (attempt ${attempt + 1}/${MAX_RETRY_ATTEMPTS})`
+    );
 
     await new Promise((resolve) => setTimeout(resolve, delay));
     await this.executeUpload(endpoint, headers, body, attempt + 1);

--- a/package/lib/call-report-models.ts
+++ b/package/lib/call-report-models.ts
@@ -41,6 +41,8 @@ export interface AudioOutboundStats {
   bytesSent: number;
   audioLevelAvg: number | null;
   bitrateAvg: number | null;
+  localTrack?: LocalAudioTrackSnapshot;
+  mediaSource?: LocalAudioSourceStats;
 }
 
 export interface AudioInboundStats {
@@ -66,6 +68,63 @@ export interface ConnectionStats {
   bytesReceived: number;
 }
 
+export interface LocalAudioTrackSnapshot {
+  id?: string;
+  label?: string;
+  enabled?: boolean;
+  muted?: boolean;
+  readyState?: string;
+  contentHint?: string;
+  settings?: {
+    deviceId?: string;
+    groupId?: string;
+    channelCount?: number;
+    sampleRate?: number;
+    sampleSize?: number;
+    latency?: number;
+    echoCancellation?: boolean;
+    noiseSuppression?: boolean;
+    autoGainControl?: boolean;
+  };
+}
+
+export interface LocalAudioSourceStats {
+  id?: string;
+  trackIdentifier?: string;
+  audioLevel?: number;
+  totalAudioEnergy?: number;
+  totalSamplesDuration?: number;
+  echoReturnLoss?: number;
+  echoReturnLossEnhancement?: number;
+}
+
+export interface IceCandidateInfo {
+  address?: string;
+  port?: number;
+  candidateType?: string;
+  protocol?: string;
+  networkType?: string;
+}
+
+export interface IceCandidatePairStats {
+  id?: string;
+  state?: string;
+  nominated?: boolean;
+  writable?: boolean;
+  local?: IceCandidateInfo;
+  remote?: IceCandidateInfo;
+  requestsSent?: number;
+  responsesReceived?: number;
+}
+
+export interface TransportStats {
+  iceState?: string;
+  dtlsState?: string;
+  srtpCipher?: string;
+  tlsVersion?: string;
+  selectedCandidatePairChanges?: number;
+}
+
 export interface StatsInterval {
   intervalStartUtc: string;
   intervalEndUtc: string;
@@ -74,6 +133,8 @@ export interface StatsInterval {
     inbound: AudioInboundStats | null;
   };
   connection: ConnectionStats | null;
+  ice?: IceCandidatePairStats;
+  transport?: TransportStats;
 }
 
 export interface CallReportLog {
@@ -88,4 +149,16 @@ export interface CallReportPayload {
   stats: StatsInterval[];
   logs: CallReportLog[];
   segment?: number;
+  flushReason?: CallReportFlushReason;
+}
+
+export interface CallReportFlushReason {
+  type: 'buffer-limit' | 'manual' | 'socket-close' | 'socket-error' | 'safety-interval';
+  socketClose?: {
+    code?: number;
+    codeName?: string;
+    reason?: string;
+    wasClean?: boolean;
+    error?: string;
+  };
 }

--- a/package/lib/call.ts
+++ b/package/lib/call.ts
@@ -22,7 +22,11 @@ import {
 import { createAttachMessage } from './messages/attach';
 import { Peer } from './peer';
 import type { TrickleIceCandidate } from './peer';
-import { prepareTrickleSdp, normalizeRemoteCandidateString, cleanCandidateString } from './sdp-utils';
+import {
+  prepareTrickleSdp,
+  normalizeRemoteCandidateString,
+  cleanCandidateString,
+} from './sdp-utils';
 import { WebRTCReporter } from './webrtc-reporter';
 import { CallReportCollector } from './call-report-collector';
 import type { CallReportConfig, CallReportSummary } from './call-report-models';
@@ -203,6 +207,7 @@ export class Call extends EventEmitter<CallEvents> {
   private debugEnabled: boolean = false;
   private callReportCollector: CallReportCollector | null = null;
   private callReportConfig: CallReportConfig;
+  private callReportPostingStarted = false;
   private callStartTimestamp: string;
 
   constructor({
@@ -351,7 +356,9 @@ export class Call extends EventEmitter<CallEvents> {
     log.debug('[Call] Setting state to connecting before answering');
     this.setState('connecting');
 
-    await this.peer.attachLocalStream({ audio: true, video: false }).then((peer) => peer.createAnswer());
+    await this.peer
+      .attachLocalStream({ audio: true, video: false })
+      .then((peer) => peer.createAnswer());
 
     if (!this.isTrickleIceEnabled()) {
       await this.peer.waitForIceGatheringComplete();
@@ -473,7 +480,7 @@ export class Call extends EventEmitter<CallEvents> {
       })
     );
 
-    this.peer?.close();
+    this.closePeerAfterCallReport('done');
     this.setState('ended');
   };
 
@@ -850,16 +857,20 @@ export class Call extends EventEmitter<CallEvents> {
     this.state = state;
 
     // Log state change to call report collector
-    this.callReportCollector?.log('info', 'Call state changed', { state, previousState: prevState });
+    this.callReportCollector?.log('info', 'Call state changed', {
+      state,
+      previousState: prevState,
+    });
 
     // Start stats collection when call becomes active
     if (state === 'active') {
       this.startCallReportCollector();
     }
 
-    // Post call report when call ends
-    if (state === 'ended' || state === 'dropped') {
-      this.stopAndPostCallReport(state === 'dropped' ? 'dropped' : 'done');
+    if (state === 'dropped') {
+      this.stopAndPostCallReport('dropped').catch((err) => {
+        log.error('[Call] Failed to stop and post call report:', err);
+      });
     }
 
     this.emit('telnyx.call.state', this, state);
@@ -946,7 +957,6 @@ export class Call extends EventEmitter<CallEvents> {
     this.telnyxSessionId = msg.params.telnyx_session_id;
   };
 
-
   private handleHangupEvent = (msg: ByeEvent) => {
     log.debug('[Call] Hangup event received', msg);
 
@@ -961,9 +971,8 @@ export class Call extends EventEmitter<CallEvents> {
     // Stop debug stats collection before ending the call
     this.stopDebugStats();
 
+    this.closePeerAfterCallReport('done');
     this.setState('ended');
-
-    this.peer?.close();
   };
 
   // --- Call Report Collector Integration ---
@@ -992,10 +1001,27 @@ export class Call extends EventEmitter<CallEvents> {
     };
   }
 
-  private stopAndPostCallReport(finalState: 'done' | 'dropped'): void {
-    if (!this.callReportCollector) return;
+  private closePeerAfterCallReport(finalState: 'done' | 'dropped'): void {
+    if (!this.callReportCollector) {
+      this.peer?.close();
+      return;
+    }
 
-    this.callReportCollector.stop();
+    this.stopAndPostCallReport(finalState)
+      .catch((err) => {
+        log.error('[Call] Failed to stop and post call report:', err);
+      })
+      .finally(() => {
+        this.peer?.close();
+      });
+  }
+
+  private async stopAndPostCallReport(finalState: 'done' | 'dropped'): Promise<void> {
+    if (!this.callReportCollector) return;
+    if (this.callReportPostingStarted) return;
+    this.callReportPostingStarted = true;
+
+    await this.callReportCollector.stop();
 
     const callReportId = CALL_REPORT_ID;
     if (!callReportId) {
@@ -1006,12 +1032,14 @@ export class Call extends EventEmitter<CallEvents> {
     const summary = this.buildReportSummary(finalState);
     const payload = this.callReportCollector.buildPayload(summary);
 
-    // Fire and forget — don't block call cleanup
-    this.callReportCollector.sendPayload(payload, callReportId, PROD_HOST, VOICE_SDK_ID).catch((err) => {
-      log.error('[Call] Failed to send call report:', err);
-    });
-
-    log.debug('[Call] Posted call report');
+    this.callReportCollector
+      .sendPayload(payload, callReportId, PROD_HOST, VOICE_SDK_ID)
+      .then(() => {
+        log.debug('[Call] Posted call report');
+      })
+      .catch((err) => {
+        log.error('[Call] Failed to send call report:', err);
+      });
   }
 
   private flushIntermediateReport(): void {
@@ -1023,9 +1051,11 @@ export class Call extends EventEmitter<CallEvents> {
     const summary = this.buildReportSummary('active');
     const payload = this.callReportCollector.flush(summary);
 
-    this.callReportCollector.sendPayload(payload, callReportId, PROD_HOST, VOICE_SDK_ID).catch((err) => {
-      log.error('[Call] Failed to send intermediate call report:', err);
-    });
+    this.callReportCollector
+      .sendPayload(payload, callReportId, PROD_HOST, VOICE_SDK_ID)
+      .catch((err) => {
+        log.error('[Call] Failed to send intermediate call report:', err);
+      });
 
     log.debug(`[Call] Flushed intermediate call report segment ${payload.segment}`);
   }

--- a/package/lib/client.ts
+++ b/package/lib/client.ts
@@ -14,7 +14,12 @@ import { setSDKVersion } from './env';
 import { KeepAliveHandler } from './keep-alive-handler';
 import { eventBus } from './legacy-event-bus';
 import { LoginHandler } from './login-handler';
-import type { InviteEvent, AnswerEvent, CandidateEvent, EndOfCandidatesEvent } from './messages/call';
+import type {
+  InviteEvent,
+  AnswerEvent,
+  CandidateEvent,
+  EndOfCandidatesEvent,
+} from './messages/call';
 import {
   isInviteEvent,
   isAnswerEvent,
@@ -229,7 +234,7 @@ export class TelnyxRTC extends EventEmitter<TelnyxRTCEvents> {
    * Access any active call tracked by the SDK.
    * A call will be accessible until it has ended (transitioned to the 'ended' state).
    * This matches the iOS SDK `getCall(callId:)` method.
-   * 
+   *
    * @param callId The unique identifier of a call.
    * @returns The Call object that matches the requested callId, or null if not found.
    * @example
@@ -249,7 +254,7 @@ export class TelnyxRTC extends EventEmitter<TelnyxRTCEvents> {
    * @returns Array of all tracked Call objects
    */
   public getActiveCalls(): Call[] {
-    return Array.from(this.calls.values()).filter(call => call.state !== 'ended');
+    return Array.from(this.calls.values()).filter((call) => call.state !== 'ended');
   }
 
   /**
@@ -1131,9 +1136,7 @@ export class TelnyxRTC extends EventEmitter<TelnyxRTCEvents> {
     }
 
     if (rejectedByPushAction) {
-      log.debug(
-        '[TelnyxRTC] Suppressing telnyx.call.incoming for call rejected via push action'
-      );
+      log.debug('[TelnyxRTC] Suppressing telnyx.call.incoming for call rejected via push action');
       return;
     }
 
@@ -1257,9 +1260,7 @@ export class TelnyxRTC extends EventEmitter<TelnyxRTCEvents> {
         });
       }
     } else {
-      log.debug(
-        '[TelnyxRTC] No call found for callID, storing media event for later processing'
-      );
+      log.debug('[TelnyxRTC] No call found for callID, storing media event for later processing');
       // Media event received before invite - this is valid and expected for early media
     }
 
@@ -1311,12 +1312,20 @@ export class TelnyxRTC extends EventEmitter<TelnyxRTCEvents> {
       // Transition call to active state
       log.debug('[TelnyxRTC] Setting call state to active');
       targetCall.setActive();
-      
+
       // Emit the answer event for applications to handle
       log.debug('[TelnyxRTC] Emitting telnyx.call.answered event');
       this.emit('telnyx.call.answered', targetCall, msg);
     } else {
       log.warn('[TelnyxRTC] No call found for callID in answer event');
+    }
+
+    if (msg.id != null) {
+      this.connection.send({
+        id: msg.id,
+        jsonrpc: '2.0',
+        result: { method: 'telnyx_rtc.answer' },
+      });
     }
 
     log.debug('[TelnyxRTC] ====== CALL ANSWER HANDLING COMPLETE ======');
@@ -1589,9 +1598,12 @@ export class TelnyxRTC extends EventEmitter<TelnyxRTCEvents> {
 
   private getCallReportConfig(): CallReportConfig {
     return {
-      enableCallReports: this.options.enableCallReports ?? DEFAULT_CALL_REPORT_CONFIG.enableCallReports,
-      callReportInterval: this.options.callReportInterval ?? DEFAULT_CALL_REPORT_CONFIG.callReportInterval,
-      callReportLogLevel: this.options.callReportLogLevel ?? DEFAULT_CALL_REPORT_CONFIG.callReportLogLevel,
+      enableCallReports:
+        this.options.enableCallReports ?? DEFAULT_CALL_REPORT_CONFIG.enableCallReports,
+      callReportInterval:
+        this.options.callReportInterval ?? DEFAULT_CALL_REPORT_CONFIG.callReportInterval,
+      callReportLogLevel:
+        this.options.callReportLogLevel ?? DEFAULT_CALL_REPORT_CONFIG.callReportLogLevel,
       callReportMaxLogEntries:
         this.options.callReportMaxLogEntries ?? DEFAULT_CALL_REPORT_CONFIG.callReportMaxLogEntries,
     };


### PR DESCRIPTION
## Summary
- expand React Native call report stats toward the JS SDK collector payload, including initial 1s sampling, final stop collection, ICE/transport snapshots, local audio track/source stats, and timed intermediate flush metadata
- enable call reports in the demo app so mobile test calls send reports by default
- preserve immediate peer close when call reports are disabled and restore answer-event JSON-RPC ACK behavior

## Test plan
- npm test -- --watchman=false --runInBand --silent

## Notes
- The JS SDK reference is team-telnyx/webrtc, packages/js/src/Modules/Verto/webrtc/CallReportCollector.ts.
- Remaining non-1:1 items are warning event surface, fetch keepalive, and JS millisecond interval semantics; RN keeps the existing SDK default with call reports disabled unless enabled by the app.