### PR TITLE
fix: convert custom headers for RN newCall

### DIFF
--- a/react-voice-commons-sdk/__tests__/internal/calls/call-state-controller.test.ts
+++ b/react-voice-commons-sdk/__tests__/internal/calls/call-state-controller.test.ts
@@ -1,0 +1,51 @@
+import { CallStateController } from '../../../src/internal/calls/call-state-controller';
+
+describe('CallStateController', () => {
+  const createController = (newCall = jest.fn()) => {
+    const sessionManager = {
+      telnyxClient: { newCall },
+      useTrickleIce: true,
+    } as any;
+
+    return new CallStateController(sessionManager);
+  };
+
+  const mockTelnyxCall = () => ({
+    callId: 'call-123',
+    on: jest.fn(),
+    off: jest.fn(),
+  });
+
+  it('converts record custom headers to the SDK array format when creating a call', async () => {
+    const newCall = jest.fn().mockResolvedValue(mockTelnyxCall());
+    const controller = createController(newCall);
+
+    await controller.newCall('15551234567', 'Alice', '15557654321', {
+      'X-Customer-Id': '123',
+      'X-Trace-Id': 'trace-abc',
+    });
+
+    expect(newCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        customHeaders: [
+          { name: 'X-Customer-Id', value: '123' },
+          { name: 'X-Trace-Id', value: 'trace-abc' },
+        ],
+      })
+    );
+  });
+
+  it('preserves array custom headers when creating a call', async () => {
+    const newCall = jest.fn().mockResolvedValue(mockTelnyxCall());
+    const controller = createController(newCall);
+    const customHeaders = [{ name: 'X-Customer-Id', value: '123' }];
+
+    await controller.newCall('15551234567', undefined, undefined, customHeaders);
+
+    expect(newCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        customHeaders,
+      })
+    );
+  });
+});

--- a/react-voice-commons-sdk/lib/internal/calls/call-state-controller.d.ts
+++ b/react-voice-commons-sdk/lib/internal/calls/call-state-controller.d.ts
@@ -1,6 +1,11 @@
 import { Observable } from 'rxjs';
 import { Call } from '../../models/call';
 import { SessionManager } from '../session/session-manager';
+export type CustomHeader = {
+  name: string;
+  value: string;
+};
+export type CustomHeaders = Record<string, string> | CustomHeader[];
 /**
  * Central state machine for call management.
  *
@@ -63,8 +68,12 @@ export declare class CallStateController {
     destination: string,
     callerName?: string,
     callerNumber?: string,
-    customHeaders?: Record<string, string>
+    customHeaders?: CustomHeaders
   ): Promise<Call>;
+  /**
+   * Normalize public custom headers into the format expected by the underlying SDK.
+   */
+  private _normalizeCustomHeaders;
   /**
    * Set callbacks for waiting for invite logic (used for push notifications)
    */

--- a/react-voice-commons-sdk/lib/internal/calls/call-state-controller.js
+++ b/react-voice-commons-sdk/lib/internal/calls/call-state-controller.js
@@ -160,7 +160,7 @@ class CallStateController {
         destinationNumber: destination,
         callerIdName: callerName,
         callerIdNumber: callerNumber,
-        customHeaders,
+        customHeaders: this._normalizeCustomHeaders(customHeaders),
         peerConnectionOptions: {
           useTrickleIce: this._sessionManager.useTrickleIce,
         },
@@ -183,6 +183,18 @@ class CallStateController {
       console.error('Failed to create new call:', error);
       throw error;
     }
+  }
+  /**
+   * Normalize public custom headers into the format expected by the underlying SDK.
+   */
+  _normalizeCustomHeaders(customHeaders) {
+    if (!customHeaders) {
+      return undefined;
+    }
+    if (Array.isArray(customHeaders)) {
+      return customHeaders;
+    }
+    return Object.entries(customHeaders).map(([name, value]) => ({ name, value }));
   }
   /**
    * Set callbacks for waiting for invite logic (used for push notifications)

--- a/react-voice-commons-sdk/lib/telnyx-voip-client.d.ts
+++ b/react-voice-commons-sdk/lib/telnyx-voip-client.d.ts
@@ -2,6 +2,7 @@ import { Observable } from 'rxjs';
 import { TelnyxConnectionState } from './models/connection-state';
 import { Call } from './models/call';
 import { CredentialConfig, TokenConfig } from './models/config';
+import { type CustomHeaders } from './internal/calls/call-state-controller';
 /**
  * Configuration options for TelnyxVoipClient
  */
