### PR TITLE
feat: supersede clientState support for outgoing calls

### DIFF
--- a/react-voice-commons-sdk/src/internal/calls/call-state-controller.ts
+++ b/react-voice-commons-sdk/src/internal/calls/call-state-controller.ts
@@ -139,7 +139,8 @@ export class CallStateController {
     destination: string,
     callerName?: string,
     callerNumber?: string,
-    customHeaders?: Record<string, string>
+    customHeaders?: Record<string, string>,
+    clientState?: string
   ): Promise<Call> {
     if (this._disposed) {
       throw new Error('CallStateController has been disposed');
@@ -156,6 +157,7 @@ export class CallStateController {
         callerIdName: callerName,
         callerIdNumber: callerNumber,
         customHeaders,
+        clientState,
         peerConnectionOptions: {
           useTrickleIce: this._sessionManager.useTrickleIce,
         },

--- a/react-voice-commons-sdk/src/telnyx-voip-client.ts
+++ b/react-voice-commons-sdk/src/telnyx-voip-client.ts
@@ -371,6 +371,7 @@ export class TelnyxVoipClient {
    * @param callerName Optional caller name to display
    * @param callerNumber Optional caller ID number
    * @param customHeaders Optional custom headers to include with the call
+   * @param clientState Optional client state to pass custom data through webhooks
    * @returns A Promise that completes with the Call object once the invitation has been sent
    *
    * The call's state can be monitored through the returned Call object's streams.
@@ -379,7 +380,8 @@ export class TelnyxVoipClient {
     destination: string,
     callerName?: string,
     callerNumber?: string,
-    customHeaders?: Record<string, string>
+    customHeaders?: Record<string, string>,
+    clientState?: string
   ): Promise<Call> {
     this._throwIfDisposed();
 
@@ -399,7 +401,8 @@ export class TelnyxVoipClient {
       destination,
       callerName,
       callerNumber,
-      customHeaders
+      customHeaders,
+      clientState
     );
   }
 


### PR DESCRIPTION
Supersedes #7 without force-pushing to the contributor branch.\n\nWhat changed:\n- Adds optional `clientState` to `TelnyxVoipClient.newCall(...)`\n- Forwards `clientState` through `CallStateController` into Telnyx `CallOptions`\n- Preserves current main's `peerConnectionOptions.useTrickleIce`, which was the merge conflict with #7\n\nValidation:\n- `git diff --check`\n\nThe original PR is stale and now conflicts in `react-voice-commons-sdk/src/internal/calls/call-state-controller.ts`. This keeps the intended clientState behavior while retaining the newer trickle ICE option on main.