### PR TITLE
Fix previous tag selection for combined releases

### DIFF
--- a/.github/workflows/release-01-create-pull-request.yml
+++ b/.github/workflows/release-01-create-pull-request.yml
@@ -84,11 +84,11 @@ jobs:
               PATTERN='^commons-sdk-v[0-9]+\.[0-9]+\.[0-9]+'
               ;;
             both)
-              PATTERN='^v[0-9]+\.[0-9]+\.[0-9]+'
+              PATTERN='^(v|voice-sdk-v|commons-sdk-v)[0-9]+\.[0-9]+\.[0-9]+'
               ;;
           esac
 
-          PREVIOUS_TAG="$(git tag --sort=-v:refname | grep -E "$PATTERN" | head -n 1 || true)"
+          PREVIOUS_TAG="$(git for-each-ref --sort=-creatordate --format='%(refname:short)' refs/tags | grep -E "$PATTERN" | head -n 1 || true)"
           echo "previous_tag=$PREVIOUS_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Generate changelog from merged pull requests

--- a/.github/workflows/release-03-create-gh-release.yml
+++ b/.github/workflows/release-03-create-gh-release.yml
@@ -64,7 +64,7 @@ jobs:
             both)
               TAG="v$VERSION"
               PACKAGE_DIR="package react-voice-commons-sdk"
-              PATTERN='^v[0-9]+\.[0-9]+\.[0-9]+'
+              PATTERN='^(v|voice-sdk-v|commons-sdk-v)[0-9]+\.[0-9]+\.[0-9]+'
               ;;
             *)
               echo "::error::Unsupported package: $PACKAGE"
@@ -90,7 +90,7 @@ jobs:
       - name: Find previous release tag
         id: previous_tag
         run: |
-          PREVIOUS_TAG="$(git tag --sort=-v:refname | grep -E "${{ steps.release.outputs.pattern }}" | head -n 1 || true)"
+          PREVIOUS_TAG="$(git for-each-ref --sort=-creatordate --format='%(refname:short)' refs/tags | grep -E "${{ steps.release.outputs.pattern }}" | head -n 1 || true)"
           echo "previous_tag=$PREVIOUS_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Generate changelog from merged pull requests


### PR DESCRIPTION
## Summary
- update combined release workflows to consider shared, voice SDK, and commons SDK tags when finding the previous release tag
- sort matching tags by creator date so the changelog range starts from the most recent relevant package release instead of falling back to the old shared v0.1.9 tag

## Validation
- local tag selection now returns commons-sdk-v0.4.3 before v0.1.9:
  `git for-each-ref --sort=-creatordate --format='%(refname:short)' refs/tags | grep -E '^(v|voice-sdk-v|commons-sdk-v)[0-9]+\.[0-9]+\.[0-9]+' | head`
