### PR TITLE
[VSDK-355] Refactor CurrentCall.tsx to use only public SDK API

### DIFF
--- a/components/CurrentCall.tsx
+++ b/components/CurrentCall.tsx
@@ -1,4 +1,4 @@
-import { Call, TelnyxCallState } from '../react-voice-commons-sdk/src';
+import { Call, TelnyxCallState, callKitCoordinator } from '../react-voice-commons-sdk/src';
 import { RingingCall } from './RingingCall';
 import { ActiveCall } from './ActiveCall';
 import { CallConnecting } from './CallConnecting';
@@ -9,10 +9,10 @@ type Props = {
 };
 
 const CurrentCall = ({ call, callState }: Props) => {
-  // Check if this is a push notification call by accessing the underlying Telnyx call's client isCallFromPush flag
-  const isPushNotificationCall = call
-    ? (call as any).telnyxCall?.connection?._client?.isCallFromPush
-    : false;
+  // Use the public callKitCoordinator API to check if the current call originated
+  // from a push notification. This replaces the previous approach of reaching
+  // into SDK internals (call.telnyxCall.connection._client.isCallFromPush).
+  const isPushNotificationCall = call ? callKitCoordinator.getIsCallFromPush() : false;
 
   console.log('CurrentCall: Rendering with', {
     hasCall: !!call,


### PR DESCRIPTION
## VSDK-355 (RN-061) — Demo CurrentCall.tsx reaches into SDK internals

**Linear:** https://linear.app/telnyx/issue/VSDK-355/rn-061-react-native-demo-currentcalltsx-reaches-into-sdk-internals

## Problem
`CurrentCall.tsx` accessed SDK internals through a 4-layer deep chain of private fields:
```ts
(call as any).telnyxCall?.connection?._client?.isCallFromPush
```
This traversed: `Call.telnyxCall` (@internal) → `Call.connection` (private) → `Connection._client` (undocumented) → `TelnyxRTC.isCallFromPush` (private). Required `as any` cast to bypass TypeScript.

## Fix
Replaced with the public `callKitCoordinator.getIsCallFromPush()` API, which is already exported from `react-voice-commons-sdk/src/index.ts` via `export * from './callkit'`.

## API gaps
None — the public API already had the correct method, the demo just wasn't using it.

## Changes
- 1 file: `components/CurrentCall.tsx` (+5, -5 lines)