### PR TITLE
[VSDK-291] Satisfy PushKit watchdog for malformed VoIP pushes

### DIFF
--- a/react-voice-commons-sdk/__tests__/internal/callkit-bridge-ios.test.js
+++ b/react-voice-commons-sdk/__tests__/internal/callkit-bridge-ios.test.js
@@ -51,12 +51,8 @@ function sliceBetween(source, startToken, endToken) {
   return source.slice(start, end + endToken.length);
 }
 
-const reportAndEndWatchdogCall = extractFunction(
-  'fileprivate func reportAndEndWatchdogCall('
-);
-const handleMissedCallPushIfNeeded = extractFunction(
-  'public func handleMissedCallPushIfNeeded('
-);
+const reportAndEndWatchdogCall = extractFunction('fileprivate func reportAndEndWatchdogCall(');
+const handleMissedCallPushIfNeeded = extractFunction('public func handleMissedCallPushIfNeeded(');
 const handleVoipPush = extractFunction('@objc public func handleVoipPush(');
 const answerAction = extractFunction(
   'public func provider(_ provider: CXProvider, perform action: CXAnswerCallAction)'
@@ -91,9 +87,10 @@ describe('iOS CallKitBridge PushKit watchdog handling', () => {
       'return'
     );
     const storeIndex = handleVoipPush.indexOf('UserDefaults.standard.set("incoming_call"');
-    const malformedReturnIndex = handleVoipPush.indexOf('return', handleVoipPush.indexOf(
-      'source: "malformed_push_watchdog"'
-    ));
+    const malformedReturnIndex = handleVoipPush.indexOf(
+      'return',
+      handleVoipPush.indexOf('source: "malformed_push_watchdog"')
+    );
 
     expect(malformedBranch).toContain('reportAndEndWatchdogCall(');
     expect(malformedBranch).toContain('callUUID: UUID()');

--- a/react-voice-commons-sdk/__tests__/internal/callkit-bridge-ios.test.js
+++ b/react-voice-commons-sdk/__tests__/internal/callkit-bridge-ios.test.js
@@ -1,0 +1,149 @@
+const fs = require('fs');
+const path = require('path');
+
+const swiftSource = fs.readFileSync(
+  path.join(__dirname, '..', '..', 'ios', 'CallKitBridge.swift'),
+  'utf8'
+);
+
+function extractFunction(signature) {
+  const start = swiftSource.indexOf(signature);
+  if (start < 0) {
+    throw new Error(`Unable to locate ${signature} in CallKitBridge.swift`);
+  }
+
+  const bodyStart = swiftSource.indexOf('{', start);
+  if (bodyStart < 0) {
+    throw new Error(`Unable to locate body for ${signature}`);
+  }
+
+  let depth = 0;
+  for (let index = bodyStart; index < swiftSource.length; index += 1) {
+    const char = swiftSource[index];
+    if (char === '{') {
+      depth += 1;
+    } else if (char === '}') {
+      depth -= 1;
+      if (depth === 0) {
+        return swiftSource.slice(start, index + 1);
+      }
+    }
+  }
+
+  throw new Error(`Unable to parse body for ${signature}`);
+}
+
+function countOccurrences(source, token) {
+  return (source.match(new RegExp(token, 'g')) || []).length;
+}
+
+function sliceBetween(source, startToken, endToken) {
+  const start = source.indexOf(startToken);
+  if (start < 0) {
+    throw new Error(`Unable to find start token: ${startToken}`);
+  }
+
+  const end = source.indexOf(endToken, start);
+  if (end < 0) {
+    throw new Error(`Unable to find end token after ${startToken}: ${endToken}`);
+  }
+
+  return source.slice(start, end + endToken.length);
+}
+
+const reportAndEndWatchdogCall = extractFunction(
+  'fileprivate func reportAndEndWatchdogCall('
+);
+const handleMissedCallPushIfNeeded = extractFunction(
+  'public func handleMissedCallPushIfNeeded('
+);
+const handleVoipPush = extractFunction('@objc public func handleVoipPush(');
+const answerAction = extractFunction(
+  'public func provider(_ provider: CXProvider, perform action: CXAnswerCallAction)'
+);
+
+describe('iOS CallKitBridge PushKit watchdog handling', () => {
+  it('reports exactly one placeholder call, ends it, cleans state, then completes', () => {
+    expect(countOccurrences(reportAndEndWatchdogCall, 'reportNewIncomingCall')).toBe(1);
+    expect(reportAndEndWatchdogCall).toContain('"watchdogPlaceholder": true');
+
+    const reportIndex = reportAndEndWatchdogCall.indexOf('reportNewIncomingCall');
+    const endIndex = reportAndEndWatchdogCall.indexOf(
+      'reportCall(with: callUUID, endedAt: Date(), reason: endedReason)'
+    );
+    const cleanupIndex = reportAndEndWatchdogCall.indexOf(
+      'activeCalls.removeValue(forKey: callUUID)'
+    );
+    const completionIndex = reportAndEndWatchdogCall.indexOf('completion?()');
+
+    expect(reportIndex).toBeGreaterThanOrEqual(0);
+    expect(endIndex).toBeGreaterThan(reportIndex);
+    expect(cleanupIndex).toBeGreaterThan(endIndex);
+    expect(completionIndex).toBeGreaterThan(cleanupIndex);
+  });
+
+  it('routes malformed or missing call_id through failed placeholder cleanup only', () => {
+    expect(countOccurrences(handleVoipPush, 'reportNewIncomingCall')).toBe(1);
+
+    const malformedBranch = sliceBetween(
+      handleVoipPush,
+      'guard let callIdString = callId, let callUUID = UUID(uuidString: callIdString) else {',
+      'return'
+    );
+    const storeIndex = handleVoipPush.indexOf('UserDefaults.standard.set("incoming_call"');
+    const malformedReturnIndex = handleVoipPush.indexOf('return', handleVoipPush.indexOf(
+      'source: "malformed_push_watchdog"'
+    ));
+
+    expect(malformedBranch).toContain('reportAndEndWatchdogCall(');
+    expect(malformedBranch).toContain('callUUID: UUID()');
+    expect(malformedBranch).toContain('source: "malformed_push_watchdog"');
+    expect(malformedBranch).toContain('endedReason: .failed');
+    expect(malformedBranch).toContain('completion: completion');
+    expect(malformedBranch).not.toContain('UserDefaults.standard.set');
+    expect(malformedBranch).not.toContain('emitCallEvent');
+    expect(storeIndex).toBeGreaterThan(malformedReturnIndex);
+  });
+
+  it('keeps missed-call duplicate suppression behind PushKit report/end satisfaction', () => {
+    expect(countOccurrences(handleMissedCallPushIfNeeded, 'reportNewIncomingCall')).toBe(1);
+
+    const duplicateBranch = sliceBetween(
+      handleMissedCallPushIfNeeded,
+      'if hasProcessedMissedCall(id: missedCallId) {',
+      'return true'
+    );
+    const collisionBranch = sliceBetween(
+      handleMissedCallPushIfNeeded,
+      'guard activeCall["source"] as? String == "missed_call_push" else {',
+      'return true'
+    );
+    const activeBranch = sliceBetween(
+      handleMissedCallPushIfNeeded,
+      'reportAndEndWatchdogCall(\n                    callUUID: UUID(),\n                    callerName: callerName,\n                    callerNumber: callerNumber,\n                    payload: payload,\n                    source: "missed_call_active_watchdog"',
+      'return true'
+    );
+
+    expect(duplicateBranch).toContain('source: "missed_call_duplicate_watchdog"');
+    expect(duplicateBranch).toContain('reportAndEndWatchdogCall(');
+    expect(duplicateBranch).not.toContain('completion?()');
+
+    expect(collisionBranch).toContain('markMissedCallProcessed(id: missedCallId)');
+    expect(collisionBranch).toContain('source: "missed_call_collision_watchdog"');
+    expect(collisionBranch).toContain('reportAndEndWatchdogCall(');
+    expect(collisionBranch).not.toContain('completion?()');
+
+    expect(activeBranch).toContain('reportAndEndWatchdogCall(');
+    expect(activeBranch).toContain('finishMissedCall()');
+  });
+
+  it('fails placeholder answer actions instead of emitting normal RN answer events', () => {
+    const placeholderIndex = answerAction.indexOf('"watchdogPlaceholder"');
+    const failIndex = answerAction.indexOf('action.fail()');
+    const emitIndex = answerAction.indexOf('emitCallEvent');
+
+    expect(placeholderIndex).toBeGreaterThanOrEqual(0);
+    expect(failIndex).toBeGreaterThan(placeholderIndex);
+    expect(emitIndex).toBeGreaterThan(failIndex);
+  });
+});

--- a/react-voice-commons-sdk/ios/CallKitBridge.swift
+++ b/react-voice-commons-sdk/ios/CallKitBridge.swift
@@ -529,18 +529,27 @@ import React
             }
         }
 
