### PR TITLE
[VSDK-292] Pass foreground service type for call service

### DIFF
--- a/react-voice-commons-sdk/android/src/main/java/com/telnyx/react_voice_commons/CallForegroundService.kt
+++ b/react-voice-commons-sdk/android/src/main/java/com/telnyx/react_voice_commons/CallForegroundService.kt
@@ -2,6 +2,8 @@ package com.telnyx.react_voice_commons
 
 import android.app.Service
 import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Build
 import android.os.IBinder
 import android.util.Log
 
@@ -18,6 +20,10 @@ class CallForegroundService : Service() {
         const val EXTRA_CALLER_NAME = "caller_name"
         const val EXTRA_CALLER_NUMBER = "caller_number"
         const val EXTRA_CALL_ID = "call_id"
+
+        private val callForegroundServiceType =
+            ServiceInfo.FOREGROUND_SERVICE_TYPE_PHONE_CALL or
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
     }
 
     override fun onBind(intent: Intent?): IBinder? {
@@ -51,7 +57,15 @@ class CallForegroundService : Service() {
             val notification = notificationHelper.createOngoingCallNotification(callerName, callerNumber, callId)
             
             // Start foreground service with the notification
-            startForeground(TelnyxNotificationHelper.ONGOING_CALL_NOTIFICATION_ID, notification)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                startForeground(
+                    TelnyxNotificationHelper.ONGOING_CALL_NOTIFICATION_ID,
+                    notification,
+                    callForegroundServiceType
+                )
+            } else {
+                startForeground(TelnyxNotificationHelper.ONGOING_CALL_NOTIFICATION_ID, notification)
+            }
             
             Log.d(TAG, "Foreground service started with ongoing call notification")
         } catch (e: Exception) {


### PR DESCRIPTION
# fix(android): pass foreground service type for call service

## Linear VSDK-292 / RN-036 - Android foreground service type

Android 14 enforces foreground service type alignment for target SDK 34 apps. `CallForegroundService` already declares `android:foregroundServiceType="phoneCall|microphone"` in the SDK manifest, and this change makes the runtime `startForeground` call pass the same type mask on API 30+.

## Behaviors

### Before changes

- `CallForegroundService` started its ongoing-call notification with `startForeground(id, notification)`.
- On target SDK 34, Android 14 can throw `MissingForegroundServiceTypeException` during call start because no runtime service type is passed.
- The manifest already declared `phoneCall|microphone`, so the failure was caused by the missing runtime type rather than missing manifest flags.

### After changes

- API 30+ uses `startForeground(id, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_PHONE_CALL | ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE)`.
- API 29 and lower keep the existing two-argument `startForeground` path.
- Runtime service type now matches the manifest declaration and the foreground service permissions:
  - `android.permission.FOREGROUND_SERVICE_PHONE_CALL`
  - `android.permission.FOREGROUND_SERVICE_MICROPHONE`
  - `android:foregroundServiceType="phoneCall|microphone"`

## TODO

- No additional source-code TODOs found during the 2026-06-23 re-inspection.
- Not run / still required: complete real API 34 call-start runtime validation after dependencies are installed and the Android demo app can build.
- Not run / still required: on an API 34 device/emulator, start or answer a call that invokes `CallForegroundService` and verify logcat has no `MissingForegroundServiceTypeException`.

## Manual testing

1. Install JS dependencies in the RN app root so `android/settings.gradle` can resolve `react-native`, `@react-native/gradle-plugin`, `expo`, and `expo-modules-autolinking`.
2. From `android/`, run `./gradlew :app:assembleDebug`.
3. Install the debug app on an API 34 emulator/device.
4. Start or answer a call that starts `CallForegroundService`.
5. Check logcat for `MissingForegroundServiceTypeException` and foreground-service startup failures.

## Validation

- Re-inspected `react-voice-commons-sdk/android/src/main/java/com/telnyx/react_voice_commons/CallForegroundService.kt`: API guard is `Build.VERSION.SDK_INT >= Build.VERSION_CODES.R` before the three-argument overload, with two-argument fallback below API 30.
- Re-inspected `react-voice-commons-sdk/android/src/main/AndroidManifest.xml`: permissions and service type remain aligned with the runtime bitmask.
- `./gradlew :app:assembleDebug --stacktrace` from `android/`: failed during settings evaluation before Android compilation. `node` cannot resolve local JS dependencies because `node_modules` is absent.
- `node --print "require.resolve('@react-native/gradle-plugin/package.json', { paths: [require.resolve('react-native/package.json')] })"` from `android/`: failed with `Cannot find module 'react-native/package.json'`.
- `node --print "require.resolve('expo-modules-autolinking/package.json', { paths: [require.resolve('expo/package.json')] })"` from `android/`: failed with `Cannot find module 'expo/package.json'`.
- `kotlinc react-voice-commons-sdk/android/src/main/java/com/telnyx/react_voice_commons/CallForegroundService.kt /private/tmp/rn036-api34-compile/TelnyxNotificationHelper.kt -classpath /Users/goncalomontespalma/Library/Android/sdk/platforms/android-34/android.jar -d /private/tmp/rn036-api34-compile/call-foreground-service.jar`: passed; only warning was the pre-existing deprecated `stopForeground(true)` call.
- `javap -classpath /private/tmp/rn036-api34-compile/call-foreground-service.jar:/Users/goncalomontespalma/Library/Android/sdk/platforms/android-34/android.jar -c -p com.telnyx.react_voice_commons.CallForegroundService`: passed; confirmed the API 30+ branch calls `startForeground:(ILandroid/app/Notification;I)V` and the generated bitmask is `132`.
- `rg -n "callForegroundServiceType|FOREGROUND_SERVICE_TYPE_(PHONE_CALL|MICROPHONE)|startForeground\\(|foregroundServiceType=\\\"phoneCall\\|microphone\\\"|FOREGROUND_SERVICE_(PHONE_CALL|MICROPHONE)" react-voice-commons-sdk/android/src/main/java/com/telnyx/react_voice_commons/CallForegroundService.kt react-voice-commons-sdk/android/src/main/AndroidManifest.xml`: passed.
- `git diff --check`: passed.
- `adb devices -l` with escalated permission: found `emulator-5554` (`sdk_gphone64_arm64`), but it is API 35, not API 34.
- `adb shell getprop ro.build.version.sdk`: returned `35`.
- `/Users/goncalomontespalma/Library/Android/sdk/emulator/emulator -list-avds`: listed `New_Pixel_9a` and `Pixel_9_Pro_XL_API_35`; AVD configs inspected are `target=android-35`.
- API 34 SDK/platform and system image exist locally, but no configured/running API 34 AVD was found in this worktree validation pass.

## Known Issues

- Real Gradle build is blocked until JS dependencies are installed in the worktree.
- Real API 34 call-start runtime validation is still blocked by the missing app build and lack of a configured/running API 34 AVD.

## Screenshots

Not applicable; Android foreground service runtime behavior change only.

## Application Flow Checklist

- [ ] Not run / still required: API 34 call-start validation for a foreground-service-backed active call.
- [ ] Not run / still required: verify no `MissingForegroundServiceTypeException` when receiving or answering a call on Android 14.
- [ ] Not run / still required: run the broader call-flow checklist from `.github/PULL_REQUEST_TEMPLATE.md` once the demo app builds.
