### PR TITLE
VSDK-234 Add React Native call stats UI

### DIFF
--- a/components/ActiveCall.tsx
+++ b/components/ActiveCall.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Alert, Modal, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { Alert, Modal, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import {
   Keyboard,
   Mic,
@@ -13,6 +13,8 @@ import {
 } from 'lucide-react-native';
 import { Call, TelnyxCallState, VoicePnBridge } from '../react-voice-commons-sdk/src';
 import { demoColors, radii, sizes, spacing } from './demoTheme';
+
+type CallStatsSnapshot = NonNullable<Call['currentStats']>;
 
 type Props = {
   call: Call;
@@ -30,6 +32,8 @@ export function ActiveCall({ call }: Props) {
   const [isSpeakerOn, setIsSpeakerOn] = useState(false);
   const [duration, setDuration] = useState(call.currentDuration);
   const [showDialpad, setShowDialpad] = useState(false);
+  const [showStats, setShowStats] = useState(false);
+  const [callStats, setCallStats] = useState(call.currentStats);
   const [dtmfDigits, setDtmfDigits] = useState('');
 
   useEffect(() => {
@@ -46,6 +50,15 @@ export function ActiveCall({ call }: Props) {
     VoicePnBridge.isSpeakerEnabled()
       .then(setIsSpeakerOn)
       .catch(() => setIsSpeakerOn(false));
+  }, [call]);
+
+  useEffect(() => {
+    setCallStats(call.currentStats);
+    const statsTimer = setInterval(() => {
+      setCallStats(call.currentStats);
+    }, 1000);
+
+    return () => clearInterval(statsTimer);
   }, [call]);
 
   if (call.currentState !== TelnyxCallState.ACTIVE && call.currentState !== TelnyxCallState.HELD) {
@@ -155,6 +168,15 @@ export function ActiveCall({ call }: Props) {
             disabled={!canDtmf}
             icon={<Keyboard size={24} color={canDtmf ? demoColors.text : demoColors.disabled} />}
           />
+          <CallControl
+            testID="callStats"
+            label="Stats"
+            onPress={() => setShowStats(true)}
+            disabled={!callStats}
+            icon={
+              <Text style={[styles.statsIcon, !callStats && styles.controlTextDisabled]}>ms</Text>
+            }
+          />
         </View>
 
         <TouchableOpacity
@@ -173,6 +195,7 @@ export function ActiveCall({ call }: Props) {
         onKeyPress={handleDtmf}
         onClose={() => setShowDialpad(false)}
       />
+      <CallStatsSheet visible={showStats} stats={callStats} onClose={() => setShowStats(false)} />
     </View>
   );
 }
@@ -257,10 +280,139 @@ function dtmfTestId(digit: string) {
   return `dtmfKey${digit}`;
 }
 
+type CallStatsSheetProps = {
+  visible: boolean;
+  stats: CallStatsSnapshot | null;
+  onClose: () => void;
+};
+
+function CallStatsSheet({ visible, stats, onClose }: CallStatsSheetProps) {
+  return (
+    <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
+      <View style={styles.sheetScrim}>
+        <View style={styles.sheet} testID="callStatsSheet">
+          <View style={styles.sheetHeader}>
+            <Text style={styles.sheetTitle}>Call Stats</Text>
+            <TouchableOpacity
+              style={styles.closeButton}
+              onPress={onClose}
+              testID="callStatsClose"
+              accessibilityLabel="Close call stats"
+            >
+              <X size={24} color={demoColors.text} />
+            </TouchableOpacity>
+          </View>
+
+          {stats ? (
+            <ScrollView style={styles.statsScroll} testID="callStatsContent">
+              <StatsSection title="Connection">
+                <StatsRow
+                  label="RTT"
+                  value={formatSecondsAsMs(stats.connection?.roundTripTimeAvg)}
+                />
+                <StatsRow label="Sent" value={formatCount(stats.connection?.packetsSent)} />
+                <StatsRow label="Received" value={formatCount(stats.connection?.packetsReceived)} />
+              </StatsSection>
+
+              <StatsSection title="Inbound Audio">
+                <StatsRow
+                  label="Packets"
+                  value={formatCount(stats.audio.inbound?.packetsReceived)}
+                />
+                <StatsRow label="Lost" value={formatCount(stats.audio.inbound?.packetsLost)} />
+                <StatsRow label="Jitter" value={formatMs(stats.audio.inbound?.jitterAvg)} />
+                <StatsRow label="Bitrate" value={formatBitrate(stats.audio.inbound?.bitrateAvg)} />
+                <StatsRow
+                  label="Audio Level"
+                  value={formatDecimal(stats.audio.inbound?.audioLevelAvg)}
+                />
+              </StatsSection>
+
+              <StatsSection title="Outbound Audio">
+                <StatsRow label="Packets" value={formatCount(stats.audio.outbound?.packetsSent)} />
+                <StatsRow label="Bitrate" value={formatBitrate(stats.audio.outbound?.bitrateAvg)} />
+                <StatsRow
+                  label="Audio Level"
+                  value={formatDecimal(stats.audio.outbound?.audioLevelAvg)}
+                />
+              </StatsSection>
+
+              <StatsSection title="ICE / Transport">
+                <StatsRow
+                  label="ICE State"
+                  value={stats.transport?.iceState || stats.ice?.state || '—'}
+                />
+                <StatsRow label="DTLS State" value={stats.transport?.dtlsState || '—'} />
+                <StatsRow label="Local Candidate" value={stats.ice?.local?.candidateType || '—'} />
+                <StatsRow
+                  label="Remote Candidate"
+                  value={stats.ice?.remote?.candidateType || '—'}
+                />
+              </StatsSection>
+            </ScrollView>
+          ) : (
+            <Text style={styles.statsEmpty}>
+              Stats will appear after the first collection interval.
+            </Text>
+          )}
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+type StatsSectionProps = {
+  title: string;
+  children: React.ReactNode;
+};
+
+function StatsSection({ title, children }: StatsSectionProps) {
+  return (
+    <View style={styles.statsSection}>
+      <Text style={styles.statsSectionTitle}>{title}</Text>
+      {children}
+    </View>
+  );
+}
+
+function StatsRow({ label, value }: { label: string; value: string }) {
+  return (
+    <View style={styles.statsRow}>
+      <Text style={styles.statsLabel}>{label}</Text>
+      <Text style={styles.statsValue}>{value}</Text>
+    </View>
+  );
+}
+
 function formatDuration(totalSeconds: number) {
   const minutes = Math.floor(totalSeconds / 60);
   const seconds = totalSeconds % 60;
   return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+}
+
+function formatMs(value: number | null | undefined) {
+  if (value == null) return '—';
+  return `${value.toFixed(2)} ms`;
+}
+
+function formatSecondsAsMs(value: number | null | undefined) {
+  if (value == null) return '—';
+  return `${(value * 1000).toFixed(2)} ms`;
+}
+
+function formatBitrate(value: number | null | undefined) {
+  if (value == null) return '—';
+  return `${Math.round(value / 1000)} kbps`;
+}
+
+function formatCount(value: number | null | undefined) {
+  if (value == null) return '—';
+  return value.toLocaleString();
+}
+
+function formatDecimal(value: number | null | undefined) {
+  if (value == null) return '—';
+  return value.toFixed(4);
 }
 
 function showCallActionError(title: string, error: unknown) {
@@ -328,6 +480,11 @@ const styles = StyleSheet.create({
   },
   controlTextDisabled: {
     color: demoColors.disabled,
+  },
+  statsIcon: {
+    color: demoColors.text,
+    fontSize: 16,
+    fontWeight: '700',
   },
   endButton: {
     width: sizes.callButton,
@@ -398,5 +555,41 @@ const styles = StyleSheet.create({
     color: demoColors.text,
     fontSize: 16,
     fontWeight: '500',
+  },
+  statsScroll: {
+    maxHeight: 440,
+  },
+  statsEmpty: {
+    color: demoColors.mutedText,
+    fontSize: 14,
+  },
+  statsSection: {
+    borderBottomWidth: 1,
+    borderBottomColor: demoColors.secondary,
+    paddingBottom: spacing.sm,
+    marginBottom: spacing.sm,
+  },
+  statsSectionTitle: {
+    color: demoColors.text,
+    fontSize: 15,
+    fontWeight: '600',
+    marginBottom: spacing.xs,
+  },
+  statsRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    gap: spacing.sm,
+    paddingVertical: 3,
+  },
+  statsLabel: {
+    color: demoColors.mutedText,
+    fontSize: 13,
+  },
+  statsValue: {
+    color: demoColors.text,
+    flex: 1,
+    fontSize: 13,
+    fontVariant: ['tabular-nums'],
+    textAlign: 'right',
   },
 });

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@rn-primitives/progress": "~1.2.0",
     "@rn-primitives/slot": "^1.2.0",
     "@rn-primitives/tooltip": "~1.2.0",
-    "@telnyx/react-native-voice-sdk": "^0.3.0",
+    "@telnyx/react-native-voice-sdk": "file:./package",
     "@telnyx/react-voice-commons-sdk": "file:react-voice-commons-sdk",
     "@ungap/structured-clone": "^1.3.0",
     "class-variance-authority": "^0.7.1",

--- a/package/lib/call-report-collector.ts
+++ b/package/lib/call-report-collector.ts
@@ -37,6 +37,7 @@ export class CallReportCollector {
   private peerConnection: RTCPeerConnectionType | null = null;
   private logCollector: LogCollector;
   private statsBuffer: StatsInterval[] = [];
+  private latestStatsInterval: StatsInterval | null = null;
   private statsTimer: ReturnType<typeof setTimeout> | null = null;
   private intervalStart: Date | null = null;
   private callStartTime: Date = new Date();
@@ -66,6 +67,11 @@ export class CallReportCollector {
 
   /** Called when intermediate flush is needed (long calls) */
   public onFlushNeeded: (() => void) | null = null;
+
+  /** Most recent stats interval collected for UI/debug surfaces. */
+  get latestInterval(): StatsInterval | null {
+    return this.latestStatsInterval;
+  }
 
   constructor(config: CallReportConfig) {
     this.config = config;
@@ -256,6 +262,7 @@ export class CallReportCollector {
         this.statsBuffer.shift();
       }
       this.statsBuffer.push(interval);
+      this.latestStatsInterval = interval;
 
       this.checkFlushThresholds();
     } catch (err) {

--- a/package/lib/call.ts
+++ b/package/lib/call.ts
@@ -29,7 +29,7 @@ import {
 } from './sdp-utils';
 import { WebRTCReporter } from './webrtc-reporter';
 import { CallReportCollector } from './call-report-collector';
-import type { CallReportConfig, CallReportSummary } from './call-report-models';
+import type { CallReportConfig, CallReportSummary, StatsInterval } from './call-report-models';
 import { DEFAULT_CALL_REPORT_CONFIG } from './call-report-models';
 import { CALL_REPORT_ID, VOICE_SDK_ID } from './global';
 import { PROD_HOST, SDK_VERSION } from './env';
@@ -105,6 +105,19 @@ export class Call extends EventEmitter<CallEvents> {
    * Format should be [{"name": "X-Header-Name", "value": "Value"}] where header names must start with "X-".
    */
   public answerCustomHeaders: { name: string; value: string }[] | null = null;
+
+  /**
+   * Latest WebRTC call stats interval collected for call reports.
+   *
+   * This is intended for demo/debug UI surfaces that want to display the same
+   * real-time packet, bitrate, jitter, RTT, ICE, and transport stats already
+   * collected by the call report pipeline. Returns null until call report
+   * collection has produced its first interval, or when call reports are
+   * disabled for the call.
+   */
+  public getLatestStats(): StatsInterval | null {
+    return this.callReportCollector?.latestInterval ?? null;
+  }
 
   static async createInboundCall({
     connection,

--- a/react-voice-commons-sdk/lib/index.d.ts
+++ b/react-voice-commons-sdk/lib/index.d.ts
@@ -40,6 +40,7 @@ export {
 } from './models/config';
 export type { Config, CredentialConfig, TokenConfig } from './models/config';
 export type { Call as TelnyxCall } from '@telnyx/react-native-voice-sdk';
+export type { StatsInterval } from '@telnyx/react-native-voice-sdk';
 export * from './callkit';
 export { VoicePnBridge } from './internal/voice-pn-bridge';
 export { useAppReadyNotifier } from './hooks/useAppReadyNotifier';

--- a/react-voice-commons-sdk/lib/models/call.d.ts
+++ b/react-voice-commons-sdk/lib/models/call.d.ts
@@ -1,6 +1,7 @@
 import { Observable } from 'rxjs';
 import { TelnyxCallState } from './call-state';
 import { Call as TelnyxCall } from '@telnyx/react-native-voice-sdk';
+import type { StatsInterval } from '@telnyx/react-native-voice-sdk';
 /**
  * Represents a call with reactive state streams.
  *
@@ -72,6 +73,11 @@ export declare class Call {
    * Current call duration in seconds (synchronous access)
    */
   get currentDuration(): number;
+  /**
+   * Latest WebRTC stats interval collected by the underlying SDK call report pipeline.
+   * Returns null until stats collection has produced its first interval.
+   */
+  get currentStats(): StatsInterval | null;
   /**
    * Custom headers received from the WebRTC INVITE message.
    * These headers are passed during call initiation and can contain application-specific information.

--- a/react-voice-commons-sdk/lib/models/call.js
+++ b/react-voice-commons-sdk/lib/models/call.js
@@ -154,6 +154,13 @@ class Call {
     return this._duration.value;
   }
   /**
+   * Latest WebRTC stats interval collected by the underlying SDK call report pipeline.
+   * Returns null until stats collection has produced its first interval.
+   */
+  get currentStats() {
+    return this._telnyxCall.getLatestStats?.() ?? null;
+  }
+  /**
    * Custom headers received from the WebRTC INVITE message.
    * These headers are passed during call initiation and can contain application-specific information.
    * Format should be [{"name": "X-Header-Name", "value": "Value"}] where header names must start with "X-".

--- a/react-voice-commons-sdk/src/index.ts
+++ b/react-voice-commons-sdk/src/index.ts
@@ -51,6 +51,7 @@ export type { Config, CredentialConfig, TokenConfig } from './models/config';
 
 // Re-export useful types from the underlying SDK
 export type { Call as TelnyxCall } from '@telnyx/react-native-voice-sdk';
+export type { StatsInterval } from '@telnyx/react-native-voice-sdk';
 
 // Export CallKit functionality
 export * from './callkit';

--- a/react-voice-commons-sdk/src/models/call.ts
+++ b/react-voice-commons-sdk/src/models/call.ts
@@ -2,6 +2,7 @@ import { BehaviorSubject, Observable } from 'rxjs';
 import { distinctUntilChanged, map } from 'rxjs/operators';
 import { TelnyxCallState, CallStateHelpers } from './call-state';
 import { Call as TelnyxCall } from '@telnyx/react-native-voice-sdk';
+import type { StatsInterval } from '@telnyx/react-native-voice-sdk';
 import { Platform } from 'react-native';
 
 /**
@@ -108,6 +109,14 @@ export class Call {
    */
   get currentDuration(): number {
     return this._duration.value;
+  }
+
+  /**
+   * Latest WebRTC stats interval collected by the underlying SDK call report pipeline.
+   * Returns null until stats collection has produced its first interval.
+   */
+  get currentStats(): StatsInterval | null {
+    return this._telnyxCall.getLatestStats?.() ?? null;
   }
 
   /**

--- a/react-voice-commons-sdk/src/types/telnyx-sdk.d.ts
+++ b/react-voice-commons-sdk/src/types/telnyx-sdk.d.ts
@@ -53,6 +53,57 @@ declare module '@telnyx/react-native-voice-sdk' {
     PURGE = 'purge',
   }
 
+  export interface StatsInterval {
+    intervalStartUtc: string;
+    intervalEndUtc: string;
+    audio: {
+      outbound: {
+        packetsSent: number;
+        bytesSent: number;
+        audioLevelAvg: number | null;
+        bitrateAvg: number | null;
+      } | null;
+      inbound: {
+        packetsReceived: number;
+        bytesReceived: number;
+        packetsLost: number;
+        packetsDiscarded: number;
+        jitterBufferDelay: number | null;
+        jitterBufferEmittedCount: number | null;
+        totalSamplesReceived: number | null;
+        concealedSamples: number | null;
+        concealmentEvents: number | null;
+        audioLevelAvg: number | null;
+        jitterAvg: number | null;
+        bitrateAvg: number | null;
+      } | null;
+    };
+    connection: {
+      roundTripTimeAvg: number | null;
+      packetsSent: number;
+      packetsReceived: number;
+      bytesSent: number;
+      bytesReceived: number;
+    } | null;
+    ice?: {
+      id?: string;
+      state?: string;
+      nominated?: boolean;
+      writable?: boolean;
+      local?: { candidateType?: string; protocol?: string; networkType?: string };
+      remote?: { candidateType?: string; protocol?: string; networkType?: string };
+      requestsSent?: number;
+      responsesReceived?: number;
+    };
+    transport?: {
+      iceState?: string;
+      dtlsState?: string;
+      srtpCipher?: string;
+      tlsVersion?: string;
+      selectedCandidatePairChanges?: number;
+    };
+  }
+
   export class Call extends EventEmitter {
     callId: string;
     state: CallState;
@@ -85,6 +136,7 @@ declare module '@telnyx/react-native-voice-sdk' {
     mute(): Promise<void>;
     unmute(): Promise<void>;
     dtmf(digits: string): Promise<void>;
+    getLatestStats?(): StatsInterval | null;
 
     on(event: string, listener: (...args: any[]) => void): this;
     off(event: string, listener: (...args: any[]) => void): this;


### PR DESCRIPTION
## Summary
- Adds a Stats action to the active call UI.
- Shows call stats in a bottom sheet: RTT, packets, bitrate, jitter, audio levels, ICE/DTLS state, and candidate types.
- Exposes latest collected call-report stats through the call wrapper/model.

Linear: https://linear.app/telnyx/issue/VSDK-234/ui-call-stats-react-native

## Validation
- react-voice-commons-sdk: npm run build ✅
- react-voice-commons-sdk: npm test -- --runInBand ✅, 55 tests passed
- package: npm test -- --runInBand ✅, 128 tests passed
- repo root: npm run quality:check ✅

## Known existing issues
- repo root: npm run security:check reports existing npm audit advisories, including minimatch via @typescript-eslint and Expo/PostCSS/uuid advisories.
- react-voice-commons-sdk: npm run lint fails because the existing lint command uses --ext with the root ESLint flat config, then legacy mode fails to parse TypeScript due parser config.

## Risk
- Demo UI only; does not merge, release, publish, or deploy.
- Needs human review before merge.