-        public func setupSynchronously() {
+        @discardableResult
+        public func setupSynchronously() -> CXProvider {
             // Only initialize once
-            guard callKitProvider == nil else {
+            if let callKitProvider = callKitProvider {
                 NSLog("TelnyxVoice: CallKit already setup, skipping")
-                return
+                return callKitProvider
             }
 
             // CRITICAL: Setup CallKit synchronously for terminated app VoIP push handling
             // This MUST happen in the same run loop as the VoIP push
             NSLog("TelnyxVoice: Synchronous CallKit setup for terminated app scenario...")
             setupCallKit()
+            if let callKitProvider = callKitProvider {
+                NSLog("TelnyxVoice: ✅ CallKit provider ready for terminated app handling")
+                return callKitProvider
+            }
+
+            NSLog("TelnyxVoice: CallKit setup did not create a provider; creating fallback provider")
+            let callKitProvider = installCallKitProvider()
             NSLog("TelnyxVoice: ✅ CallKit provider ready for terminated app handling")
+            return callKitProvider
         }
 
         private func setupAutomatically() {
@@ -571,6 +580,10 @@ import React
                 return
             }
 
+            _ = installCallKitProvider()
+        }
+
+        private func installCallKitProvider() -> CXProvider {
             // Use the localizedName from the app's bundle display name or fallback
             let appName =
                 Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String
@@ -584,14 +597,62 @@ import React
             configuration.supportedHandleTypes = [.phoneNumber, .generic]
             configuration.includesCallsInRecents = true
 
-            callKitProvider = CXProvider(configuration: configuration)
-            callKitProvider?.setDelegate(self, queue: nil)
+            let provider = CXProvider(configuration: configuration)
+            provider.setDelegate(self, queue: nil)
+            callKitProvider = provider
             callKitController = CXCallController()
 
             NSLog("TelnyxVoice: CallKit provider and controller created")
+            return provider
         }
 
-     
+        fileprivate func reportAndEndWatchdogCall(
+            callUUID: UUID,
+            callerName: String,
+            callerNumber: String,
+            payload: [AnyHashable: Any],
+            source: String,
+            endedReason: CXCallEndedReason,
+            completion: (() -> Void)? = nil
+        ) {
+            let callKitProvider = setupSynchronously()
+
+            activeCalls[callUUID] = [
+                "caller": callerName,
+                "handle": callerNumber,
+                "payload": payload,
+                "uuid": callUUID.uuidString,
+                "direction": "incoming",
+                "source": source,
+                "watchdogPlaceholder": true,
+            ]
+
+            let handle = CXHandle(type: .phoneNumber, value: callerNumber)
+            let callUpdate = CXCallUpdate()
+            callUpdate.remoteHandle = handle
+            callUpdate.hasVideo = false
+            callUpdate.localizedCallerName = callerName
+
+            callKitProvider.reportNewIncomingCall(with: callUUID, update: callUpdate) { error in
+                if let error = error {
+                    NSLog(
+                        "TelnyxVoice: Watchdog CallKit report failed for \(source): \(error.localizedDescription)"
+                    )
+                } else {
+                    NSLog("TelnyxVoice: Watchdog CallKit call reported for \(source)")
+                }
+
+                callKitProvider.reportCall(with: callUUID, endedAt: Date(), reason: endedReason)
+                self.activeCalls.removeValue(forKey: callUUID)
+
+                if self.pendingAnswerAction?.callUUID == callUUID {
+                    self.pendingAnswerAction?.fail()
+                    self.pendingAnswerAction = nil
+                }
+
+                completion?()
+            }
+        }
 
         private func observeAppDelegate() {
             // Automatically hook into app lifecycle if needed
@@ -620,22 +681,30 @@ import React
             }
 
             NSLog("TelnyxVoice: Missed call VoIP push received: \(payload)")
-            setupSynchronously()
+            let callKitProvider = setupSynchronously()
 
             let callId = TelnyxMissedCallPush.callId(from: payload)
             let missedCallId = TelnyxMissedCallPush.stableIdentifier(from: payload)
-            if hasProcessedMissedCall(id: missedCallId) {
-                NSLog("TelnyxVoice: Ignoring duplicate missed call push: \(missedCallId)")
-                completion?()
-                return true
-            }
-
             let callUUID = TelnyxMissedCallPush.uuid(from: missedCallId)
             let callerName = TelnyxMissedCallPush.callerName(from: payload)
             let callerNumber = TelnyxMissedCallPush.callerNumber(from: payload)
 
+            if hasProcessedMissedCall(id: missedCallId) {
+                NSLog("TelnyxVoice: Suppressing duplicate missed call notification: \(missedCallId)")
+                reportAndEndWatchdogCall(
+                    callUUID: UUID(),
+                    callerName: callerName,
+                    callerNumber: callerNumber,
+                    payload: payload,
+                    source: "missed_call_duplicate_watchdog",
+                    endedReason: .remoteEnded,
+                    completion: completion
+                )
+                return true
+            }
+
             let finishMissedCall = {
-                self.callKitProvider?.reportCall(with: callUUID, endedAt: Date(), reason: .remoteEnded)
+                callKitProvider.reportCall(with: callUUID, endedAt: Date(), reason: .remoteEnded)
                 self.activeCalls.removeValue(forKey: callUUID)
 
                 if self.pendingAnswerAction?.callUUID == callUUID {
@@ -656,13 +725,30 @@ import React
 
             if let activeCall = activeCalls[callUUID] {
                 guard activeCall["source"] as? String == "missed_call_push" else {
-                    NSLog("TelnyxVoice: Ignoring missed call push because UUID belongs to an active call: \(callUUID)")
+                    NSLog("TelnyxVoice: Suppressing missed call notification because UUID belongs to an active call: \(callUUID)")
                     markMissedCallProcessed(id: missedCallId)
-                    completion?()
+                    reportAndEndWatchdogCall(
+                        callUUID: UUID(),
+                        callerName: callerName,
+                        callerNumber: callerNumber,
+                        payload: payload,
+                        source: "missed_call_collision_watchdog",
+                        endedReason: .remoteEnded,
+                        completion: completion
+                    )
                     return true
                 }
 
-                finishMissedCall()
+                reportAndEndWatchdogCall(
+                    callUUID: UUID(),
+                    callerName: callerName,
+                    callerNumber: callerNumber,
+                    payload: payload,
+                    source: "missed_call_active_watchdog",
+                    endedReason: .remoteEnded
+                ) {
+                    finishMissedCall()
+                }
                 return true
             }
 
@@ -681,9 +767,10 @@ import React
             callUpdate.hasVideo = false
             callUpdate.localizedCallerName = callerName
 
-            callKitProvider?.reportNewIncomingCall(with: callUUID, update: callUpdate) { error in
+            callKitProvider.reportNewIncomingCall(with: callUUID, update: callUpdate) { error in
                 if let error = error {
                     NSLog("TelnyxVoice: Missed call CallKit report failed: \(error.localizedDescription)")
+                    callKitProvider.reportCall(with: callUUID, endedAt: Date(), reason: .failed)
                     self.activeCalls.removeValue(forKey: callUUID)
                     self.clearPendingPushData(for: callId)
                     completion?()
@@ -952,6 +1039,13 @@ import React
             NSLog("📞 TelnyxVoice: CALLKIT ANSWER ACTION - Provider: \(provider), Action: \(action)")
             NSLog("TelnyxVoice: User answered call with UUID: \(action.callUUID)")
 
+            if activeCalls[action.callUUID]?["watchdogPlaceholder"] as? Bool == true {
+                NSLog("TelnyxVoice: Failing answer for watchdog placeholder call: \(action.callUUID)")
+                activeCalls.removeValue(forKey: action.callUUID)
+                action.fail()
+                return
+            }
+
             // Check if this is a programmatic answer (call already answered in WebRTC)
             // vs a user answer from CallKit UI
             if let callData = activeCalls[action.callUUID],
@@ -1132,6 +1226,47 @@ import React
             } catch {
                 NSLog("Failed to activate audio session: \(error)")
             }
+
+            // Extract caller information and call_id from the payload
+            var callerName = "Unknown Caller"
+            var callerNumber = "Unknown"
+            var callId: String?
+
+            if let metadata = payload.dictionaryPayload["metadata"] as? [String: Any] {
+                callerName =
+                    metadata["caller_name"] as? String ?? metadata["caller_number"] as? String
+                    ?? "Unknown Caller"
+                callerNumber = metadata["caller_number"] as? String ?? callerName
+                callId = metadata["call_id"] as? String
+            } else {
+                callerName =
+                    payload.dictionaryPayload["caller"] as? String ?? payload.dictionaryPayload[
+                        "from"] as? String ?? "Unknown Caller"
+                callerNumber = payload.dictionaryPayload["caller_number"] as? String ?? callerName
+                callId = payload.dictionaryPayload["call_id"] as? String
+            }
+
+            // Use call_id as CallKit UUID to ensure matching with WebRTC.
+            guard let callIdString = callId, let callUUID = UUID(uuidString: callIdString) else {
+                NSLog(
+                    "[TelnyxVoipPushHandler] ⚠️ Invalid or missing call_id in payload (\(callId ?? "nil")); reporting failed watchdog placeholder"
+                )
+                TelnyxCallKitManager.shared.reportAndEndWatchdogCall(
+                    callUUID: UUID(),
+                    callerName: callerName,
+                    callerNumber: callerNumber,
+                    payload: payload.dictionaryPayload,
+                    source: "malformed_push_watchdog",
+                    endedReason: .failed,
+                    completion: completion
+                )
+                return
+            }
+
+            NSLog(
+                "[TelnyxVoipPushHandler] Processing call - Call ID as UUID: \(callUUID.uuidString), Caller: \(callerName), Number: \(callerNumber)"
+            )
+
             // Store the VoIP push data for VoicePnBridge
             do {
                 let jsonData = try JSONSerialization.data(withJSONObject: payload.dictionaryPayload)
@@ -1162,38 +1297,6 @@ import React
                 UserDefaults.standard.synchronize()
             }
 
-            // Extract caller information and call_id from the payload
-            var callerName = "Unknown Caller"
-            var callerNumber = "Unknown"
-            var callId: String?
-
-            if let metadata = payload.dictionaryPayload["metadata"] as? [String: Any] {
-                callerName =
-                    metadata["caller_name"] as? String ?? metadata["caller_number"] as? String
-                    ?? "Unknown Caller"
-                callerNumber = metadata["caller_number"] as? String ?? callerName
-                callId = metadata["call_id"] as? String
-            } else {
-                callerName =
-                    payload.dictionaryPayload["caller"] as? String ?? payload.dictionaryPayload[
-                        "from"] as? String ?? "Unknown Caller"
-                callerNumber = payload.dictionaryPayload["caller_number"] as? String ?? callerName
-                callId = payload.dictionaryPayload["call_id"] as? String
-            }
-
-            // Use call_id as CallKit UUID to ensure matching with WebRTC
-            guard let callIdString = callId, let callUUID = UUID(uuidString: callIdString) else {
-                NSLog(
-                    "[TelnyxVoipPushHandler] ❌ No valid call_id found in payload, cannot process call"
-                )
-                completion()
-                return
-            }
-
-            NSLog(
-                "[TelnyxVoipPushHandler] Processing call - Call ID as UUID: \(callUUID.uuidString), Caller: \(callerName), Number: \(callerNumber)"
-            )
-
             // Use unified CallKit handling path that works for both running and terminated app scenarios
             NSLog("[TelnyxVoipPushHandler] Using unified CallKit handling path")
 
@@ -1202,16 +1305,7 @@ import React
 
             // CRITICAL: Setup CallKit SYNCHRONOUSLY - no async dispatch allowed
             // This must happen in the same run loop as the VoIP push
-            callKitManager.setupSynchronously()
-
-            // Ensure we have a valid CallKit provider after setup
-            guard let callKitProvider = callKitManager.callKitProvider else {
-                NSLog(
-                    "[TelnyxVoipPushHandler] ❌ FATAL: CallKit provider not available after synchronous setup!"
-                )
-                completion()
-                return
-            }
+            let callKitProvider = callKitManager.setupSynchronously()
 
             NSLog("[TelnyxVoipPushHandler] ✅ CallKit provider ready, reporting incoming call")
 


### PR DESCRIPTION
# fix(ios): satisfy PushKit watchdog for malformed VoIP pushes

RN-028 fixes the iOS PushKit watchdog paths in `CallKitBridge.swift`. Malformed or missing `call_id` payloads now report a generated placeholder CallKit incoming call, immediately end it as `.failed`, clean local placeholder state, and only then invoke the PushKit completion callback.

The missed-call helper also keeps duplicate notification suppression separate from PushKit satisfaction: duplicate and UUID-collision missed-call pushes now run through a report-then-end watchdog placeholder instead of calling completion directly.

## :older_man: :baby: Behaviors

### Before changes

- Malformed or missing `call_id` values in `TelnyxVoipPushHandler.handleVoipPush` could complete the PushKit callback without a required CallKit report.
- The initial fallback path could store malformed payloads as normal pending RN push data and leave a generated UUID active/answerable.
- Duplicate or colliding missed-call pushes suppressed local notification work by calling completion before any report/end sequence for that consumed VoIP push.

### After changes

- Valid UUID `call_id` values still use the payload UUID for normal CallKit/WebRTC coordination.
- Malformed or missing `call_id` values use a generated placeholder UUID, call `reportNewIncomingCall`, immediately call `reportCall(... reason: .failed)`, remove placeholder state, and then call completion.
- Placeholder answer actions are failed locally and are not emitted as normal React Native answer events.
- Missed-call duplicate/collision paths report and end a placeholder CallKit call before completion while preserving duplicate notification suppression.

## TODO

- Re-run Jest and the iOS sample build after installing `node_modules` and CocoaPods dependencies in this worktree.
- Validate malformed and valid VoIP pushes on a real iOS device; PushKit/CallKit behavior cannot be fully proven on the simulator.

## ✋ Manual testing

1. Not run: real-device PushKit delivery with malformed `call_id`.
2. Not run: real-device PushKit delivery with missing `call_id`.
3. Not run: duplicate missed-call push delivery against an already processed missed-call identifier.

## Automated validation

- PASS: `xcrun swiftc -frontend -parse react-voice-commons-sdk/ios/CallKitBridge.swift`
- PASS: `node --check react-voice-commons-sdk/__tests__/internal/callkit-bridge-ios.test.js`
- PASS: dependency-free Node execution of the static regression test with a minimal Jest shim.
- PASS: `git diff --check`
- BLOCKED: `npm test -- --runTestsByPath __tests__/internal/callkit-bridge-ios.test.js --runInBand` from `react-voice-commons-sdk` failed with `sh: jest: command not found`; this worktree has no installed `node_modules`.
- BLOCKED: `xcodebuild -project ios/telnyxreactnativevoicesdkdemo.xcodeproj -scheme telnyxreactnativevoicesdkdemo -configuration Debug -sdk iphonesimulator -derivedDataPath /private/tmp/RN028DerivedData CODE_SIGNING_ALLOWED=NO build` failed before compilation because `ios/Pods/Target Support Files/Pods-telnyxreactnativevoicesdkdemo/Pods-telnyxreactnativevoicesdkdemo.debug.xcconfig` is missing.

## Known Issues

- No native XCTest harness exists for `CallKitBridge.swift` in this checkout, so regression coverage is source-level/static until the package grows an executable iOS test seam.
- This change does not validate APNs/PushKit behavior on hardware.

## Screenshots

Not applicable.

## Application Flow Checklist

### 🧪 Logged in with Token

- [ ] **Connection:** Establish connection via Token
- [ ] Receive push notification (App Background) -> Reject Call
- [ ] Receive push notification (App Background) -> Accept Call
- [ ] Receive push notification (App Terminated) -> Reject Call
- [ ] Receive push notification (App Terminated) -> Accept Call

### 📞 Logged in with SIP Connection

- [ ] **Connection:** Establish connection via SIP Credential
- [ ] Receive inbound call via push notification
- [ ] Reject inbound push call
- [ ] Accept inbound push call

### 👤 Logged in with genCred

- [ ] **Connection:** Establish connection via genCred
- [ ] Receive inbound call via push notification
- [ ] Reject inbound push call
- [ ] Accept inbound push call