@@ -161,7 +162,7 @@ export declare class TelnyxVoipClient {
     destination: string,
     callerName?: string,
     callerNumber?: string,
-    customHeaders?: Record<string, string>
+    customHeaders?: CustomHeaders
   ): Promise<Call>;
   /**
    * Handle push notification payload.

--- a/react-voice-commons-sdk/src/internal/calls/call-state-controller.ts
+++ b/react-voice-commons-sdk/src/internal/calls/call-state-controller.ts
@@ -7,6 +7,9 @@ import { SessionManager } from '../session/session-manager';
 import { callKitCoordinator } from '../../callkit/callkit-coordinator';
 import { VoicePnBridge } from '../voice-pn-bridge';
 
+export type CustomHeader = { name: string; value: string };
+export type CustomHeaders = Record<string, string> | CustomHeader[];
+
 /**
  * Central state machine for call management.
  *
@@ -139,7 +142,7 @@ export class CallStateController {
     destination: string,
     callerName?: string,
     callerNumber?: string,
-    customHeaders?: Record<string, string>
+    customHeaders?: CustomHeaders
   ): Promise<Call> {
     if (this._disposed) {
       throw new Error('CallStateController has been disposed');
@@ -155,7 +158,7 @@ export class CallStateController {
         destinationNumber: destination,
         callerIdName: callerName,
         callerIdNumber: callerNumber,
-        customHeaders,
+        customHeaders: this._normalizeCustomHeaders(customHeaders),
         peerConnectionOptions: {
           useTrickleIce: this._sessionManager.useTrickleIce,
         },
@@ -181,6 +184,21 @@ export class CallStateController {
       console.error('Failed to create new call:', error);
       throw error;
     }
+  }
+
+  /**
+   * Normalize public custom headers into the format expected by the underlying SDK.
+   */
+  private _normalizeCustomHeaders(customHeaders?: CustomHeaders): CustomHeader[] | undefined {
+    if (!customHeaders) {
+      return undefined;
+    }
+
+    if (Array.isArray(customHeaders)) {
+      return customHeaders;
+    }
+
+    return Object.entries(customHeaders).map(([name, value]) => ({ name, value }));
   }
 
   /**

--- a/react-voice-commons-sdk/src/telnyx-voip-client.ts
+++ b/react-voice-commons-sdk/src/telnyx-voip-client.ts
@@ -4,7 +4,7 @@ import { Call } from './models/call';
 import { TelnyxCallState } from './models/call-state';
 import { Config, CredentialConfig, TokenConfig, validateConfig } from './models/config';
 import { SessionManager } from './internal/session/session-manager';
-import { CallStateController } from './internal/calls/call-state-controller';
+import { CallStateController, type CustomHeaders } from './internal/calls/call-state-controller';
 import { VoicePnBridge } from './internal/voice-pn-bridge';
 
 const USE_TRICKLE_ICE_STORAGE_KEY = '@use_trickle_ice';
@@ -379,7 +379,7 @@ export class TelnyxVoipClient {
     destination: string,
     callerName?: string,
     callerNumber?: string,
-    customHeaders?: Record<string, string>
+    customHeaders?: CustomHeaders
   ): Promise<Call> {
     this._throwIfDisposed();
 

--- a/react-voice-commons-sdk/src/types/telnyx-sdk.d.ts
+++ b/react-voice-commons-sdk/src/types/telnyx-sdk.d.ts
@@ -9,7 +9,7 @@ declare module '@telnyx/react-native-voice-sdk' {
   export interface CallOptions {
     callerIdName?: string;
     callerIdNumber?: string;
-    customHeaders?: Record<string, string>;
+    customHeaders?: { name: string; value: string }[];
     clientState?: string;
     destinationNumber?: string;
     audio?: boolean;


### PR DESCRIPTION
## Summary
- normalize `newCall()` record custom headers into the `{ name, value }[]` shape expected by `@telnyx/react-native-voice-sdk`
- preserve callers that already pass the SDK array shape
- align local SDK typings and generated lib output

Fixes https://github.com/team-telnyx/react-native-voice-commons/issues/84

## Validation
- `npm run build`
- `npm test -- --runInBand`