### PR TITLE
[VSDK-293] Fallback when Android call notifications are unavailable

### DIFF
--- a/react-voice-commons-sdk/android/src/main/java/com/telnyx/react_voice_commons/TelnyxNotificationHelper.kt
+++ b/react-voice-commons-sdk/android/src/main/java/com/telnyx/react_voice_commons/TelnyxNotificationHelper.kt
@@ -1,15 +1,21 @@
 package com.telnyx.react_voice_commons
 
+import android.Manifest
+import android.annotation.SuppressLint
+import android.app.ActivityOptions
 import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
-import android.os.Build
-import androidx.core.app.NotificationCompat
+import android.content.pm.PackageManager
 import android.graphics.Color
+import android.os.Build
 import android.util.Log
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.ContextCompat
 
 /**
  * Helper class for managing Telnyx voice call notifications
@@ -47,6 +53,88 @@ class TelnyxNotificationHelper(private val context: Context) {
 
     init {
         createNotificationChannel()
+    }
+
+    private fun getNotificationBlockReason(): String? {
+        if (
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+            ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED
+        ) {
+            return "POST_NOTIFICATIONS permission is denied"
+        }
+
+        if (!NotificationManagerCompat.from(context).areNotificationsEnabled()) {
+            return "app notifications are disabled"
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = notificationManager.getNotificationChannel(CHANNEL_ID)
+            if (channel?.importance == NotificationManager.IMPORTANCE_NONE) {
+                return "incoming-call notification channel is blocked"
+            }
+
+            val channelGroupId = channel?.group
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && channelGroupId != null) {
+                val channelGroup = notificationManager.getNotificationChannelGroup(channelGroupId)
+                if (channelGroup?.isBlocked == true) {
+                    return "incoming-call notification channel group is blocked"
+                }
+            }
+        }
+
+        return null
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun notifyIfPermitted(notificationId: Int, notification: Notification): String? {
+        val blockReason = getNotificationBlockReason()
+        if (blockReason != null) {
+            Log.w(TAG, "Skipping notification $notificationId because $blockReason")
+            return blockReason
+        }
+
+        notificationManager.notify(notificationId, notification)
+        return null
+    }
+
+    private fun launchFullScreenIntentFallback(
+        notification: Notification,
+        callId: String,
+        metadata: String,
+        blockReason: String,
+    ) {
+        val fullScreenIntent = notification.fullScreenIntent
+        if (fullScreenIntent == null) {
+            Log.w(TAG, "Notifications unavailable ($blockReason); no full-screen fallback available for call: $callId")
+            return
+        }
+
+        try {
+            VoicePnManager.setPendingPushAction(context, "incoming_call", metadata)
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to preserve incoming-call metadata before fallback launch for call: $callId", e)
+        }
+
+        try {
+            sendFullScreenIntent(fullScreenIntent)
+            Log.w(TAG, "Notifications unavailable ($blockReason); launched full-screen incoming call fallback for call: $callId")
+        } catch (e: PendingIntent.CanceledException) {
+            Log.e(TAG, "Notifications unavailable ($blockReason); failed to launch full-screen incoming call fallback for call: $callId", e)
+        } catch (e: RuntimeException) {
+            Log.e(TAG, "Notifications unavailable ($blockReason); background fallback launch failed for call: $callId", e)
+        }
+    }
+
+    private fun sendFullScreenIntent(fullScreenIntent: PendingIntent) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            val options = ActivityOptions.makeBasic().apply {
+                setPendingIntentBackgroundActivityStartMode(ActivityOptions.MODE_BACKGROUND_ACTIVITY_START_ALLOWED)
+            }.toBundle()
+
+            fullScreenIntent.send(context, 0, null, null, null, null, options)
+        } else {
+            fullScreenIntent.send()
+        }
     }
 
     private fun createNotificationChannel() {
@@ -95,7 +183,10 @@ class TelnyxNotificationHelper(private val context: Context) {
         val appIntent = Intent(context, activityClass).apply {
             flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
             putExtra("call_id", callId)
-            putExtra("action", "open_call")
+            putExtra("action", "incoming_call")
+            putExtra("meta_data", metadata)
+            putExtra("caller_name", callerName)
+            putExtra("caller_number", callerNumber)
         }
         val appPendingIntent = PendingIntent.getActivity(
             context, 0, appIntent,
@@ -160,8 +251,12 @@ class TelnyxNotificationHelper(private val context: Context) {
         hideIncomingCallNotification()
         
         val notification = createIncomingCallNotification(callerName, callerNumber, callId,metadata, mainActivityClass)
-        notificationManager.notify(NOTIFICATION_ID, notification)
-        Log.d(TAG, "Showed incoming call notification for: $callerName ($callerNumber)")
+        val blockReason = notifyIfPermitted(NOTIFICATION_ID, notification)
+        if (blockReason == null) {
+            Log.d(TAG, "Showed incoming call notification for: $callerName ($callerNumber)")
+        } else {
+            launchFullScreenIntentFallback(notification, callId, metadata, blockReason)
+        }
     }
 
     fun showMissedCallNotification(
@@ -186,8 +281,12 @@ class TelnyxNotificationHelper(private val context: Context) {
             .setColor(Color.RED)
             .build()
             
-        notificationManager.notify(NOTIFICATION_ID, notification)
-        Log.d(TAG, "Showed missed call notification for: $callerName ($callerNumber)")
+        val blockReason = notifyIfPermitted(NOTIFICATION_ID, notification)
+        if (blockReason == null) {
+            Log.d(TAG, "Showed missed call notification for: $callerName ($callerNumber)")
+        } else {
+            Log.w(TAG, "Skipped missed call notification because $blockReason")
+        }
     }
 
     fun showOngoingCallNotification(
@@ -197,8 +296,12 @@ class TelnyxNotificationHelper(private val context: Context) {
         mainActivityClass: Class<*>? = null
     ) {
         val notification = createOngoingCallNotification(callerName, callerNumber, callId, mainActivityClass)
-        notificationManager.notify(ONGOING_CALL_NOTIFICATION_ID, notification)
-        Log.d(TAG, "Showed ongoing call notification for: $callerName ($callerNumber)")
+        val blockReason = notifyIfPermitted(ONGOING_CALL_NOTIFICATION_ID, notification)
+        if (blockReason == null) {
+            Log.d(TAG, "Showed ongoing call notification for: $callerName ($callerNumber)")
+        } else {
+            Log.w(TAG, "Skipped ongoing call notification because $blockReason")
+        }
     }
 
     /**

--- a/react-voice-commons-sdk/android/src/main/java/com/telnyx/react_voice_commons/TelnyxNotificationHelper.kt
+++ b/react-voice-commons-sdk/android/src/main/java/com/telnyx/react_voice_commons/TelnyxNotificationHelper.kt
@@ -120,8 +120,18 @@ class TelnyxNotificationHelper(private val context: Context) {
             Log.w(TAG, "Notifications unavailable ($blockReason); launched full-screen incoming call fallback for call: $callId")
         } catch (e: PendingIntent.CanceledException) {
             Log.e(TAG, "Notifications unavailable ($blockReason); failed to launch full-screen incoming call fallback for call: $callId", e)
+            clearFallbackPushAction(callId)
         } catch (e: RuntimeException) {
             Log.e(TAG, "Notifications unavailable ($blockReason); background fallback launch failed for call: $callId", e)
+            clearFallbackPushAction(callId)
+        }
+    }
+
+    private fun clearFallbackPushAction(callId: String) {
+        try {
+            VoicePnManager.clearPendingPushAction(context)
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to clear preserved incoming-call metadata after fallback launch failure for call: $callId", e)
         }
     }
 


### PR DESCRIPTION


Adds a broader Android notification delivery gate for incoming, missed, and ongoing call notifications. The gate now treats any of these states as unavailable before calling `NotificationManager.notify(...)`:

- Android 13+ `POST_NOTIFICATIONS` runtime permission denied.
- App-level notifications disabled.
- The Telnyx incoming-call notification channel blocked.
- The incoming-call channel group blocked on API 28+.

When an incoming call cannot be posted, the SDK preserves the original push metadata in `VoicePnManager` and launches the existing full-screen incoming-call pending intent. On Android 14/API 34+, that pending-intent send includes `ActivityOptions.setPendingIntentBackgroundActivityStartMode(ActivityOptions.MODE_BACKGROUND_ACTIVITY_START_ALLOWED)` so targetSdk 34 builds do not keep the direct `PendingIntent.send()` path that can be denied by background activity launch restrictions.

## :older_man: :baby: Behaviors

### Before changes

- Incoming, missed, and ongoing notification posts could call `NotificationManager.notify(...)` even when Android would suppress delivery.
- The RN-037 guard only covered `POST_NOTIFICATIONS`, so app-level disabled notifications or a blocked incoming-call channel could still leave the incoming-call UI unreachable.
- The denied-notification fallback sent the full-screen pending intent directly, which can silently fail under Android 14 background activity launch rules for targetSdk 34.

### After changes

- Every direct `notify(...)` call in `TelnyxNotificationHelper` goes through one notification availability gate.
- Incoming calls fall back when notification delivery is unavailable due to permission, app-level notification settings, channel block, or channel-group block.
- Fallback preserves the incoming push metadata and caller extras so React Native can reconstruct the incoming call and present the answer path.
- Android 14+ fallback pending-intent sends include the required background activity start mode option.
- Missed and ongoing notifications are skipped with a reason when delivery is blocked; they do not attempt a full-screen fallback because there is no incoming call to answer.

## TODO

- Validate on a real Android 14/API 34 device or emulator with targetSdk 34 because background activity launch behavior is platform-enforced.
- Validate on Android 13+ with `POST_NOTIFICATIONS` denied, app notifications disabled, and the `telnyx_voice_calls` channel blocked.

## ✋ Manual testing

1. Install the sample app on an Android 14/API 34 device or emulator with the app targeting SDK 34.
2. Log in with a Telnyx credential that receives inbound calls.
3. With `POST_NOTIFICATIONS` denied, send an incoming Telnyx call while the app is backgrounded and confirm the fallback opens the incoming-call UI with the correct call metadata.
4. Enable `POST_NOTIFICATIONS`, disable app-level notifications in Android settings, repeat the inbound-call background test, and confirm the same fallback.
5. Re-enable app notifications, block the `Telnyx Voice Calls` / `telnyx_voice_calls` channel, repeat the inbound-call background test, and confirm the same fallback.
6. Confirm missed-call and ongoing-call notifications do not crash and log/skip when notifications are blocked.

### Local validation

- `./gradlew :app:compileDebugKotlin` from `android/`: failed during `settings.gradle` evaluation because `node` could not resolve `react-native/package.json`; this isolated worktree has no `node_modules`.
- `./gradlew -p ../react-voice-commons-sdk/android compileDebugKotlin` from `android/`: failed because the standalone SDK Android build does not provide the `com.android.library` plugin classpath.
- Focused Kotlin compile passed: `VoicePnManager.kt` and `TelnyxNotificationHelper.kt` compiled against Android 34 plus cached `androidx.core:core:1.8.0` classes.
- `git diff --check`: passed.
- `rg -n "notificationManager\\.notify|\\.notify\\(" . --glob '*.kt' --glob '*.java'`: only the guarded helper call remains.
- `rg -n "PendingIntent\\.send|\\.send\\(|ActivityOptions|MODE_BACKGROUND_ACTIVITY_START" react-voice-commons-sdk/android/src/main/java/com/telnyx/react_voice_commons/TelnyxNotificationHelper.kt`: API 34 fallback uses `ActivityOptions.MODE_BACKGROUND_ACTIVITY_START_ALLOWED`; no-arg `send()` remains only for pre-34.

## Known Issues

- This worktree does not include `node_modules`, so the full Android Gradle app build cannot be completed locally without dependency installation.
- The fallback can only launch where Android permits background activity starts. API 34 sends now opt in with `ActivityOptions`, but platform validation is still required for OEM-specific behavior.

## Screenshots

N/A. Android notification/settings behavior requires device or emulator validation rather than a static screenshot.

## Application Flow Checklist

### 🧪 Logged in with Token

- [ ] **Connection:** Establish connection via Token

#### Inbound Calls (Receiving as Token user)

- [ ] Receive push notification or fallback incoming-call UI while app is backgrounded and `POST_NOTIFICATIONS` is denied.
- [ ] Receive push notification or fallback incoming-call UI while app-level notifications are disabled.
- [ ] Receive push notification or fallback incoming-call UI while `telnyx_voice_calls` channel is blocked.
- [ ] Accept the fallback incoming call and confirm the call can be answered.
- [ ] Reject the fallback incoming call and confirm the call is dismissed.

### 📞 Logged in with SIP Connection

- [ ] Not run for this scoped fix.

### 👤 Logged in with genCred

- [ ] Not run for this scoped fix.

### 🔁 General Reconnection Scenarios

- [ ] Not run for this scoped fix.

### 📊 General Stats Scenarios

- [ ] Not run for this scoped fix.
