### PR TITLE
[VSDK-297]: Use production APNs entitlement for Release iOS demo builds

### DIFF
--- a/ios/telnyxreactnativevoicesdkdemo.entitlements
+++ b/ios/telnyxreactnativevoicesdkdemo.entitlements
@@ -3,6 +3,6 @@
 <plist version="1.0">
   <dict>
     <key>aps-environment</key>
-    <string>development</string>
+    <string>production</string>
   </dict>
 </plist>

--- a/ios/telnyxreactnativevoicesdkdemo.xcodeproj/project.pbxproj
+++ b/ios/telnyxreactnativevoicesdkdemo.xcodeproj/project.pbxproj
@@ -385,7 +385,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_ENTITLEMENTS = telnyxreactnativevoicesdkdemo/telnyxreactnativevoicesdkdemo.entitlements;
+				CODE_SIGN_ENTITLEMENTS = telnyxreactnativevoicesdkdemo.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 46;


### PR DESCRIPTION
Release/TestFlight iOS demo builds were using the same development APNs entitlement as Debug. This keeps Debug on the development entitlement, points Release at the existing root entitlement file, and sets that Release entitlement to `aps-environment = production`.

Signing settings were re-checked during review follow-up. The app target and project use automatic signing (`CODE_SIGN_STYLE = Automatic`) with the existing Apple Development/iPhone Developer identity settings in both Debug and Release. This PR intentionally does not force Release to `Apple Distribution`; distribution signing, archive export, and TestFlight upload should remain controlled by Xcode automatic signing or the release pipeline.

## :older_man: :baby: Behaviors

### Before changes

- Debug and Release target build settings both pointed at `ios/telnyxreactnativevoicesdkdemo/telnyxreactnativevoicesdkdemo.entitlements`.
- Both entitlement files declared `aps-environment = development`.
- Release/TestFlight builds could ship with a sandbox APNs entitlement, causing production APNs to reject device tokens.

### After changes

- Debug continues to use `ios/telnyxreactnativevoicesdkdemo/telnyxreactnativevoicesdkdemo.entitlements` with `aps-environment = development`.
- Release uses `ios/telnyxreactnativevoicesdkdemo.entitlements` with `aps-environment = production`.
- The scheme still archives with the `Release` configuration.
- Release signing remains automatic; no manual distribution identity or provisioning profile is introduced by this fix.

## TODO

- Remaining release gate: produce a signed Release archive/export through the release signing path, upload/install via TestFlight, and verify the app receives a production APNs/VoIP token accepted by production APNs.
- Static plist and `xcodebuild -showBuildSettings` checks are necessary local checks, but they do not satisfy the TestFlight production APNs token acceptance gate.

## ✋ Manual testing

1. Confirm Debug entitlement value:
   ```sh
   plutil -extract aps-environment raw ios/telnyxreactnativevoicesdkdemo/telnyxreactnativevoicesdkdemo.entitlements
   ```
2. Confirm Release entitlement value:
   ```sh
   plutil -extract aps-environment raw ios/telnyxreactnativevoicesdkdemo.entitlements
   ```
3. Confirm Debug build settings:
   ```sh
   xcodebuild -project ios/telnyxreactnativevoicesdkdemo.xcodeproj -scheme telnyxreactnativevoicesdkdemo -configuration Debug -destination generic/platform=iOS -showBuildSettings -json
   ```
4. Confirm Release build and signing settings:
   ```sh
   xcodebuild -workspace ios/telnyxreactnativevoicesdkdemo.xcworkspace -scheme telnyxreactnativevoicesdkdemo -configuration Release -destination generic/platform=iOS -showBuildSettings -json
   ```
5. Release gate, not completed locally: run the signed archive/export path with installed dependencies and Apple signing credentials, then verify on a TestFlight-installed device that VoIP push registration returns a production APNs token accepted by production APNs.

## Known Issues

- Local archive/export validation was not completed in this worktree. `node_modules` and `ios/Pods` are absent, and an archive probe fails before signing because `ios/Pods/Target Support Files/Pods-telnyxreactnativevoicesdkdemo/Pods-telnyxreactnativevoicesdkdemo.release.xcconfig` is missing.
- No TestFlight install or real device VoIP push was exercised locally, so the production APNs token acceptance gate remains open.

## Screenshots

N/A. This is an iOS entitlement/signing configuration fix with no UI changes.

## Application Flow Checklist

Scope for RN-035 is limited to iOS Release/TestFlight APNs entitlement selection.

### 🧪 Logged in with Token

- [ ] **Connection:** Not exercised; unaffected by this configuration-only change.
- [ ] **Notifications:** TestFlight/device push gate still required for production APNs token acceptance.

### 📞 Logged in with SIP Connection

- [ ] **Connection:** Not exercised; unaffected by this configuration-only change.
- [ ] **Notifications:** TestFlight/device push gate still required for production APNs token acceptance.

### 👤 Logged in with genCred

- [ ] **Connection:** Not exercised; unaffected by this configuration-only change.
- [ ] **Notifications:** TestFlight/device push gate still required for production APNs token acceptance.

### 🔁 General Reconnection Scenarios

- [ ] Not exercised; unaffected by this configuration-only change.

### 📊 General Stats Scenarios

- [ ] Not exercised; unaffected by this configuration-only change.
