### PR TITLE
fix: support repeated hold and iOS call waiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ import { createCredentialConfig } from '@telnyx/react-voice-commons-sdk';
 const config = createCredentialConfig('your_sip_username', 'your_sip_password', {
   debug: true,
   pushNotificationDeviceToken: 'your_device_token',
+  pushWhenActive: true,
 });
 
 await voipClient.login(config);
@@ -221,10 +222,13 @@ import { createTokenConfig } from '@telnyx/react-voice-commons-sdk';
 const config = createTokenConfig('your_jwt_token', {
   debug: true,
   pushNotificationDeviceToken: 'your_device_token',
+  pushWhenActive: true,
 });
 
 await voipClient.loginWithToken(config);
 ```
+
+`pushWhenActive` is opt-in and defaults to `false`. Enable it on iOS when the device must receive a second PushKit call while another call is active or held.
 
 ### Automatic Storage & Reconnection
 
@@ -238,6 +242,7 @@ The library uses these AsyncStorage keys internally:
 - `@telnyx_password` - SIP password (credential auth)
 - `@credential_token` - JWT authentication token (token auth)
 - `@push_token` - Push notification device token
+- `@push_when_active` - Whether the device remains eligible for PushKit calls while connected
 
 **Note**: These are managed automatically by the library. You only need to call `login()` once, and the library will handle storage and future reconnections.
 

--- a/components/InlineCallControls.tsx
+++ b/components/InlineCallControls.tsx
@@ -1,43 +1,118 @@
-import React from 'react';
-import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
-import { Phone, PhoneOff } from 'lucide-react-native';
+import React, { useState } from 'react';
+import { Alert, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { ArrowLeftRight, Pause, Phone, PhoneOff, Play } from 'lucide-react-native';
 import { Call, TelnyxCallState } from '../react-voice-commons-sdk/src';
 import { demoColors, radii, spacing } from './demoTheme';
 
 type InlineCallControlsProps = {
   activeCall: Call | null;
+  calls: Call[];
   activeCallState: TelnyxCallState | null;
   destination: string;
   isStartingCall: boolean;
   onAnswer: () => void;
   onEnd: () => void;
+  onSwap: (heldCall: Call) => Promise<void>;
 };
 
 export function InlineCallControls({
   activeCall,
+  calls,
   activeCallState,
   destination,
   isStartingCall,
   onAnswer,
   onEnd,
+  onSwap,
 }: InlineCallControlsProps) {
+  const [isChangingHold, setIsChangingHold] = useState(false);
+  const [swappingCallId, setSwappingCallId] = useState<string | null>(null);
   const showIncomingActions = activeCall?.isIncoming && activeCallState === TelnyxCallState.RINGING;
+  const isOnHold = activeCallState === TelnyxCallState.HELD;
+  const canChangeHold =
+    !!activeCall &&
+    (activeCallState === TelnyxCallState.ACTIVE || activeCallState === TelnyxCallState.HELD);
+  const otherCalls = calls.filter(
+    (call) => call.callId !== activeCall?.callId && isVisibleCallState(call.currentState)
+  );
+  const stateLabel = isStartingCall ? 'Connecting' : callStateLabel(activeCallState);
+
+  const handleHoldChange = async () => {
+    if (!activeCall || !canChangeHold || isChangingHold) return;
+
+    setIsChangingHold(true);
+    try {
+      if (isOnHold) {
+        await activeCall.resume();
+      } else {
+        await activeCall.hold();
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown call-control error';
+      Alert.alert(isOnHold ? 'Resume Failed' : 'Hold Failed', message);
+    } finally {
+      setIsChangingHold(false);
+    }
+  };
+
+  const handleSwap = async (heldCall: Call) => {
+    if (swappingCallId || activeCallState !== TelnyxCallState.ACTIVE) return;
+
+    setSwappingCallId(heldCall.callId);
+    try {
+      await onSwap(heldCall);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown call-swap error';
+      Alert.alert('Swap Failed', message);
+    } finally {
+      setSwappingCallId(null);
+    }
+  };
 
   return (
-    <View style={styles.inlineCallState} testID="callConnectingView">
-      <View style={styles.inlineCallText}>
-        <Text style={styles.inlineCallLabel}>
-          {isStartingCall ? 'Connecting' : callStateLabel(activeCallState)}
+    <View style={[styles.callCard, isOnHold && styles.callCardHeld]} testID="callConnectingView">
+      <View style={styles.callHeader}>
+        <View style={[styles.stateBadge, isOnHold && styles.stateBadgeHeld]}>
+          <View style={[styles.stateDot, isOnHold && styles.stateDotHeld]} />
+          <Text
+            style={[styles.stateBadgeText, isOnHold && styles.stateBadgeTextHeld]}
+            testID="callStateText"
+            accessibilityLiveRegion="assertive"
+          >
+            {stateLabel}
+          </Text>
+        </View>
+        <Text style={styles.callDirection}>{activeCall?.isIncoming ? 'Incoming' : 'Outgoing'}</Text>
+      </View>
+
+      <View style={styles.callIdentity}>
+        <Text style={styles.callTitle}>
+          {isOnHold ? 'Call on hold' : callTitle(activeCallState)}
         </Text>
-        <Text style={styles.inlineCallDestination} numberOfLines={1}>
-          {activeCall?.callerName || activeCall?.callerNumber || destination.trim()}
+        <Text style={styles.callDestination} numberOfLines={1}>
+          {callDisplayName(activeCall, destination)}
         </Text>
       </View>
 
+      {isOnHold && (
+        <View
+          style={styles.heldNotice}
+          testID="heldIndicator"
+          accessibilityRole="text"
+          accessibilityLiveRegion="assertive"
+        >
+          <Pause size={18} color={demoColors.selectedGreen} pointerEvents="none" />
+          <View style={styles.heldNoticeText}>
+            <Text style={styles.heldNoticeTitle}>This call is on hold</Text>
+            <Text style={styles.heldNoticeDescription}>Tap Resume to return to the call.</Text>
+          </View>
+        </View>
+      )}
+
       {showIncomingActions ? (
-        <View style={styles.inlineCallActions}>
+        <View style={styles.callActions}>
           <TouchableOpacity
-            style={styles.inlineEndButton}
+            style={[styles.actionButton, styles.endButton]}
             onPress={onEnd}
             testID="callReject"
             accessibilityRole="button"
@@ -45,10 +120,10 @@ export function InlineCallControls({
             activeOpacity={0.75}
           >
             <PhoneOff size={20} color={demoColors.white} pointerEvents="none" />
-            <Text style={styles.callActionText}>Reject</Text>
+            <Text style={styles.lightActionText}>Reject</Text>
           </TouchableOpacity>
           <TouchableOpacity
-            style={styles.inlineAnswerButton}
+            style={[styles.actionButton, styles.answerButton]}
             onPress={onAnswer}
             testID="callAnswer"
             accessibilityRole="button"
@@ -56,23 +131,122 @@ export function InlineCallControls({
             activeOpacity={0.75}
           >
             <Phone size={20} color={demoColors.text} pointerEvents="none" />
-            <Text style={styles.answerActionText}>Answer</Text>
+            <Text style={styles.darkActionText}>Answer</Text>
           </TouchableOpacity>
         </View>
       ) : (
-        <TouchableOpacity
-          style={styles.inlineEndButton}
-          onPress={onEnd}
-          testID="hangupButton"
-          accessibilityRole="button"
-          accessibilityLabel="End"
-          activeOpacity={0.75}
-        >
-          <PhoneOff size={20} color={demoColors.white} pointerEvents="none" />
-          <Text style={styles.callActionText}>Hangup</Text>
-        </TouchableOpacity>
+        <View style={styles.callActions}>
+          {canChangeHold && (
+            <TouchableOpacity
+              style={[styles.actionButton, styles.holdButton, isChangingHold && styles.disabled]}
+              onPress={handleHoldChange}
+              disabled={isChangingHold}
+              testID="holdButton"
+              accessibilityRole="button"
+              accessibilityLabel={isOnHold ? 'Resume call' : 'Hold call'}
+              accessibilityState={{ disabled: isChangingHold }}
+              activeOpacity={0.75}
+            >
+              {isOnHold ? (
+                <Play size={20} color={demoColors.text} pointerEvents="none" />
+              ) : (
+                <Pause size={20} color={demoColors.text} pointerEvents="none" />
+              )}
+              <Text style={styles.darkActionText}>
+                {isChangingHold
+                  ? isOnHold
+                    ? 'Resuming…'
+                    : 'Holding…'
+                  : isOnHold
+                    ? 'Resume'
+                    : 'Hold'}
+              </Text>
+            </TouchableOpacity>
+          )}
+          <TouchableOpacity
+            style={[styles.actionButton, styles.endButton]}
+            onPress={onEnd}
+            testID="hangupButton"
+            accessibilityRole="button"
+            accessibilityLabel="End call"
+            activeOpacity={0.75}
+          >
+            <PhoneOff size={20} color={demoColors.white} pointerEvents="none" />
+            <Text style={styles.lightActionText}>Hangup</Text>
+          </TouchableOpacity>
+        </View>
+      )}
+
+      {otherCalls.length > 0 && (
+        <View style={styles.otherCalls} testID="otherCallsStatus">
+          <Text style={styles.otherCallsHeading}>Other calls</Text>
+          {otherCalls.map((call) => {
+            const held = call.currentState === TelnyxCallState.HELD;
+            return (
+              <View key={call.callId} style={[styles.otherCall, held && styles.otherCallHeld]}>
+                <View style={[styles.otherCallDot, held && styles.otherCallDotHeld]} />
+                <View style={styles.otherCallIdentity}>
+                  <Text style={styles.otherCallName} numberOfLines={1}>
+                    {callDisplayName(call, '')}
+                  </Text>
+                  <Text style={[styles.otherCallState, held && styles.otherCallStateHeld]}>
+                    {held ? 'On hold' : callStateLabel(call.currentState)}
+                  </Text>
+                </View>
+                {held && activeCallState === TelnyxCallState.ACTIVE && (
+                  <TouchableOpacity
+                    style={[styles.swapButton, swappingCallId && styles.disabled]}
+                    onPress={() => handleSwap(call)}
+                    disabled={swappingCallId !== null}
+                    testID={`swapCall-${call.callId}`}
+                    accessibilityRole="button"
+                    accessibilityLabel={`Swap to ${callDisplayName(call, 'held call')}`}
+                    activeOpacity={0.75}
+                  >
+                    <ArrowLeftRight size={16} color={demoColors.text} pointerEvents="none" />
+                    <Text style={styles.swapButtonText}>
+                      {swappingCallId === call.callId ? 'Swapping…' : 'Swap'}
+                    </Text>
+                  </TouchableOpacity>
+                )}
+              </View>
+            );
+          })}
+        </View>
       )}
     </View>
+  );
+}
+
+function callDisplayName(call: Call | null, fallback: string) {
+  return (
+    call?.callerName || call?.callerNumber || call?.destination || fallback.trim() || 'Unknown'
+  );
+}
+
+function callTitle(callState: TelnyxCallState | null) {
+  switch (callState) {
+    case TelnyxCallState.ACTIVE:
+      return 'Call active';
+    case TelnyxCallState.RINGING:
+      return 'Incoming call';
+    case TelnyxCallState.CONNECTING:
+      return 'Connecting call';
+    case TelnyxCallState.DROPPED:
+      return 'Call interrupted';
+    case TelnyxCallState.FAILED:
+      return 'Call failed';
+    default:
+      return 'Call';
+  }
+}
+
+function isVisibleCallState(callState: TelnyxCallState) {
+  return (
+    callState === TelnyxCallState.RINGING ||
+    callState === TelnyxCallState.CONNECTING ||
+    callState === TelnyxCallState.ACTIVE ||
+    callState === TelnyxCallState.HELD
   );
 }
 
@@ -97,40 +271,101 @@ function callStateLabel(callState: TelnyxCallState | null) {
 }
 
 const styles = StyleSheet.create({
-  inlineCallState: {
+  callCard: {
     width: '100%',
-    minHeight: 64,
-    borderWidth: 1,
-    borderColor: demoColors.outline,
+    borderWidth: 2,
+    borderColor: demoColors.selectedGreen,
     borderRadius: radii.md,
-    paddingHorizontal: spacing.md,
-    paddingVertical: spacing.sm,
+    padding: spacing.md,
+    gap: spacing.md,
+    backgroundColor: demoColors.white,
+  },
+  callCardHeld: {
+    borderColor: demoColors.selectedGreen,
+    backgroundColor: demoColors.secondarySurface,
+  },
+  callHeader: {
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
+  },
+  stateBadge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xs,
+    borderRadius: radii.pill,
+    backgroundColor: demoColors.selectedGreen,
+  },
+  stateBadgeHeld: {
+    backgroundColor: demoColors.secondary,
+  },
+  stateDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
     backgroundColor: demoColors.white,
   },
-  inlineCallText: {
-    flex: 1,
-    marginRight: spacing.md,
+  stateDotHeld: {
+    backgroundColor: demoColors.selectedGreen,
   },
-  inlineCallLabel: {
+  stateBadgeText: {
+    color: demoColors.white,
+    fontSize: 13,
+    fontWeight: '700',
+    textTransform: 'uppercase',
+  },
+  stateBadgeTextHeld: {
+    color: demoColors.selectedGreen,
+  },
+  callDirection: {
     color: demoColors.mutedText,
-    fontSize: 14,
-    marginBottom: 2,
+    fontSize: 13,
   },
-  inlineCallDestination: {
+  callIdentity: {
+    gap: 3,
+  },
+  callTitle: {
     color: demoColors.text,
-    fontSize: 16,
-    fontWeight: '500',
+    fontSize: 22,
+    fontWeight: '700',
   },
-  inlineCallActions: {
+  callDestination: {
+    color: demoColors.mutedText,
+    fontSize: 16,
+  },
+  heldNotice: {
     flexDirection: 'row',
     alignItems: 'center',
-    gap: spacing.xs,
+    gap: spacing.sm,
+    borderWidth: 1,
+    borderColor: demoColors.selectedGreen,
+    borderRadius: radii.md,
+    padding: spacing.sm,
+    backgroundColor: demoColors.white,
   },
-  inlineEndButton: {
-    minWidth: 104,
+  heldNoticeText: {
+    flex: 1,
+  },
+  heldNoticeTitle: {
+    color: demoColors.selectedGreen,
+    fontSize: 15,
+    fontWeight: '700',
+  },
+  heldNoticeDescription: {
+    color: demoColors.mutedText,
+    fontSize: 13,
+    marginTop: 2,
+  },
+  callActions: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+  },
+  actionButton: {
+    flex: 1,
+    minWidth: 112,
     height: 48,
     borderRadius: radii.pill,
     flexDirection: 'row',
@@ -138,27 +373,97 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     gap: spacing.xs,
     paddingHorizontal: spacing.md,
+  },
+  endButton: {
     backgroundColor: demoColors.danger,
   },
-  inlineAnswerButton: {
-    minWidth: 104,
-    height: 48,
-    borderRadius: radii.pill,
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: spacing.xs,
-    paddingHorizontal: spacing.md,
+  answerButton: {
     backgroundColor: demoColors.telnyxGreen,
   },
-  callActionText: {
+  holdButton: {
+    borderWidth: 1,
+    borderColor: demoColors.outline,
+    backgroundColor: demoColors.secondary,
+  },
+  disabled: {
+    opacity: 0.5,
+  },
+  lightActionText: {
     color: demoColors.white,
     fontSize: 15,
     fontWeight: '700',
   },
-  answerActionText: {
+  darkActionText: {
     color: demoColors.text,
     fontSize: 15,
+    fontWeight: '700',
+  },
+  otherCalls: {
+    borderTopWidth: 1,
+    borderTopColor: demoColors.outline,
+    paddingTop: spacing.sm,
+    gap: spacing.xs,
+  },
+  otherCallsHeading: {
+    color: demoColors.mutedText,
+    fontSize: 13,
+    fontWeight: '700',
+    textTransform: 'uppercase',
+  },
+  otherCall: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    padding: spacing.sm,
+    borderRadius: radii.md,
+    backgroundColor: demoColors.secondarySurface,
+  },
+  otherCallHeld: {
+    borderWidth: 1,
+    borderColor: demoColors.selectedGreen,
+  },
+  otherCallDot: {
+    width: 10,
+    height: 10,
+    borderRadius: 5,
+    backgroundColor: demoColors.ringing,
+  },
+  otherCallDotHeld: {
+    backgroundColor: demoColors.selectedGreen,
+  },
+  otherCallIdentity: {
+    flex: 1,
+  },
+  otherCallName: {
+    color: demoColors.text,
+    fontSize: 15,
+    fontWeight: '500',
+  },
+  otherCallState: {
+    color: demoColors.mutedText,
+    fontSize: 13,
+    marginTop: 2,
+  },
+  otherCallStateHeld: {
+    color: demoColors.selectedGreen,
+    fontWeight: '700',
+  },
+  swapButton: {
+    minWidth: 88,
+    height: 38,
+    borderWidth: 1,
+    borderColor: demoColors.outline,
+    borderRadius: radii.pill,
+    backgroundColor: demoColors.secondary,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing.xs,
+    paddingHorizontal: spacing.sm,
+  },
+  swapButtonText: {
+    color: demoColors.text,
+    fontSize: 14,
     fontWeight: '700',
   },
 });

--- a/components/TelnyxDialer.tsx
+++ b/components/TelnyxDialer.tsx
@@ -36,6 +36,7 @@ export const TelnyxDialer: React.FC<TelnyxDialerProps> = ({ debug = false }) => 
   const [callerIdName, setCallerIdName] = useState('');
   const [callerIdNumber, setCallerIdNumber] = useState('');
   const [connectionState, setConnectionState] = useState(voipClient.currentConnectionState);
+  const [calls, setCalls] = useState<Call[]>(voipClient.currentCalls);
   const [activeCall, setActiveCall] = useState<Call | null>(voipClient.currentActiveCall);
   const [activeCallState, setActiveCallState] = useState<TelnyxCallState | null>(
     voipClient.currentActiveCall?.currentState || null
@@ -60,6 +61,12 @@ export const TelnyxDialer: React.FC<TelnyxDialerProps> = ({ debug = false }) => 
     loadProfile();
     return () => connectionSubscription.unsubscribe();
   }, [voipClient, log]);
+
+  useEffect(() => {
+    const callsSubscription = voipClient.calls$.subscribe(setCalls);
+
+    return () => callsSubscription.unsubscribe();
+  }, [voipClient]);
 
   useEffect(() => {
     const activeCallSubscription = voipClient.activeCall$.subscribe((call) => {
@@ -216,63 +223,72 @@ export const TelnyxDialer: React.FC<TelnyxDialerProps> = ({ debug = false }) => 
           </View>
         </View>
 
-        <View style={styles.segmentedControl}>
-          <TouchableOpacity
-            style={[styles.segment, destinationType === 'sip' && styles.segmentSelected]}
-            onPress={() => setDestinationType('sip')}
-            disabled={!isConnected}
-            testID="sipAddressToggle"
-            accessibilityLabel="SIP address"
-          >
-            <Text
-              style={[styles.segmentText, destinationType === 'sip' && styles.segmentTextSelected]}
+        {!isStartingCall && !activeCall && (
+          <View style={styles.segmentedControl}>
+            <TouchableOpacity
+              style={[styles.segment, destinationType === 'sip' && styles.segmentSelected]}
+              onPress={() => setDestinationType('sip')}
+              disabled={!isConnected}
+              testID="sipAddressToggle"
+              accessibilityLabel="SIP address"
             >
-              SIP address
-            </Text>
-          </TouchableOpacity>
-          <TouchableOpacity
-            style={[styles.segment, destinationType === 'phone' && styles.segmentSelected]}
-            onPress={() => setDestinationType('phone')}
-            disabled={!isConnected}
-            testID="phoneNumberToggle"
-            accessibilityLabel="Phone number"
-          >
-            <Text
-              style={[
-                styles.segmentText,
-                destinationType === 'phone' && styles.segmentTextSelected,
-              ]}
+              <Text
+                style={[
+                  styles.segmentText,
+                  destinationType === 'sip' && styles.segmentTextSelected,
+                ]}
+              >
+                SIP address
+              </Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={[styles.segment, destinationType === 'phone' && styles.segmentSelected]}
+              onPress={() => setDestinationType('phone')}
+              disabled={!isConnected}
+              testID="phoneNumberToggle"
+              accessibilityLabel="Phone number"
             >
-              Phone number
-            </Text>
-          </TouchableOpacity>
-        </View>
+              <Text
+                style={[
+                  styles.segmentText,
+                  destinationType === 'phone' && styles.segmentTextSelected,
+                ]}
+              >
+                Phone number
+              </Text>
+            </TouchableOpacity>
+          </View>
+        )}
 
-        <TextInput
-          style={[styles.callInput, inputFocused && styles.inputFocused]}
-          placeholder={destinationType === 'phone' ? 'Enter phone number' : 'Enter SIP address'}
-          placeholderTextColor="gray"
-          value={destinationNumber}
-          onChangeText={setDestinationNumber}
-          onFocus={() => setInputFocused(true)}
-          onBlur={() => setInputFocused(false)}
-          keyboardType={destinationType === 'phone' ? 'phone-pad' : 'default'}
-          autoCapitalize="none"
-          autoCorrect={false}
-          editable={isConnected}
-          testID="numberToCallTextField"
-          accessibilityLabel="Call input"
-        />
+        {!isStartingCall && !activeCall && (
+          <TextInput
+            style={[styles.callInput, inputFocused && styles.inputFocused]}
+            placeholder={destinationType === 'phone' ? 'Enter phone number' : 'Enter SIP address'}
+            placeholderTextColor="gray"
+            value={destinationNumber}
+            onChangeText={setDestinationNumber}
+            onFocus={() => setInputFocused(true)}
+            onBlur={() => setInputFocused(false)}
+            keyboardType={destinationType === 'phone' ? 'phone-pad' : 'default'}
+            autoCapitalize="none"
+            autoCorrect={false}
+            editable={isConnected}
+            testID="numberToCallTextField"
+            accessibilityLabel="Call input"
+          />
+        )}
 
         <View style={styles.actions}>
           {isStartingCall || activeCall ? (
             <InlineCallControls
               activeCall={activeCall}
+              calls={calls}
               activeCallState={activeCallState}
               destination={destinationNumber}
               isStartingCall={isStartingCall}
               onAnswer={handleAnswerCall}
               onEnd={handleEndCall}
+              onSwap={(heldCall) => voipClient.swapCalls(heldCall.callId)}
             />
           ) : (
             <TouchableOpacity

--- a/components/TelnyxLoginForm.tsx
+++ b/components/TelnyxLoginForm.tsx
@@ -61,6 +61,7 @@ async function buildProfileConnectionConfig(
   const options = {
     debug: true,
     pushNotificationDeviceToken: pushToken || undefined,
+    pushWhenActive: true,
     enableMissedCallNotifications: false,
     useTrickleIce: DEMO_USE_TRICKLE_ICE,
     enableCallReports: true,
@@ -123,6 +124,7 @@ export const TelnyxLoginForm: React.FC<TelnyxLoginFormProps> = ({
   const [editingProfileKey, setEditingProfileKey] = useState<string | null>(null);
   const [showProfileSheet, setShowProfileSheet] = useState(false);
   const [connectionState, setConnectionState] = useState(voipClient.currentConnectionState);
+  const [calls, setCalls] = useState<Call[]>(voipClient.currentCalls);
   const [activeCall, setActiveCall] = useState<Call | null>(voipClient.currentActiveCall);
   const [activeCallState, setActiveCallState] = useState<TelnyxCallState | null>(
     voipClient.currentActiveCall?.currentState || null
@@ -159,6 +161,12 @@ export const TelnyxLoginForm: React.FC<TelnyxLoginFormProps> = ({
     loadProfile();
     return () => subscription.unsubscribe();
   }, [voipClient, onLoginSuccess]);
+
+  useEffect(() => {
+    const subscription = voipClient.calls$.subscribe(setCalls);
+
+    return () => subscription.unsubscribe();
+  }, [voipClient]);
 
   useEffect(() => {
     const subscription = voipClient.activeCall$.subscribe((call) => {
@@ -523,9 +531,13 @@ export const TelnyxLoginForm: React.FC<TelnyxLoginFormProps> = ({
 
         <ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
           <Text style={styles.instructions}>
-            {isConnected
-              ? 'Enter a destination (phone number or SIP user) to initiate your call.'
-              : 'Please confirm details below and click Connect to make a call.'}
+            {activeCallState === TelnyxCallState.HELD
+              ? 'Your call is on hold. Tap Resume when you are ready to continue.'
+              : activeCallState === TelnyxCallState.ACTIVE
+                ? 'Your call is active. Use the controls below to hold or end it.'
+                : isConnected
+                  ? 'Enter a destination (phone number or SIP user) to initiate your call.'
+                  : 'Please confirm details below and click Connect to make a call.'}
           </Text>
 
           {!isConnected && (
@@ -562,64 +574,73 @@ export const TelnyxLoginForm: React.FC<TelnyxLoginFormProps> = ({
 
           {isConnected && (
             <View style={styles.callSection}>
-              <View style={styles.segmentedControl}>
-                <TouchableOpacity
-                  style={[styles.segment, destinationType === 'sip' && styles.segmentSelected]}
-                  onPress={() => setDestinationType('sip')}
-                  testID="sipAddressToggle"
-                  accessibilityLabel="SIP address"
-                >
-                  <Text
-                    style={[
-                      styles.segmentText,
-                      destinationType === 'sip' && styles.segmentTextSelected,
-                    ]}
-                  >
-                    SIP address
-                  </Text>
-                </TouchableOpacity>
-                <TouchableOpacity
-                  style={[styles.segment, destinationType === 'phone' && styles.segmentSelected]}
-                  onPress={() => setDestinationType('phone')}
-                  testID="phoneNumberToggle"
-                  accessibilityLabel="Phone number"
-                >
-                  <Text
-                    style={[
-                      styles.segmentText,
-                      destinationType === 'phone' && styles.segmentTextSelected,
-                    ]}
-                  >
-                    Phone number
-                  </Text>
-                </TouchableOpacity>
-              </View>
+              {!isStartingCall && !activeCall && (
+                <>
+                  <View style={styles.segmentedControl}>
+                    <TouchableOpacity
+                      style={[styles.segment, destinationType === 'sip' && styles.segmentSelected]}
+                      onPress={() => setDestinationType('sip')}
+                      testID="sipAddressToggle"
+                      accessibilityLabel="SIP address"
+                    >
+                      <Text
+                        style={[
+                          styles.segmentText,
+                          destinationType === 'sip' && styles.segmentTextSelected,
+                        ]}
+                      >
+                        SIP address
+                      </Text>
+                    </TouchableOpacity>
+                    <TouchableOpacity
+                      style={[
+                        styles.segment,
+                        destinationType === 'phone' && styles.segmentSelected,
+                      ]}
+                      onPress={() => setDestinationType('phone')}
+                      testID="phoneNumberToggle"
+                      accessibilityLabel="Phone number"
+                    >
+                      <Text
+                        style={[
+                          styles.segmentText,
+                          destinationType === 'phone' && styles.segmentTextSelected,
+                        ]}
+                      >
+                        Phone number
+                      </Text>
+                    </TouchableOpacity>
+                  </View>
 
-              <TextInput
-                style={[styles.callInput, inputFocused && styles.inputFocused]}
-                placeholder={
-                  destinationType === 'phone' ? 'Enter phone number' : 'Enter SIP address'
-                }
-                placeholderTextColor="gray"
-                value={destinationNumber}
-                onChangeText={setDestinationNumber}
-                onFocus={() => setInputFocused(true)}
-                onBlur={() => setInputFocused(false)}
-                autoCapitalize="none"
-                autoCorrect={false}
-                keyboardType={destinationType === 'phone' ? 'phone-pad' : 'default'}
-                testID="numberToCallTextField"
-                accessibilityLabel="Call input"
-              />
+                  <TextInput
+                    style={[styles.callInput, inputFocused && styles.inputFocused]}
+                    placeholder={
+                      destinationType === 'phone' ? 'Enter phone number' : 'Enter SIP address'
+                    }
+                    placeholderTextColor="gray"
+                    value={destinationNumber}
+                    onChangeText={setDestinationNumber}
+                    onFocus={() => setInputFocused(true)}
+                    onBlur={() => setInputFocused(false)}
+                    autoCapitalize="none"
+                    autoCorrect={false}
+                    keyboardType={destinationType === 'phone' ? 'phone-pad' : 'default'}
+                    testID="numberToCallTextField"
+                    accessibilityLabel="Call input"
+                  />
+                </>
+              )}
 
               {isStartingCall || activeCall ? (
                 <InlineCallControls
                   activeCall={activeCall}
+                  calls={calls}
                   activeCallState={activeCallState}
                   destination={destinationNumber}
                   isStartingCall={isStartingCall}
                   onAnswer={handleAnswerCall}
                   onEnd={handleEndCall}
+                  onSwap={(heldCall) => voipClient.swapCalls(heldCall.callId)}
                 />
               ) : (
                 <TouchableOpacity

--- a/package/CHANGELOG.md
+++ b/package/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG.md
 
+## Unreleased
+
+### Bug Fixing
+
+- Accept the gateway's canonical `holdState: "active"` unhold response so repeated hold/resume cycles do not leave the call stuck in `HELD`.
+- Add opt-in `pushWhenActive` parity with the native iOS SDK. Login sends `push_when_active` and `pn_late_fanout`, and answers include `answered_device_token` when a non-empty PushKit token is configured.
+
 ## [0.4.5](https://github.com/team-telnyx/react-native-voice-commons/releases/tag/voice-sdk-v0.4.5) (2026-04-30)
 
 ### Bug Fixing

--- a/package/README.md
+++ b/package/README.md
@@ -26,6 +26,9 @@ import { TelnyxRTC, ClientOptions } from '@telnyx/react-native-voice-sdk';
 // Initialize the client
 const clientOptions: ClientOptions = {
   login_token: 'your-jwt-token', // Recommended
+  pushNotificationDeviceToken: 'your-ios-voip-token',
+  // Required when this device must receive another PushKit call while active.
+  pushWhenActive: true,
   // OR use login/password
   // login: 'your-sip-username',
   // password: 'your-sip-password',
@@ -102,6 +105,12 @@ Represents an individual voice call.
 ### Push Notifications & Auto-Answer
 
 ```typescript
+const client = new TelnyxRTC({
+  login_token: 'your-jwt-token',
+  pushNotificationDeviceToken: 'your-ios-voip-token',
+  pushWhenActive: true,
+});
+
 // Process push notification
 client.processVoIPNotification(pushPayload);
 

--- a/package/__tests__/call-custom-headers.test.ts
+++ b/package/__tests__/call-custom-headers.test.ts
@@ -109,6 +109,32 @@ describe('Call Custom Headers', () => {
       });
     });
 
+    it('should include the answering device token when push-when-active is enabled', async () => {
+      const pushCall = new Call({
+        connection: mockConnection,
+        options: mockCallOptions,
+        sessionId: 'test-session-id',
+        direction: 'inbound',
+        telnyxSessionId: 'test-telnyx-session-id',
+        telnyxLegId: 'test-telnyx-leg-id',
+        callId: 'test-call-id',
+        pushWhenActive: true,
+        pushDeviceToken: 'push-token',
+      });
+      (pushCall as any).peer = mockPeer;
+      mockConnection.sendAndWait.mockResolvedValue({});
+      (createAnswerMessage as jest.Mock).mockReturnValue('mock-answer-message');
+
+      await pushCall.answer();
+
+      expect(createAnswerMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          pushWhenActive: true,
+          pushDeviceToken: 'push-token',
+        })
+      );
+    });
+
     it('should send the answer message through connection', async () => {
       // Setup
       const mockAnswerMessage = { id: 'test-id', method: 'telnyx_rtc.answer' };
@@ -253,6 +279,7 @@ describe('Call Custom Headers', () => {
       // Verify CallKit UUID was assigned
       expect((inboundCall as any)._callKitUUID).toBe('test-callkit-uuid');
       expect((inboundCall as any)._isPushNotificationCall).toBe(true);
+      expect(inboundCall.callId).toBe('test-call-id');
       expect(mockConnectionWithClient._client.setPushNotificationCallKitUUID).toHaveBeenCalledWith(
         null
       );

--- a/package/__tests__/call-hold.test.ts
+++ b/package/__tests__/call-hold.test.ts
@@ -1,0 +1,77 @@
+import { Call } from '../lib/call';
+import type { Connection } from '../lib/connection';
+
+function modifyAnswer(holdState: 'held' | 'active' | 'unheld') {
+  return {
+    id: 'modify-id',
+    jsonrpc: '2.0',
+    result: {
+      action: holdState === 'held' ? 'hold' : 'unhold',
+      callID: 'signaling-call-id',
+      holdState,
+      sessid: 'session-id',
+    },
+    voice_sdk_id: 'voice-sdk-id',
+  };
+}
+
+describe('Call repeated hold and unhold', () => {
+  let call: Call;
+  let connection: jest.Mocked<Connection>;
+
+  beforeEach(() => {
+    connection = {
+      addListener: jest.fn(),
+      sendAndWait: jest.fn(),
+      send: jest.fn(),
+    } as any;
+    call = new Call({
+      connection,
+      options: { destinationNumber: '+15551234567' },
+      sessionId: 'session-id',
+      direction: 'inbound',
+      telnyxSessionId: 'telnyx-session-id',
+      telnyxLegId: 'telnyx-leg-id',
+      callId: 'signaling-call-id',
+      callState: 'active',
+    });
+  });
+
+  it('completes three consecutive hold/unhold cycles', async () => {
+    connection.sendAndWait
+      .mockResolvedValueOnce(modifyAnswer('held'))
+      .mockResolvedValueOnce(modifyAnswer('active'))
+      .mockResolvedValueOnce(modifyAnswer('held'))
+      .mockResolvedValueOnce(modifyAnswer('active'))
+      .mockResolvedValueOnce(modifyAnswer('held'))
+      .mockResolvedValueOnce(modifyAnswer('active'));
+
+    for (let cycle = 0; cycle < 3; cycle += 1) {
+      await call.hold();
+      expect(call.state).toBe('held');
+      await call.unhold();
+      expect(call.state).toBe('active');
+    }
+  });
+
+  it('keeps HELD after a failed unhold response and allows a retry', async () => {
+    call.state = 'held';
+    connection.sendAndWait
+      .mockResolvedValueOnce(modifyAnswer('held'))
+      .mockResolvedValueOnce(modifyAnswer('active'));
+
+    await expect(call.unhold()).rejects.toThrow('Unhold action failed');
+    expect(call.state).toBe('held');
+
+    await expect(call.unhold()).resolves.toBeUndefined();
+    expect(call.state).toBe('active');
+  });
+
+  it('accepts the legacy unheld response for backwards compatibility', async () => {
+    call.state = 'held';
+    connection.sendAndWait.mockResolvedValueOnce(modifyAnswer('unheld'));
+
+    await expect(call.unhold()).resolves.toBeUndefined();
+    expect(call.state).toBe('active');
+  });
+});

--- a/package/__tests__/client-custom-headers.test.ts
+++ b/package/__tests__/client-custom-headers.test.ts
@@ -1,6 +1,5 @@
 import { TelnyxRTC } from '../lib/client';
 
-// Mock dependencies
 jest.mock('@react-native-community/netinfo', () => ({
   addEventListener: jest.fn(() => jest.fn()),
 }));
@@ -18,19 +17,17 @@ jest.mock('../lib/login-handler');
 jest.mock('../lib/keep-alive-handler');
 
 describe('TelnyxRTC Client Custom Headers', () => {
+  const callKitUUID = 'AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE';
+  const actionKey = callKitUUID.toLowerCase();
   let client: TelnyxRTC;
   let mockCall: any;
 
   beforeEach(() => {
     jest.clearAllMocks();
-
-    // Create client instance
-    client = new TelnyxRTC({
-      logLevel: 'debug',
-    });
-
-    // Mock call object with answer method
+    client = new TelnyxRTC({ logLevel: 'debug' });
     mockCall = {
+      callId: 'signaling-call-id',
+      _callKitUUID: callKitUUID,
       answer: jest.fn().mockResolvedValue(undefined),
       hangup: jest.fn(),
       state: 'ringing',
@@ -38,150 +35,101 @@ describe('TelnyxRTC Client Custom Headers', () => {
   });
 
   describe('queueAnswerFromCallKit', () => {
-    it('should store custom headers for pending answer', () => {
-      // Setup
+    it('stores custom headers under the normalized CallKit UUID', () => {
       const customHeaders = {
         'X-CallKit-Answer': 'true',
         'X-User-Action': 'answered-from-notification',
       };
 
-      // Execute
-      client.queueAnswerFromCallKit(customHeaders);
+      client.queueAnswerFromCallKit(callKitUUID, customHeaders);
 
-      // Verify internal state
-      expect((client as any).pendingAnswerAction).toBe(true);
-      expect((client as any).pendingCustomHeaders).toEqual(customHeaders);
+      expect((client as any).pendingAnswerActions.get(actionKey)).toEqual(customHeaders);
+      expect((client as any).pendingAnswerActions.size).toBe(1);
     });
 
-    it('should execute immediately if call already exists', async () => {
-      // Setup - add call to calls Map and ensure it's in 'ringing' state for the queue logic
-      mockCall.state = 'ringing';
+    it('executes immediately against the matching CallKit UUID', async () => {
       (client as any).calls.set(mockCall.callId, mockCall);
-      const customHeaders = {
-        'X-Immediate': 'true',
-      };
 
-      // Execute
-      client.queueAnswerFromCallKit(customHeaders);
-
-      // Wait for async execution
+      client.queueAnswerFromCallKit(callKitUUID, { 'X-Immediate': 'true' });
       await new Promise((resolve) => setTimeout(resolve, 0));
 
-      // Verify call was answered with converted headers
       expect(mockCall.answer).toHaveBeenCalledWith([{ name: 'X-Immediate', value: 'true' }]);
+      expect((client as any).pendingAnswerActions.has(actionKey)).toBe(false);
     });
 
-    it('should handle empty custom headers', () => {
-      // Execute
-      client.queueAnswerFromCallKit({});
+    it('stores empty headers for a UUID-keyed answer', () => {
+      client.queueAnswerFromCallKit(callKitUUID, {});
 
-      // Verify
-      expect((client as any).pendingCustomHeaders).toEqual({});
+      expect((client as any).pendingAnswerActions.get(actionKey)).toEqual({});
     });
 
-    it('should handle undefined custom headers', () => {
-      // Execute
+    it('keeps the legacy no-UUID form as an unambiguous empty-header action', () => {
       client.queueAnswerFromCallKit();
 
-      // Verify
-      expect((client as any).pendingCustomHeaders).toEqual({});
+      expect((client as any).pendingAnswerActions.get('__legacy_unambiguous_call__')).toEqual({});
     });
   });
 
   describe('executePendingAnswer', () => {
-    beforeEach(() => {
-      // Set up pending answer
-      (client as any).pendingAnswerAction = true;
-      (client as any).calls.set(mockCall.callId, mockCall);
-    });
-
-    it('should convert Record<string, string> to header array format', async () => {
-      // Setup
-      (client as any).pendingCustomHeaders = {
+    it('converts Record<string, string> to header array format', async () => {
+      (client as any).pendingAnswerActions.set(actionKey, {
         'X-Header-1': 'value1',
         'X-Header-2': 'value2',
-      };
+      });
 
-      // Execute
-      await (client as any).executePendingAnswer();
+      await (client as any).executePendingAnswer(mockCall, actionKey);
 
-      // Verify conversion
       expect(mockCall.answer).toHaveBeenCalledWith([
         { name: 'X-Header-1', value: 'value1' },
         { name: 'X-Header-2', value: 'value2' },
       ]);
     });
 
-    it('should reset pending actions after successful execution', async () => {
-      // Setup
-      (client as any).pendingCustomHeaders = { 'X-Test': 'value' };
+    it('removes only the completed UUID-keyed action after success', async () => {
+      const otherKey = 'ffffffff-1111-2222-3333-444444444444';
+      (client as any).pendingAnswerActions.set(actionKey, { 'X-Test': 'value' });
+      (client as any).pendingAnswerActions.set(otherKey, { 'X-Other': 'value' });
 
-      // Execute
-      await (client as any).executePendingAnswer();
+      await (client as any).executePendingAnswer(mockCall, actionKey);
 
-      // Verify reset
-      expect((client as any).pendingAnswerAction).toBe(false);
-      expect((client as any).pendingCustomHeaders).toEqual({});
+      expect((client as any).pendingAnswerActions.has(actionKey)).toBe(false);
+      expect((client as any).pendingAnswerActions.get(otherKey)).toEqual({
+        'X-Other': 'value',
+      });
     });
 
-    it('should reset pending actions even after failure', async () => {
-      // Setup
+    it('removes the UUID-keyed action after answer failure', async () => {
       mockCall.answer.mockRejectedValue(new Error('Answer failed'));
-      (client as any).pendingCustomHeaders = { 'X-Test': 'value' };
+      (client as any).pendingAnswerActions.set(actionKey, { 'X-Test': 'value' });
 
-      // Execute
-      await (client as any).executePendingAnswer();
+      await (client as any).executePendingAnswer(mockCall, actionKey);
 
-      // Verify reset even after error
-      expect((client as any).pendingAnswerAction).toBe(false);
-      expect((client as any).pendingCustomHeaders).toEqual({});
+      expect((client as any).pendingAnswerActions.has(actionKey)).toBe(false);
     });
 
-    it('should handle empty custom headers object', async () => {
-      // Setup
-      (client as any).pendingCustomHeaders = {};
+    it('handles an empty custom-header object', async () => {
+      (client as any).pendingAnswerActions.set(actionKey, {});
 
-      // Execute
-      await (client as any).executePendingAnswer();
+      await (client as any).executePendingAnswer(mockCall, actionKey);
 
-      // Verify
       expect(mockCall.answer).toHaveBeenCalledWith([]);
     });
 
-    it('should not execute when no pending action', async () => {
-      // Setup
-      (client as any).pendingAnswerAction = false;
+    it('does not execute when the requested UUID has no pending answer', async () => {
+      await (client as any).executePendingAnswer(mockCall, actionKey);
 
-      // Execute
-      await (client as any).executePendingAnswer();
-
-      // Verify
       expect(mockCall.answer).not.toHaveBeenCalled();
     });
 
-    it('should not execute when no call exists', async () => {
-      // Setup - clear the calls Map
-      (client as any).calls.clear();
-
-      // Execute
-      await (client as any).executePendingAnswer();
-
-      // Verify
-      expect(mockCall.answer).not.toHaveBeenCalled();
-    });
-
-    it('should handle special characters in header values', async () => {
-      // Setup
-      (client as any).pendingCustomHeaders = {
+    it('preserves special characters in header values', async () => {
+      (client as any).pendingAnswerActions.set(actionKey, {
         'X-Special-Chars': 'value with spaces & symbols!@#$%^&*()',
         'X-Unicode': 'héllo wørld 🌍',
         'X-Empty': '',
-      };
+      });
 
-      // Execute
-      await (client as any).executePendingAnswer();
+      await (client as any).executePendingAnswer(mockCall, actionKey);
 
-      // Verify
       expect(mockCall.answer).toHaveBeenCalledWith([
         { name: 'X-Special-Chars', value: 'value with spaces & symbols!@#$%^&*()' },
         { name: 'X-Unicode', value: 'héllo wørld 🌍' },
@@ -190,36 +138,27 @@ describe('TelnyxRTC Client Custom Headers', () => {
     });
   });
 
-  describe('resetPendingActions', () => {
-    it('should reset all pending action flags and custom headers', () => {
-      // Setup
-      (client as any).pendingAnswerAction = true;
-      (client as any).pendingEndAction = true;
-      (client as any).pendingCustomHeaders = { 'X-Test': 'value' };
+  describe('UUID-keyed pending action replacement', () => {
+    it('replaces an answer with an end action only for the same UUID', () => {
+      const otherKey = 'ffffffff-1111-2222-3333-444444444444';
+      (client as any).pendingAnswerActions.set(otherKey, { 'X-Other': 'value' });
+      client.queueAnswerFromCallKit(callKitUUID, { 'X-Test': 'value' });
 
-      // Execute
-      (client as any).resetPendingActions();
+      client.queueEndFromCallKit(callKitUUID);
 
-      // Verify
-      expect((client as any).pendingAnswerAction).toBe(false);
-      expect((client as any).pendingEndAction).toBe(false);
-      expect((client as any).pendingCustomHeaders).toEqual({});
-      // Note: isCallFromPush should NOT be reset by this method
+      expect((client as any).pendingAnswerActions.has(actionKey)).toBe(false);
+      expect((client as any).pendingEndActions.has(actionKey)).toBe(true);
+      expect((client as any).pendingAnswerActions.has(otherKey)).toBe(true);
     });
   });
 
-  describe('integration with processInvite', () => {
-    it('should execute pending answer with custom headers when invite arrives', async () => {
-      // This test would require more complex mocking of the invite processing
-      // For now, we verify the conceptual flow
-
-      // Setup pending answer
+  describe('integration with invite processing', () => {
+    it('retains UUID-keyed custom headers until the matching invite arrives', () => {
       const customHeaders = { 'X-Push-Answer': 'true' };
-      client.queueAnswerFromCallKit(customHeaders);
 
-      // Verify pending state
-      expect((client as any).pendingAnswerAction).toBe(true);
-      expect((client as any).pendingCustomHeaders).toEqual(customHeaders);
+      client.queueAnswerFromCallKit(callKitUUID, customHeaders);
+
+      expect((client as any).pendingAnswerActions.get(actionKey)).toEqual(customHeaders);
     });
   });
 });

--- a/package/__tests__/multi-call.test.ts
+++ b/package/__tests__/multi-call.test.ts
@@ -202,4 +202,48 @@ describe('TelnyxRTC Multi-Call Support', () => {
       expect(client.hasActiveCalls).toBe(false);
     });
   });
+
+  describe('UUID-targeted pending CallKit actions', () => {
+    it('answers B without answering active call A when app and signaling IDs differ', async () => {
+      const callA = createMockCall('signal-a', 'active');
+      const callB = createMockCall('signal-c', 'ringing');
+      (callB as any)._callKitUUID = 'callkit-b';
+      (callB.answer as jest.Mock).mockResolvedValue(undefined);
+
+      client.calls.set('signal-a', callA as any);
+      client.calls.set('signal-c', callB as any);
+
+      client.queueAnswerFromCallKit('CALLKIT-B');
+      await Promise.resolve();
+
+      expect(callA.answer).not.toHaveBeenCalled();
+      expect(callB.answer).toHaveBeenCalledTimes(1);
+    });
+
+    it('ends B without ending active call A when app and signaling IDs differ', () => {
+      const callA = createMockCall('signal-a', 'active');
+      const callB = createMockCall('signal-c', 'ringing');
+      (callB as any)._callKitUUID = 'callkit-b';
+
+      client.calls.set('signal-a', callA as any);
+      client.calls.set('signal-c', callB as any);
+
+      client.queueEndFromCallKit('CALLKIT-B');
+
+      expect(callA.hangup).not.toHaveBeenCalled();
+      expect(callB.hangup).toHaveBeenCalledTimes(1);
+    });
+
+    it('preserves A and stores push UUID B separately from the future INVITE ID C', () => {
+      const callA = createMockCall('signal-a', 'active');
+      client.calls.set('signal-a', callA as any);
+
+      client.processVoIPNotification({
+        metadata: { call_id: 'CALLKIT-B', voice_sdk_id: 'voice-sdk-b' },
+      });
+
+      expect(client.getCall('signal-a')).toBe(callA);
+      expect(client.getPushNotificationCallKitUUID()).toBe('callkit-b');
+    });
+  });
 });

--- a/package/__tests__/push-when-active.test.ts
+++ b/package/__tests__/push-when-active.test.ts
@@ -1,0 +1,86 @@
+import { createAnswerMessage } from '../lib/messages/call';
+import {
+  createLoginUserVariables,
+  createPasswordLoginMessage,
+  createTokenLoginMessage,
+} from '../lib/messages/login';
+
+describe('push-when-active signaling', () => {
+  it.each(['password', 'token'])(
+    'adds active push routing flags to %s login userVariables',
+    (loginType) => {
+      const userVariables = createLoginUserVariables({
+        pushDeviceToken: 'push-token',
+        pushNotificationProvider: 'ios',
+        pushNotificationEnvironment: 'debug',
+        pushWhenActive: true,
+      });
+      const message =
+        loginType === 'password'
+          ? createPasswordLoginMessage({
+              login: 'sip-user',
+              password: 'sip-password',
+              userVariables,
+            })
+          : createTokenLoginMessage({
+              login_token: 'credential-token',
+              userVariables,
+            });
+
+      expect(message.params.userVariables).toEqual(
+        expect.objectContaining({
+          push_device_token: 'push-token',
+          push_when_active: 'true',
+          pn_late_fanout: 'true',
+        })
+      );
+    }
+  );
+
+  it('omits active push routing flags by default', () => {
+    const userVariables = createLoginUserVariables({
+      pushDeviceToken: 'push-token',
+      pushNotificationProvider: 'ios',
+      pushNotificationEnvironment: 'debug',
+    });
+    const message = createPasswordLoginMessage({
+      login: 'sip-user',
+      password: 'sip-password',
+      userVariables,
+    });
+
+    expect(message.params.userVariables).not.toHaveProperty('push_when_active');
+    expect(message.params.userVariables).not.toHaveProperty('pn_late_fanout');
+  });
+
+  it('identifies the answering PushKit device only when opted in', () => {
+    const baseParams = {
+      callId: 'call-id',
+      dialogParams: {},
+      sdp: 'answer-sdp',
+      telnyxLegId: 'leg-id',
+      telnyxSessionId: 'telnyx-session-id',
+      sessionId: 'session-id',
+    };
+
+    const enabled = createAnswerMessage({
+      ...baseParams,
+      pushWhenActive: true,
+      pushDeviceToken: 'push-token',
+    });
+    const disabled = createAnswerMessage({
+      ...baseParams,
+      pushWhenActive: false,
+      pushDeviceToken: 'push-token',
+    });
+    const blankToken = createAnswerMessage({
+      ...baseParams,
+      pushWhenActive: true,
+      pushDeviceToken: '   ',
+    });
+
+    expect(enabled.params.answered_device_token).toBe('push-token');
+    expect(disabled.params).not.toHaveProperty('answered_device_token');
+    expect(blankToken.params).not.toHaveProperty('answered_device_token');
+  });
+});

--- a/package/lib/call.ts
+++ b/package/lib/call.ts
@@ -64,6 +64,8 @@ type CallConstructorParams = {
   callState?: CallState;
   debug?: boolean;
   callReportConfig?: CallReportConfig;
+  pushWhenActive?: boolean;
+  pushDeviceToken?: string;
 };
 
 export type CallDirection = 'inbound' | 'outbound';
@@ -81,6 +83,8 @@ export type CreateInboundCall = {
   initialState?: CallState;
   debug?: boolean;
   callReportConfig?: CallReportConfig;
+  pushWhenActive?: boolean;
+  pushDeviceToken?: string;
 };
 
 // TODO persist customHeaders and clientState
@@ -119,6 +123,8 @@ export class Call extends EventEmitter<CallEvents> {
     initialState = 'ringing',
     debug = false,
     callReportConfig,
+    pushWhenActive = false,
+    pushDeviceToken,
   }: CreateInboundCall) {
     const call = new Call({
       connection,
@@ -132,6 +138,8 @@ export class Call extends EventEmitter<CallEvents> {
       callState: initialState,
       debug,
       callReportConfig,
+      pushWhenActive,
+      pushDeviceToken,
     });
 
     // Store the custom headers from the INVITE message
@@ -209,6 +217,8 @@ export class Call extends EventEmitter<CallEvents> {
   private callReportConfig: CallReportConfig;
   private callReportPostingStarted = false;
   private callStartTimestamp: string;
+  private readonly pushWhenActive: boolean;
+  private readonly pushDeviceToken?: string;
 
   constructor({
     connection,
@@ -222,6 +232,8 @@ export class Call extends EventEmitter<CallEvents> {
     callState = 'new',
     debug = false,
     callReportConfig,
+    pushWhenActive = false,
+    pushDeviceToken,
   }: CallConstructorParams) {
     super();
 
@@ -237,6 +249,8 @@ export class Call extends EventEmitter<CallEvents> {
     this.peer = null;
     this.debugEnabled = debug;
     this.callReportConfig = callReportConfig ?? DEFAULT_CALL_REPORT_CONFIG;
+    this.pushWhenActive = pushWhenActive;
+    this.pushDeviceToken = pushDeviceToken;
     this.callStartTimestamp = new Date().toISOString();
 
     // Initialize call report collector if enabled
@@ -364,6 +378,13 @@ export class Call extends EventEmitter<CallEvents> {
       await this.peer.waitForIceGatheringComplete();
     }
 
+    const pushAnswerParams = this.pushWhenActive
+      ? {
+          pushWhenActive: true,
+          pushDeviceToken: this.pushDeviceToken,
+        }
+      : {};
+
     await this.connection.sendAndWait(
       createAnswerMessage({
         callId: this.callId,
@@ -373,6 +394,7 @@ export class Call extends EventEmitter<CallEvents> {
         telnyxSessionId: this.telnyxSessionId!,
         sessionId: this.sessionId,
         customHeaders,
+        ...pushAnswerParams,
       })
     );
 
@@ -503,7 +525,7 @@ export class Call extends EventEmitter<CallEvents> {
     if (!isModifyCallAnswer(result)) {
       throw new Error(`[Call] Invalid hold response received: ${JSON.stringify(result)}`);
     }
-    if (result.result.holdState !== 'held') {
+    if (result.result.action !== 'hold' || result.result.holdState !== 'held') {
       throw new Error(`[Call] Hold action failed: ${JSON.stringify(result)}`);
     }
     this.setState('held');
@@ -524,10 +546,13 @@ export class Call extends EventEmitter<CallEvents> {
     });
     const result = await this.connection.sendAndWait(unholdRequest);
     if (!isModifyCallAnswer(result)) {
-      throw new Error(`[Call] Invalid hold response received: ${JSON.stringify(result)}`);
+      throw new Error(`[Call] Invalid unhold response received: ${JSON.stringify(result)}`);
     }
-    if (result.result.holdState !== 'held') {
-      throw new Error(`[Call] Hold action failed: ${JSON.stringify(result)}`);
+    if (
+      result.result.action !== 'unhold' ||
+      (result.result.holdState !== 'active' && result.result.holdState !== 'unheld')
+    ) {
+      throw new Error(`[Call] Unhold action failed: ${JSON.stringify(result)}`);
     }
 
     this.setState('active');

--- a/package/lib/client-options.ts
+++ b/package/lib/client-options.ts
@@ -35,6 +35,15 @@ export interface ClientOptions {
    */
   pushNotificationDeviceToken?: string;
   /**
+   * Keep this PushKit device eligible for incoming call delivery while its
+   * WebSocket session is already active.
+   *
+   * When enabled, login advertises `push_when_active` and `pn_late_fanout`,
+   * and answers identify the PushKit device that accepted the call.
+   * @default false
+   */
+  pushWhenActive?: boolean;
+  /**
    * Enable native missed call push notifications.
    * When enabled, the SDK tags the User-Agent with the missed-call notification marker.
    * @default false

--- a/package/lib/client.ts
+++ b/package/lib/client.ts
@@ -109,10 +109,12 @@ export class TelnyxRTC extends EventEmitter<TelnyxRTCEvents> {
   private pendingTrickleEvents: Map<string, PendingTrickleEvent[]> = new Map();
   private static readonly PENDING_TRICKLE_TTL_MS = 30000;
 
-  // Pending call actions (matching iOS SDK behavior)
-  private pendingAnswerAction: boolean = false;
-  private pendingEndAction: boolean = false;
-  private pendingCustomHeaders: Record<string, string> = {};
+  // Pending CallKit actions are keyed by the app-facing CallKit UUID. A
+  // singleton flag is unsafe once two calls can coexist because it resolves
+  // through `call` (the first non-ended call).
+  private pendingAnswerActions: Map<string, Record<string, string>> = new Map();
+  private pendingEndActions: Set<string> = new Set();
+  private static readonly LEGACY_PENDING_ACTION_KEY = '__legacy_unambiguous_call__';
 
   // AsyncStorage keys for persisting push state
   private static readonly PUSH_STATE_KEY = '@telnyx_push_state';
@@ -197,10 +199,7 @@ export class TelnyxRTC extends EventEmitter<TelnyxRTCEvents> {
     this.keepAliveHandler = null;
     // calls Map is initialized in class declaration
 
-    // Initialize pending actions
-    this.pendingAnswerAction = false;
-    this.pendingEndAction = false;
-    this.pendingCustomHeaders = {};
+    // Pending action collections are initialized in their field declarations.
 
     // Force debug logging in development or when explicitly requested
     const shouldDebug = __DEV__ || opts.logLevel === 'debug' || (global as any).__TELNYX_DEBUG__;
@@ -435,6 +434,8 @@ export class TelnyxRTC extends EventEmitter<TelnyxRTCEvents> {
       options,
       debug: this.options.debug,
       callReportConfig: this.getCallReportConfig(),
+      pushWhenActive: this.options.pushWhenActive,
+      pushDeviceToken: this.options.pushNotificationDeviceToken,
     });
 
     // Add to calls tracking (matches iOS SDK behavior)
@@ -464,6 +465,14 @@ export class TelnyxRTC extends EventEmitter<TelnyxRTCEvents> {
 
     // Extract voice_sdk_id from push notification metadata (matching iOS SDK)
     const metadata = pushNotificationPayload?.metadata || pushNotificationPayload;
+    const pushCallKitUUID = metadata?.call_id || metadata?.callId;
+    if (typeof pushCallKitUUID === 'string' && pushCallKitUUID.length > 0) {
+      // Keep the app-facing PushKit/CallKit identity separate from the
+      // signaling INVITE callID. Call.createInboundCall attaches this UUID to
+      // the new call without changing Call.callId.
+      this.setPushNotificationCallKitUUID(this.normalizeCallIdentity(pushCallKitUUID));
+    }
+
     if (metadata?.voice_sdk_id) {
       const newVoiceSDKId = metadata.voice_sdk_id;
       const currentVoiceSDKId = (this as any)._pushVoiceSDKId;
@@ -503,17 +512,35 @@ export class TelnyxRTC extends EventEmitter<TelnyxRTCEvents> {
    * This should be called when the user answers from CallKit before the socket connection is established
    * @param customHeaders Optional custom headers to include with the answer
    */
-  public queueAnswerFromCallKit(customHeaders: Record<string, string> = {}) {
-    log.debug('[TelnyxRTC] Queuing answer action from CallKit', customHeaders);
-    this.pendingAnswerAction = true;
-    this.pendingCustomHeaders = customHeaders;
+  public queueAnswerFromCallKit(
+    callKitUUIDOrHeaders?: string | Record<string, string>,
+    customHeaders: Record<string, string> = {}
+  ) {
+    const callKitUUID =
+      typeof callKitUUIDOrHeaders === 'string'
+        ? this.normalizeCallIdentity(callKitUUIDOrHeaders)
+        : null;
+    const headers =
+      callKitUUIDOrHeaders && typeof callKitUUIDOrHeaders !== 'string'
+        ? callKitUUIDOrHeaders
+        : customHeaders;
+    const actionKey = callKitUUID ?? TelnyxRTC.LEGACY_PENDING_ACTION_KEY;
+    const targetCall = this.resolveCallKitTarget(callKitUUID, 'ringing');
 
-    // If call already exists, answer immediately
-    if (this.call && this.call.state === 'ringing') {
-      log.debug('[TelnyxRTC] Call exists, answering immediately');
-      this.executePendingAnswer();
+    if (!callKitUUID && !targetCall && this.getActiveCalls().length > 1) {
+      log.warn('[TelnyxRTC] Refusing ambiguous legacy CallKit answer with multiple calls');
+      return;
+    }
+
+    log.debug('[TelnyxRTC] Queuing answer action from CallKit', { callKitUUID, headers });
+    this.pendingEndActions.delete(actionKey);
+    this.pendingAnswerActions.set(actionKey, headers);
+
+    if (targetCall) {
+      log.debug('[TelnyxRTC] Target call exists, answering immediately:', targetCall.callId);
+      void this.executePendingAnswer(targetCall, actionKey);
     } else {
-      log.debug('[TelnyxRTC] Call not yet available, answer will be executed when invite arrives');
+      log.debug('[TelnyxRTC] Target call not yet available; answer remains keyed for its invite');
     }
   }
 
@@ -521,16 +548,25 @@ export class TelnyxRTC extends EventEmitter<TelnyxRTCEvents> {
    * Queue an end action for when the call invite arrives (matching iOS SDK behavior)
    * This should be called when the user ends from CallKit before the socket connection is established
    */
-  public queueEndFromCallKit() {
-    log.debug('[TelnyxRTC] Queuing end action from CallKit');
-    this.pendingEndAction = true;
+  public queueEndFromCallKit(callKitUUID?: string) {
+    const normalizedUUID = callKitUUID ? this.normalizeCallIdentity(callKitUUID) : null;
+    const actionKey = normalizedUUID ?? TelnyxRTC.LEGACY_PENDING_ACTION_KEY;
+    const targetCall = this.resolveCallKitTarget(normalizedUUID);
 
-    // If call already exists, end immediately
-    if (this.call) {
-      log.debug('[TelnyxRTC] Call exists, ending immediately');
-      this.executePendingEnd();
+    if (!normalizedUUID && !targetCall && this.getActiveCalls().length > 1) {
+      log.warn('[TelnyxRTC] Refusing ambiguous legacy CallKit end with multiple calls');
+      return;
+    }
+
+    log.debug('[TelnyxRTC] Queuing end action from CallKit', { callKitUUID: normalizedUUID });
+    this.pendingAnswerActions.delete(actionKey);
+    this.pendingEndActions.add(actionKey);
+
+    if (targetCall) {
+      log.debug('[TelnyxRTC] Target call exists, ending immediately:', targetCall.callId);
+      this.executePendingEnd(targetCall, actionKey);
     } else {
-      log.debug('[TelnyxRTC] Call not yet available, end will be executed when invite arrives');
+      log.debug('[TelnyxRTC] Target call not yet available; end remains keyed for its invite');
     }
   }
 
@@ -556,8 +592,9 @@ export class TelnyxRTC extends EventEmitter<TelnyxRTCEvents> {
   /**
    * Execute pending answer action
    */
-  private async executePendingAnswer() {
-    if (!this.pendingAnswerAction || !this.call) {
+  private async executePendingAnswer(targetCall: Call, actionKey: string) {
+    const pendingHeaders = this.pendingAnswerActions.get(actionKey);
+    if (!pendingHeaders) {
       return;
     }
 
@@ -565,37 +602,39 @@ export class TelnyxRTC extends EventEmitter<TelnyxRTCEvents> {
       log.debug('[TelnyxRTC] Executing pending answer action');
 
       // Convert Record<string, string> to { name: string; value: string }[] format
-      const customHeaders = Object.entries(this.pendingCustomHeaders).map(([name, value]) => ({
+      const customHeaders = Object.entries(pendingHeaders).map(([name, value]) => ({
         name,
         value,
       }));
 
       // Use the answer method with custom headers
-      await this.call.answer(customHeaders);
+      await targetCall.answer(customHeaders);
       log.debug('[TelnyxRTC] Pending answer executed successfully');
     } catch (error) {
       log.error('[TelnyxRTC] Failed to execute pending answer:', error);
     } finally {
-      this.resetPendingActions();
+      this.pendingAnswerActions.delete(actionKey);
+      this.resetPushContextIfActionsComplete();
     }
   }
 
   /**
    * Execute pending end action
    */
-  private executePendingEnd() {
-    if (!this.pendingEndAction || !this.call) {
+  private executePendingEnd(targetCall: Call, actionKey: string) {
+    if (!this.pendingEndActions.has(actionKey)) {
       return;
     }
 
     try {
       log.debug('[TelnyxRTC] Executing pending end action');
-      this.call.hangup();
+      targetCall.hangup();
       log.debug('[TelnyxRTC] Pending end executed successfully');
     } catch (error) {
       log.error('[TelnyxRTC] Failed to execute pending end:', error);
     } finally {
-      this.resetPendingActions();
+      this.pendingEndActions.delete(actionKey);
+      this.resetPushContextIfActionsComplete();
     }
   }
 
@@ -603,15 +642,12 @@ export class TelnyxRTC extends EventEmitter<TelnyxRTCEvents> {
    * Reset pending action flags (matching iOS SDK resetPushVariables)
    * Also resets push flags so subsequent calls are not auto-answered.
    */
-  private resetPendingActions() {
-    log.debug('[TelnyxRTC] Resetting pending actions');
-    this.pendingAnswerAction = false;
-    this.pendingEndAction = false;
-    this.pendingCustomHeaders = {};
-
-    // Reset push flags after the pending action has been executed
-    // so subsequent calls are not auto-answered
-    if (this.isCallFromPush) {
+  private resetPushContextIfActionsComplete() {
+    if (
+      this.isCallFromPush &&
+      this.pendingAnswerActions.size === 0 &&
+      this.pendingEndActions.size === 0
+    ) {
       log.debug('[TelnyxRTC] Resetting push flags after pending action executed');
       this.isCallFromPush = false;
       this.pushNotificationPayload = null;
@@ -620,6 +656,29 @@ export class TelnyxRTC extends EventEmitter<TelnyxRTCEvents> {
         log.warn('[TelnyxRTC] Failed to clear push state after pending action:', error);
       });
     }
+  }
+
+  private normalizeCallIdentity(callId: string): string {
+    return callId.toLowerCase();
+  }
+
+  private getCallKitIdentity(call: Call): string {
+    const callKitUUID = (call as any)._callKitUUID;
+    return this.normalizeCallIdentity(callKitUUID || call.callId);
+  }
+
+  private resolveCallKitTarget(callKitUUID: string | null, requiredState?: string): Call | null {
+    const candidates = this.getActiveCalls().filter(
+      (call) => !requiredState || call.state === requiredState
+    );
+
+    if (callKitUUID) {
+      return (
+        candidates.find((call) => this.getCallKitIdentity(call) === callKitUUID) || null
+      );
+    }
+
+    return candidates.length === 1 ? candidates[0] : null;
   }
 
   /**
@@ -1071,6 +1130,8 @@ export class TelnyxRTC extends EventEmitter<TelnyxRTCEvents> {
         inviteCustomHeaders: msg.params.dialogParams?.custom_headers || null,
         debug: this.options.debug,
         callReportConfig: this.getCallReportConfig(),
+        pushWhenActive: this.options.pushWhenActive,
+        pushDeviceToken: this.options.pushNotificationDeviceToken,
       });
     } catch (error) {
       log.error('[TelnyxRTC] Failed to create inbound call:', error);
@@ -1127,25 +1188,35 @@ export class TelnyxRTC extends EventEmitter<TelnyxRTCEvents> {
           rejectedByPushAction = true;
         }
         // Reset push flags immediately since the action was handled inline
-        this.resetPendingActions();
-      } else if (this.pendingAnswerAction) {
-        log.debug('[TelnyxRTC] Found pending answer action, executing...');
-        // Execute pending answer asynchronously to allow call setup to complete first
-        // Push flags are reset inside resetPendingActions() after execution
-        setTimeout(() => this.executePendingAnswer(), 100);
-      } else if (this.pendingEndAction) {
-        log.debug('[TelnyxRTC] Found pending end action, executing...');
-        // Execute pending end asynchronously
-        // Push flags are reset inside resetPendingActions() after execution
-        setTimeout(() => this.executePendingEnd(), 100);
-        // Same reasoning as the inline `action === 'reject'` branch above —
-        // we've decided to end this call before the user sees it.
-        rejectedByPushAction = true;
+        this.resetPushContextIfActionsComplete();
       } else {
-        log.debug('[TelnyxRTC] No pending actions to execute for push notification call');
-        // No pending actions yet - keep isCallFromPush alive so that
-        // queueAnswerFromCallKit() can still trigger auto-answer when
-        // the user answers from CallKit after the invite has arrived.
+        const callIdentity = this.getCallKitIdentity(incomingCall);
+        const answerKey = this.pendingAnswerActions.has(callIdentity)
+          ? callIdentity
+          : this.pendingAnswerActions.has(TelnyxRTC.LEGACY_PENDING_ACTION_KEY)
+            ? TelnyxRTC.LEGACY_PENDING_ACTION_KEY
+            : null;
+        const endKey = this.pendingEndActions.has(callIdentity)
+          ? callIdentity
+          : this.pendingEndActions.has(TelnyxRTC.LEGACY_PENDING_ACTION_KEY)
+            ? TelnyxRTC.LEGACY_PENDING_ACTION_KEY
+            : null;
+
+        if (answerKey) {
+          log.debug('[TelnyxRTC] Found pending answer action, executing...');
+          // Execute pending answer asynchronously to allow call setup to complete first
+          setTimeout(() => void this.executePendingAnswer(incomingCall, answerKey), 100);
+        } else if (endKey) {
+          log.debug('[TelnyxRTC] Found pending end action, executing...');
+          setTimeout(() => this.executePendingEnd(incomingCall, endKey), 100);
+          // Same reasoning as the inline `action === 'reject'` branch above —
+          // we've decided to end this call before the user sees it.
+          rejectedByPushAction = true;
+        } else {
+          log.debug('[TelnyxRTC] No pending actions to execute for push notification call');
+          // No pending actions yet - keep isCallFromPush alive so that a
+          // UUID-targeted CallKit action can resolve this call later.
+        }
       }
     } else {
       log.debug('[TelnyxRTC] Not a push notification call, no pending actions to check');
@@ -1164,6 +1235,11 @@ export class TelnyxRTC extends EventEmitter<TelnyxRTCEvents> {
       type: 'callUpdate',
       call: incomingCall,
     });
+
+    // The INVITE now owns the durable app-facing UUID. If no pre-INVITE
+    // action is pending, the global push context is no longer needed and
+    // must not leak into the next call.
+    this.resetPushContextIfActionsComplete();
 
     log.debug('[TelnyxRTC] ====== CALL INVITE HANDLING COMPLETE ======');
   };
@@ -1206,6 +1282,8 @@ export class TelnyxRTC extends EventEmitter<TelnyxRTCEvents> {
       initialState: 'connecting', // Set initial state to connecting
       debug: this.options.debug,
       callReportConfig: this.getCallReportConfig(),
+      pushWhenActive: this.options.pushWhenActive,
+      pushDeviceToken: this.options.pushNotificationDeviceToken,
     });
 
     // Add to calls tracking (matches iOS SDK behavior)

--- a/package/lib/login-handler.ts
+++ b/package/lib/login-handler.ts
@@ -12,6 +12,7 @@ import { updateCallReportId } from './global';
 import {
   createPasswordLoginMessage,
   createTokenLoginMessage,
+  createLoginUserVariables,
   isLoginSuccessResponse,
 } from './messages/login';
 import { createDeferredPromise } from './promise';
@@ -128,11 +129,12 @@ export class LoginHandler {
   }
 
   private createLoginMessage = (options: ClientOptions) => {
-    const userVariables = {
-      push_device_token: options.pushNotificationDeviceToken,
-      push_notification_provider: Platform.OS,
-      push_notification_environment: __DEV__ ? 'debug' : 'production',
-    };
+    const userVariables = createLoginUserVariables({
+      pushDeviceToken: options.pushNotificationDeviceToken,
+      pushNotificationProvider: Platform.OS,
+      pushNotificationEnvironment: __DEV__ ? 'debug' : 'production',
+      pushWhenActive: options.pushWhenActive,
+    });
 
     // Use stored sessid from previous login response, or from options if provided
     const sessid = (options as any).sessid || this.lastSessionId;

--- a/package/lib/messages/call.ts
+++ b/package/lib/messages/call.ts
@@ -408,6 +408,7 @@ type AnswerMessage = {
       custom_headers?: { name: string; value: string }[];
     };
     'User-Agent': string;
+    answered_device_token?: string;
   };
 };
 
@@ -419,6 +420,8 @@ type CreateAnswerMessageParams = {
   telnyxSessionId: string;
   telnyxLegId: string;
   customHeaders?: { name: string; value: string }[];
+  pushWhenActive?: boolean;
+  pushDeviceToken?: string;
 };
 export function createAnswerMessage({
   dialogParams,
@@ -428,8 +431,10 @@ export function createAnswerMessage({
   telnyxLegId,
   telnyxSessionId,
   customHeaders,
+  pushWhenActive = false,
+  pushDeviceToken,
 }: CreateAnswerMessageParams): AnswerMessage {
-  return {
+  const message: AnswerMessage = {
     id: uuid(),
     jsonrpc: '2.0',
     method: TelnyxRTCMethod.ANSWER,
@@ -446,6 +451,12 @@ export function createAnswerMessage({
       'User-Agent': `ReactNative-${SDK_VERSION}`,
     },
   };
+
+  if (pushWhenActive && pushDeviceToken?.trim()) {
+    message.params.answered_device_token = pushDeviceToken;
+  }
+
+  return message;
 }
 
 type ModifyCallRequest = {
@@ -486,7 +497,9 @@ type ModifyCallAnswer = {
   result: {
     action: 'hold' | 'unhold';
     callID: string;
-    holdState: 'held' | 'unheld';
+    // The gateway reports an unheld call as `active`. Keep accepting the
+    // legacy `unheld` value for compatibility with older deployments.
+    holdState: 'held' | 'active' | 'unheld';
     sessid: string;
   };
   voice_sdk_id: string;
@@ -500,7 +513,9 @@ export function isModifyCallAnswer(msg: unknown): msg is ModifyCallAnswer {
   return (
     Boolean(temp.result?.callID) &&
     Boolean(temp.result?.sessid) &&
-    (temp.result?.holdState === 'held' || temp.result?.holdState === 'unheld')
+    (temp.result?.holdState === 'held' ||
+      temp.result?.holdState === 'active' ||
+      temp.result?.holdState === 'unheld')
   );
 }
 

--- a/package/lib/messages/login.ts
+++ b/package/lib/messages/login.ts
@@ -1,6 +1,39 @@
 import uuid from 'uuid-random';
 import { SDK_VERSION } from '../env';
 
+export type LoginUserVariables = {
+  push_device_token?: string;
+  push_notification_provider?: string;
+  push_notification_environment?: string;
+  push_when_active?: 'true';
+  pn_late_fanout?: 'true';
+};
+
+export function createLoginUserVariables({
+  pushDeviceToken,
+  pushNotificationProvider,
+  pushNotificationEnvironment,
+  pushWhenActive = false,
+}: {
+  pushDeviceToken?: string;
+  pushNotificationProvider?: string;
+  pushNotificationEnvironment?: string;
+  pushWhenActive?: boolean;
+}): LoginUserVariables {
+  const userVariables: LoginUserVariables = {
+    push_device_token: pushDeviceToken,
+    push_notification_provider: pushNotificationProvider,
+    push_notification_environment: pushNotificationEnvironment,
+  };
+
+  if (pushWhenActive) {
+    userVariables.push_when_active = 'true';
+    userVariables.pn_late_fanout = 'true';
+  }
+
+  return userVariables;
+}
+
 function userAgent(enableMissedCallNotifications: boolean = false) {
   return `ReactNative${enableMissedCallNotifications ? '-mpn' : ''}-${SDK_VERSION}`;
 }
@@ -12,10 +45,7 @@ export type LoginWithPasswordParams = {
   attachCall?: boolean;
   fromPush?: boolean;
   enableMissedCallNotifications?: boolean;
-  userVariables?: {
-    push_device_token?: string;
-    push_notification_provider?: string;
-  };
+  userVariables?: LoginUserVariables;
   sessid?: string;
 };
 
@@ -25,10 +55,7 @@ export type LoginWithTokenParams = {
   attachCall?: boolean;
   fromPush?: boolean;
   enableMissedCallNotifications?: boolean;
-  userVariables?: {
-    push_device_token?: string;
-    push_notification_provider?: string;
-  };
+  userVariables?: LoginUserVariables;
   sessid?: string;
 };
 

--- a/react-voice-commons-sdk/CHANGELOG.md
+++ b/react-voice-commons-sdk/CHANGELOG.md
@@ -1,5 +1,20 @@
 # CHANGELOG.md
 
+## Unreleased
+
+### Bug Fixing
+
+- Hydrate iOS login and reconnect configurations from the current native PushKit token when callers omit one, preventing locked-device inbound calls from being missed when JavaScript login races token delivery.
+- Support two simultaneous iOS CallKit calls with UUID-targeted answer, end, hold, resume, and survivor restoration.
+- Route app hold/resume through CallKit and compensate partial call-swap failures to keep native and WebRTC state aligned.
+- Preserve the active signaling client when a second-call push arrives and avoid duplicate cold-answer actions.
+- Persist and forward the opt-in `pushWhenActive` configuration required for locked/background active-call PushKit delivery.
+- Treat Focus/DND-filtered CallKit registrations as terminal so rejected UUIDs cannot produce follow-up `UnknownCallUUID` answer transactions or ghost signaling calls.
+
+### Enhancement
+
+- Add public `swapCalls(targetCallId)` support and matching demo hold/resume/swap controls.
+
 ## [0.4.3] (2026-04-30)
 
 ### Bug Fixing

--- a/react-voice-commons-sdk/README.md
+++ b/react-voice-commons-sdk/README.md
@@ -270,6 +270,7 @@ import { createCredentialConfig } from '@telnyx/react-voice-commons-sdk';
 const config = createCredentialConfig('your_sip_username', 'your_sip_password', {
   debug: true,
   pushNotificationDeviceToken: 'your_device_token',
+  pushWhenActive: true,
 });
 
 await voipClient.login(config);
@@ -283,10 +284,13 @@ import { createTokenConfig } from '@telnyx/react-voice-commons-sdk';
 const config = createTokenConfig('your_jwt_token', {
   debug: true,
   pushNotificationDeviceToken: 'your_device_token',
+  pushWhenActive: true,
 });
 
 await voipClient.loginWithToken(config);
 ```
+
+`pushWhenActive` is opt-in and defaults to `false`. Enable it on iOS when the device must receive a second PushKit call while another call is active or held.
 
 ### Automatic Storage & Reconnection
 
@@ -300,6 +304,7 @@ The library uses these AsyncStorage keys internally:
 - `@telnyx_password` - SIP password (credential auth)
 - `@credential_token` - JWT authentication token (token auth)
 - `@push_token` - Push notification device token
+- `@push_when_active` - Whether the device remains eligible for PushKit calls while connected
 
 **Note**: These are managed automatically by the library. You only need to call `login()` once, and the library will handle storage and future reconnections.
 

--- a/react-voice-commons-sdk/__mocks__/react-native.js
+++ b/react-voice-commons-sdk/__mocks__/react-native.js
@@ -3,6 +3,10 @@ module.exports = {
     OS: 'ios',
     select: jest.fn((obj) => obj.ios),
   },
+  AppState: {
+    currentState: 'active',
+    addEventListener: jest.fn(() => ({ remove: jest.fn() })),
+  },
   NativeModules: {},
   NativeEventEmitter: jest.fn(() => ({
     addListener: jest.fn(),

--- a/react-voice-commons-sdk/__tests__/internal/callkit-bridge-ios.test.js
+++ b/react-voice-commons-sdk/__tests__/internal/callkit-bridge-ios.test.js
@@ -5,6 +5,10 @@ const swiftSource = fs.readFileSync(
   path.join(__dirname, '..', '..', 'ios', 'CallKitBridge.swift'),
   'utf8'
 );
+const objectiveCSource = fs.readFileSync(
+  path.join(__dirname, '..', '..', 'ios', 'CallKitBridge.m'),
+  'utf8'
+);
 
 function extractFunction(signature) {
   const start = swiftSource.indexOf(signature);
@@ -53,10 +57,15 @@ function sliceBetween(source, startToken, endToken) {
 
 const reportAndEndWatchdogCall = extractFunction('fileprivate func reportAndEndWatchdogCall(');
 const handleMissedCallPushIfNeeded = extractFunction('public func handleMissedCallPushIfNeeded(');
+const endAction = extractFunction(
+  'public func provider(_ provider: CXProvider, perform action: CXEndCallAction)'
+);
 const handleVoipPush = extractFunction('@objc public func handleVoipPush(');
 const answerAction = extractFunction(
   'public func provider(_ provider: CXProvider, perform action: CXAnswerCallAction)'
 );
+const answerCall = extractFunction('@objc func answerCall(');
+const handleIncomingVoipPush = extractFunction('@objc public func handleVoipPush(');
 
 describe('iOS CallKitBridge PushKit watchdog handling', () => {
   it('reports exactly one placeholder call, ends it, cleans state, then completes', () => {
@@ -86,7 +95,9 @@ describe('iOS CallKitBridge PushKit watchdog handling', () => {
       'guard let callIdString = callId, let callUUID = UUID(uuidString: callIdString) else {',
       'return'
     );
-    const storeIndex = handleVoipPush.indexOf('UserDefaults.standard.set("incoming_call"');
+    const storeIndex = handleVoipPush.indexOf(
+      'self.storePendingVoipPush(payload.dictionaryPayload)'
+    );
     const malformedReturnIndex = handleVoipPush.indexOf(
       'return',
       handleVoipPush.indexOf('source: "malformed_push_watchdog"')
@@ -142,5 +153,90 @@ describe('iOS CallKitBridge PushKit watchdog handling', () => {
     expect(placeholderIndex).toBeGreaterThanOrEqual(0);
     expect(failIndex).toBeGreaterThan(placeholderIndex);
     expect(emitIndex).toBeGreaterThan(failIndex);
+  });
+});
+
+describe('iOS CallKitBridge call waiting contract', () => {
+  it('allows two one-call groups and advertises holding', () => {
+    expect(swiftSource).toContain('configuration.maximumCallGroups = 2');
+    expect(swiftSource).toContain('configuration.maximumCallsPerCallGroup = 1');
+    expect(swiftSource).toContain('callUpdate.supportsHolding = true');
+  });
+
+  it('keeps answer and held actions keyed by UUID', () => {
+    expect(swiftSource).toContain('LockedDictionary<UUID, CXAnswerCallAction>');
+    expect(swiftSource).toContain('LockedDictionary<UUID, CXSetHeldCallAction>');
+    expect(swiftSource).toContain('pendingAnswerActions.removeValue(forKey: uuid)');
+    expect(swiftSource).toContain('pendingHeldActions.removeValue(forKey: uuid)');
+  });
+
+  it('rejects programmatic answers before submitting a transaction for an unknown UUID', () => {
+    const registrationGuard = answerCall.indexOf('guard manager.isCallKitRegistered(uuid)');
+    const transaction = answerCall.indexOf('CXAnswerCallAction(call: uuid)');
+
+    expect(objectiveCSource).toContain('RCT_EXTERN_METHOD(isCallRegistered:');
+    expect(registrationGuard).toBeGreaterThanOrEqual(0);
+    expect(transaction).toBeGreaterThan(registrationGuard);
+    expect(answerAction).toContain('guard isCallKitRegistered(action.callUUID)');
+  });
+
+  it('persists PushKit data only after CallKit accepts incoming registration', () => {
+    const errorBranch = sliceBetween(handleIncomingVoipPush, 'if let error = error {', '} else {');
+    const successStart = handleIncomingVoipPush.indexOf('} else {');
+    const persistIndex = handleIncomingVoipPush.indexOf(
+      'self.storePendingVoipPush(payload.dictionaryPayload)'
+    );
+    const registrationIndex = handleIncomingVoipPush.indexOf(
+      'callKitManager.markCallKitRegistered(callUUID)'
+    );
+
+    expect(errorBranch).toContain('clearPendingPushData(for: callUUID.uuidString)');
+    expect(errorBranch).not.toContain('storePendingVoipPush');
+    expect(registrationIndex).toBeGreaterThan(successStart);
+    expect(persistIndex).toBeGreaterThan(registrationIndex);
+    expect(persistIndex).toBeGreaterThan(successStart);
+  });
+
+  it('emits held actions and waits for explicit JavaScript completion', () => {
+    const heldAction = extractFunction(
+      'public func provider(_ provider: CXProvider, perform action: CXSetHeldCallAction)'
+    );
+    const completion = extractFunction('@objc func completeHeldCallAction(');
+
+    expect(heldAction).toContain('emitHeldCallEvent(');
+    expect(heldAction).not.toContain('action.fulfill()');
+    expect(completion).toContain('action.fulfill()');
+    expect(completion).toContain('action.fail()');
+  });
+
+  it('requests an atomic two-action transaction when swapping calls', () => {
+    const swapCalls = extractFunction('@objc func swapCalls(');
+
+    expect(objectiveCSource).toContain('RCT_EXTERN_METHOD(swapCalls:');
+    expect(swapCalls).toContain('CXSetHeldCallAction(call: activeUUID, onHold: true)');
+    expect(swapCalls).toContain('CXSetHeldCallAction(call: heldUUID, onHold: false)');
+    expect(swapCalls).toContain('CXTransaction(actions: actions)');
+  });
+
+  it('requests a CallKit transaction for app-originated hold changes', () => {
+    const setCallHeld = extractFunction('@objc func setCallHeld(');
+
+    expect(objectiveCSource).toContain('RCT_EXTERN_METHOD(setCallHeld:');
+    expect(setCallHeld).toContain('CXSetHeldCallAction(call: uuid, onHold: isOnHold)');
+    expect(setCallHeld).toContain('CXTransaction(action: action)');
+  });
+
+  it('fails an end action for an unknown UUID before emitting or removing anything', () => {
+    const guardIndex = endAction.indexOf('guard let callData = activeCalls[action.callUUID]');
+    const failIndex = endAction.indexOf('action.fail()');
+    const returnIndex = endAction.indexOf('return', failIndex);
+    const emitIndex = endAction.indexOf('emitCallEvent(');
+    const removeIndex = endAction.indexOf('activeCalls.removeValue(forKey: action.callUUID)');
+
+    expect(guardIndex).toBeGreaterThanOrEqual(0);
+    expect(failIndex).toBeGreaterThan(guardIndex);
+    expect(returnIndex).toBeGreaterThan(failIndex);
+    expect(emitIndex).toBeGreaterThan(returnIndex);
+    expect(removeIndex).toBeGreaterThan(returnIndex);
   });
 });

--- a/react-voice-commons-sdk/__tests__/internal/callkit-coordinator-call-waiting.test.ts
+++ b/react-voice-commons-sdk/__tests__/internal/callkit-coordinator-call-waiting.test.ts
@@ -64,6 +64,8 @@ describe('CallKitCoordinator UUID-targeted call waiting', () => {
     jest.spyOn(CallKit, 'setCallHeld').mockResolvedValue(true);
     jest.spyOn(CallKit, 'swapCalls').mockResolvedValue(true);
     jest.spyOn(CallKit, 'endCall').mockResolvedValue(true);
+    jest.spyOn(CallKit, 'reportCallConnected').mockResolvedValue(true);
+    jest.spyOn(CallKit, 'reportCallEnded').mockResolvedValue(true);
   });
 
   afterEach(() => {
@@ -406,5 +408,79 @@ describe('CallKitCoordinator UUID-targeted call waiting', () => {
     expect(voipClient.queueAnswerFromCallKit).toHaveBeenCalledWith('callkit-b');
     expect(voipClient.handlePushNotification).toHaveBeenCalledTimes(1);
     expect(VoicePnBridge.clearPendingVoipPush).not.toHaveBeenCalled();
+  });
+
+  it('returns false when CallKit registration is rejected', async () => {
+    (CallKit.isCallRegistered as jest.Mock).mockResolvedValue(false);
+    (VoicePnBridge.getPendingVoipPush as jest.Mock).mockResolvedValue(
+      JSON.stringify({
+        payload: { metadata: { call_id: 'callkit-rejected', voice_sdk_id: 'voice-sdk-r' } },
+      })
+    );
+    const voipClient = {
+      queueEndFromCallKit: jest.fn(),
+      handlePushNotification: jest.fn().mockResolvedValue(undefined),
+    };
+    coordinator.voipClient = voipClient;
+
+    const result = await callKitCoordinator.handleCallKitPushReceived('CALLKIT-REJECTED');
+
+    expect(result).toBe(false);
+    expect(voipClient.handlePushNotification).not.toHaveBeenCalled();
+  });
+
+  it('returns false for a duplicate push UUID', async () => {
+    coordinator.pendingPushCallUUIDs.add('callkit-dup');
+
+    const result = await callKitCoordinator.handleCallKitPushReceived('callkit-dup');
+
+    expect(result).toBe(false);
+  });
+
+  it('returns true when push notification is processed successfully', async () => {
+    (VoicePnBridge.getPendingVoipPush as jest.Mock).mockResolvedValue(
+      JSON.stringify({
+        payload: { metadata: { call_id: 'callkit-ok', voice_sdk_id: 'voice-sdk-ok' } },
+      })
+    );
+    const voipClient = {
+      setPushNotificationCallKitUUID: jest.fn(),
+      queueAnswerFromCallKit: jest.fn(),
+      handlePushNotification: jest.fn().mockResolvedValue(undefined),
+    };
+    coordinator.voipClient = voipClient;
+
+    const result = await callKitCoordinator.handleCallKitPushReceived('callkit-ok');
+
+    expect(result).toBe(true);
+    expect(voipClient.handlePushNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it('completes the pending CallKit answer action when the call is already active', async () => {
+    const call = lowLevelCall('signal-active', 'active');
+    (call as any)._callKitUUID = 'callkit-active';
+    coordinator.callMap.set('callkit-active', call);
+    coordinator.connectedCalls.clear();
+
+    await callKitCoordinator.handleCallKitAnswer('callkit-active');
+
+    // Should not attempt to answer again
+    expect(call.answer).not.toHaveBeenCalled();
+    // Should report connected to fulfill the pending CXAnswerCallAction
+    expect(CallKit.reportCallConnected).toHaveBeenCalledWith('callkit-active');
+    // Should mark the call as connected to avoid duplicate reports
+    expect(coordinator.connectedCalls.has('callkit-active')).toBe(true);
+  });
+
+  it('does not double-report connected when already-active call was previously connected', async () => {
+    const call = lowLevelCall('signal-active', 'active');
+    (call as any)._callKitUUID = 'callkit-active';
+    coordinator.callMap.set('callkit-active', call);
+    coordinator.connectedCalls.add('callkit-active');
+
+    await callKitCoordinator.handleCallKitAnswer('callkit-active');
+
+    expect(call.answer).not.toHaveBeenCalled();
+    expect(CallKit.reportCallConnected).not.toHaveBeenCalled();
   });
 });

--- a/react-voice-commons-sdk/__tests__/internal/callkit-coordinator-call-waiting.test.ts
+++ b/react-voice-commons-sdk/__tests__/internal/callkit-coordinator-call-waiting.test.ts
@@ -1,0 +1,390 @@
+import CallKit from '../../src/callkit/callkit';
+import { callKitCoordinator } from '../../src/callkit/callkit-coordinator';
+import { VoicePnBridge } from '../../src/internal/voice-pn-bridge';
+
+jest.mock('../../src/internal/voice-pn-bridge', () => ({
+  VoicePnBridge: {
+    getPendingVoipPush: jest.fn(),
+    clearPendingVoipPush: jest.fn().mockResolvedValue(true),
+    setPendingPushAction: jest.fn().mockResolvedValue(true),
+  },
+}));
+
+function lowLevelCall(callId: string, state: string) {
+  return {
+    callId,
+    state,
+    direction: 'inbound',
+    hold: jest.fn().mockImplementation(async function (this: any) {
+      this.state = 'held';
+    }),
+    unhold: jest.fn().mockImplementation(async function (this: any) {
+      this.state = 'active';
+    }),
+    answer: jest.fn().mockResolvedValue(undefined),
+    hangup: jest.fn(),
+    on: jest.fn(),
+    removeListener: jest.fn(),
+  } as any;
+}
+
+const flushMicrotasks = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+describe('CallKitCoordinator UUID-targeted call waiting', () => {
+  const coordinator = callKitCoordinator as any;
+
+  beforeEach(() => {
+    coordinator.callMap.clear();
+    coordinator.processingCalls.clear();
+    coordinator.endedCalls.clear();
+    coordinator.connectedCalls.clear();
+    coordinator.pendingPushCallUUIDs.clear();
+    coordinator.autoAnswerCallUUIDs.clear();
+    coordinator.selectedCallKitUUID = null;
+    coordinator.voipClient = null;
+    for (const request of coordinator.pendingHeldRequests.values()) {
+      clearTimeout(request.timeout);
+    }
+    coordinator.pendingHeldRequests.clear();
+    if (coordinator.pendingSwap) {
+      clearTimeout(coordinator.pendingSwap.timeout);
+      coordinator.pendingSwap = null;
+    }
+    (VoicePnBridge.getPendingVoipPush as jest.Mock).mockResolvedValue(null);
+    (VoicePnBridge.clearPendingVoipPush as jest.Mock).mockResolvedValue(true);
+    jest.spyOn(CallKit, 'isAvailable').mockReturnValue(true);
+    jest.spyOn(CallKit, 'isCallRegistered').mockResolvedValue(true);
+    jest.spyOn(CallKit, 'reportIncomingCall').mockResolvedValue(true);
+    jest.spyOn(CallKit, 'completeHeldCallAction').mockResolvedValue(true);
+    jest.spyOn(CallKit, 'setCallHeld').mockResolvedValue(true);
+    jest.spyOn(CallKit, 'swapCalls').mockResolvedValue(true);
+    jest.spyOn(CallKit, 'endCall').mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('holds only the call identified by the CallKit UUID', async () => {
+    const first = lowLevelCall('signal-a', 'active');
+    const second = lowLevelCall('signal-b', 'active');
+    coordinator.callMap.set('callkit-a', first);
+    coordinator.callMap.set('callkit-b', second);
+
+    await callKitCoordinator.handleCallKitHeld('CALLKIT-A', true);
+
+    expect(first.hold).toHaveBeenCalledTimes(1);
+    expect(second.hold).not.toHaveBeenCalled();
+    expect(CallKit.completeHeldCallAction).toHaveBeenCalledWith('callkit-a', true);
+  });
+
+  it('fails an unknown UUID without modifying another call', async () => {
+    const existing = lowLevelCall('signal-a', 'active');
+    coordinator.callMap.set('callkit-a', existing);
+
+    await callKitCoordinator.handleCallKitHeld('missing-call', true);
+
+    expect(existing.hold).not.toHaveBeenCalled();
+    expect(existing.unhold).not.toHaveBeenCalled();
+    expect(CallKit.completeHeldCallAction).toHaveBeenCalledWith('missing-call', false);
+  });
+
+  it('ends and unmaps a signaling call when CallKit rejects incoming registration', async () => {
+    const call = lowLevelCall('f8cb65d9-8b26-4992-bec1-be0afab4c4bb', 'ringing');
+    (CallKit.reportIncomingCall as jest.Mock).mockResolvedValue(false);
+
+    await expect(
+      callKitCoordinator.reportIncomingCall(call, 'Focus caller', 'focus-caller')
+    ).resolves.toBeNull();
+
+    expect(call.hangup).toHaveBeenCalledTimes(1);
+    expect(coordinator.callMap.has(call.callId)).toBe(false);
+    expect((call as any)._callKitUUID).toBeUndefined();
+  });
+
+  it('does not submit an answer transaction for a rejected CallKit UUID', async () => {
+    const call = lowLevelCall('signal-focus', 'ringing');
+    Object.defineProperty(call, '_callKitUUID', {
+      value: 'callkit-focus',
+      writable: false,
+      configurable: false,
+    });
+    coordinator.callMap.set('callkit-focus', call);
+    (CallKit.isCallRegistered as jest.Mock).mockResolvedValue(false);
+    const answerCall = jest.spyOn(CallKit, 'answerCall').mockResolvedValue(true);
+
+    await expect(callKitCoordinator.answerCallFromUI(call)).resolves.toBe(false);
+
+    expect(answerCall).not.toHaveBeenCalled();
+    expect(call.answer).not.toHaveBeenCalled();
+    expect(call.hangup).toHaveBeenCalledTimes(1);
+    expect(coordinator.callMap.has('callkit-focus')).toBe(false);
+  });
+
+  it('selects the exact call after a successful resume', async () => {
+    const held = lowLevelCall('signal-b', 'held');
+    const wrapper = { callId: 'signal-b' };
+    const voipClient = {
+      findCallByTelnyxCall: jest.fn(() => wrapper),
+      setActiveCall: jest.fn(),
+    };
+    coordinator.voipClient = voipClient;
+    coordinator.callMap.set('callkit-b', held);
+    (held as any)._callKitUUID = 'callkit-b';
+
+    await callKitCoordinator.handleCallKitHeld('callkit-b', false);
+
+    expect(held.unhold).toHaveBeenCalledTimes(1);
+    expect(voipClient.setActiveCall).toHaveBeenCalledWith('signal-b');
+  });
+
+  it('routes an app hold request through CallKit and waits for signaling completion', async () => {
+    const first = lowLevelCall('signal-a', 'active');
+    (first as any)._callKitUUID = 'callkit-a';
+    coordinator.callMap.set('callkit-a', first);
+
+    const request = callKitCoordinator.setHeldFromUI(first, true);
+    await flushMicrotasks();
+
+    expect(CallKit.setCallHeld).toHaveBeenCalledWith('callkit-a', true);
+
+    await callKitCoordinator.handleCallKitHeld('callkit-a', true);
+
+    await expect(request).resolves.toBe(true);
+    expect(first.hold).toHaveBeenCalledTimes(1);
+  });
+
+  it('swaps the active and held calls through one CallKit transaction', async () => {
+    const first = lowLevelCall('signal-a', 'active');
+    const second = lowLevelCall('signal-b', 'held');
+    (first as any)._callKitUUID = 'callkit-a';
+    (second as any)._callKitUUID = 'callkit-b';
+    const secondWrapper = { callId: 'signal-b' };
+    const voipClient = {
+      findCallByTelnyxCall: jest.fn((call) => (call === second ? secondWrapper : null)),
+      setActiveCall: jest.fn(),
+    };
+    coordinator.voipClient = voipClient;
+    coordinator.callMap.set('callkit-a', first);
+    coordinator.callMap.set('callkit-b', second);
+
+    const swapPromise = callKitCoordinator.swapCallsFromUI(first, second);
+    await Promise.resolve();
+
+    expect(CallKit.swapCalls).toHaveBeenCalledWith('callkit-a', 'callkit-b');
+
+    await callKitCoordinator.handleCallKitHeld('callkit-a', true);
+    await callKitCoordinator.handleCallKitHeld('callkit-b', false);
+
+    await expect(swapPromise).resolves.toBe(true);
+    expect(first.hold).toHaveBeenCalledTimes(1);
+    expect(second.unhold).toHaveBeenCalledTimes(1);
+    expect(voipClient.setActiveCall).toHaveBeenCalledWith('signal-b');
+  });
+
+  it('resumes and selects the held survivor when the selected call ends', async () => {
+    const first = lowLevelCall('signal-a', 'held');
+    const second = lowLevelCall('signal-b', 'active');
+    (first as any)._callKitUUID = 'callkit-a';
+    (second as any)._callKitUUID = 'callkit-b';
+    const firstWrapper = { callId: 'signal-a' };
+    const voipClient = {
+      findCallByTelnyxCall: jest.fn((call) => (call === first ? firstWrapper : null)),
+      setActiveCall: jest.fn(),
+    };
+    coordinator.voipClient = voipClient;
+    coordinator.callMap.set('callkit-a', first);
+    coordinator.callMap.set('callkit-b', second);
+    coordinator.selectedCallKitUUID = 'callkit-b';
+
+    const end = coordinator.handleCallKitEnd('callkit-b');
+    await flushMicrotasks();
+    expect(CallKit.setCallHeld).toHaveBeenCalledWith('callkit-a', false);
+
+    await callKitCoordinator.handleCallKitHeld('callkit-a', false);
+    await end;
+
+    expect(second.hangup).toHaveBeenCalledTimes(1);
+    expect(first.unhold).toHaveBeenCalledTimes(1);
+    expect(voipClient.setActiveCall).toHaveBeenCalledWith('signal-a');
+  });
+
+  it('lets the CallKit end event drive app-UI hangup and survivor restoration', async () => {
+    const first = lowLevelCall('signal-a', 'held');
+    const second = lowLevelCall('signal-b', 'active');
+    (first as any)._callKitUUID = 'callkit-a';
+    (second as any)._callKitUUID = 'callkit-b';
+    coordinator.callMap.set('callkit-a', first);
+    coordinator.callMap.set('callkit-b', second);
+    coordinator.selectedCallKitUUID = 'callkit-b';
+
+    await expect(callKitCoordinator.endCallFromUI(second)).resolves.toBe(true);
+    expect(second.hangup).not.toHaveBeenCalled();
+
+    const nativeEnd = coordinator.handleCallKitEnd('callkit-b');
+    await flushMicrotasks();
+    await callKitCoordinator.handleCallKitHeld('callkit-a', false);
+    await nativeEnd;
+
+    expect(second.hangup).toHaveBeenCalledTimes(1);
+    expect(first.unhold).toHaveBeenCalledTimes(1);
+    expect(first.state).toBe('active');
+  });
+
+  it('restores original states through a compensating transaction after a partial swap failure', async () => {
+    const first = lowLevelCall('signal-a', 'active');
+    const second = lowLevelCall('signal-b', 'held');
+    (first as any)._callKitUUID = 'callkit-a';
+    (second as any)._callKitUUID = 'callkit-b';
+    coordinator.callMap.set('callkit-a', first);
+    coordinator.callMap.set('callkit-b', second);
+    (CallKit.completeHeldCallAction as jest.Mock)
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(true);
+
+    const swap = callKitCoordinator.swapCallsFromUI(first, second);
+    await flushMicrotasks();
+    await callKitCoordinator.handleCallKitHeld('callkit-a', true);
+    await callKitCoordinator.handleCallKitHeld('callkit-b', false);
+    await flushMicrotasks();
+
+    expect(CallKit.swapCalls).toHaveBeenNthCalledWith(1, 'callkit-a', 'callkit-b');
+    expect(CallKit.swapCalls).toHaveBeenNthCalledWith(2, 'callkit-b', 'callkit-a');
+    expect(first.state).toBe('active');
+    expect(second.state).toBe('held');
+
+    await callKitCoordinator.handleCallKitHeld('callkit-b', true);
+    await callKitCoordinator.handleCallKitHeld('callkit-a', false);
+
+    await expect(swap).resolves.toBe(false);
+    expect(first.state).toBe('active');
+    expect(second.state).toBe('held');
+  });
+
+  it('blocks another swap while compensating WebRTC state is being restored', async () => {
+    const first = lowLevelCall('signal-a', 'active');
+    const second = lowLevelCall('signal-b', 'held');
+    (first as any)._callKitUUID = 'callkit-a';
+    (second as any)._callKitUUID = 'callkit-b';
+    coordinator.callMap.set('callkit-a', first);
+    coordinator.callMap.set('callkit-b', second);
+
+    let finishRestoration!: () => void;
+    const restoration = new Promise<void>((resolve) => {
+      finishRestoration = resolve;
+    });
+    jest.spyOn(coordinator, 'restoreOriginalWebRTCStates').mockImplementation(() => restoration);
+
+    const originalSwap = callKitCoordinator.swapCallsFromUI(first, second);
+    await flushMicrotasks();
+    const pendingSwap = coordinator.pendingSwap;
+    const rollback = coordinator.beginSwapRollback(pendingSwap);
+    await flushMicrotasks();
+
+    await expect(callKitCoordinator.swapCallsFromUI(first, second)).resolves.toBe(false);
+    expect(CallKit.swapCalls).toHaveBeenCalledTimes(1);
+
+    finishRestoration();
+    await rollback;
+    expect(CallKit.swapCalls).toHaveBeenCalledTimes(2);
+
+    coordinator.finishPendingSwap(false);
+    await expect(originalSwap).resolves.toBe(false);
+  });
+
+  it('processes a pushed UUID once across native event and app-resume delivery', async () => {
+    (VoicePnBridge.getPendingVoipPush as jest.Mock).mockResolvedValue(
+      JSON.stringify({
+        payload: { metadata: { call_id: 'callkit-b', voice_sdk_id: 'voice-sdk-b' } },
+      })
+    );
+    const voipClient = {
+      setPushNotificationCallKitUUID: jest.fn(),
+      queueAnswerFromCallKit: jest.fn(),
+      handlePushNotification: jest.fn().mockResolvedValue(undefined),
+    };
+    coordinator.voipClient = voipClient;
+
+    await callKitCoordinator.handleCallKitPushReceived('CALLKIT-B');
+    await callKitCoordinator.handleCallKitPushReceived('callkit-b');
+
+    expect(voipClient.handlePushNotification).toHaveBeenCalledTimes(1);
+    expect(voipClient.setPushNotificationCallKitUUID).toHaveBeenCalledWith('callkit-b');
+  });
+
+  it('suppresses persisted push processing when CallKit rejected its UUID', async () => {
+    (CallKit.isCallRegistered as jest.Mock).mockResolvedValue(false);
+    (VoicePnBridge.getPendingVoipPush as jest.Mock).mockResolvedValue(
+      JSON.stringify({
+        payload: { metadata: { call_id: 'callkit-focus', voice_sdk_id: 'voice-sdk-focus' } },
+      })
+    );
+    const voipClient = {
+      queueEndFromCallKit: jest.fn(),
+      handlePushNotification: jest.fn().mockResolvedValue(undefined),
+    };
+    coordinator.voipClient = voipClient;
+
+    await callKitCoordinator.handleCallKitPushReceived('CALLKIT-FOCUS');
+
+    expect(voipClient.queueEndFromCallKit).toHaveBeenCalledWith('callkit-focus');
+    expect(voipClient.handlePushNotification).not.toHaveBeenCalled();
+    expect(VoicePnBridge.clearPendingVoipPush).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses only the UUID-keyed pending answer path for a cold CallKit answer', async () => {
+    (VoicePnBridge.getPendingVoipPush as jest.Mock).mockResolvedValue(
+      JSON.stringify({
+        payload: { metadata: { call_id: 'callkit-b', voice_sdk_id: 'voice-sdk-b' } },
+      })
+    );
+    const voipClient = {
+      setPushNotificationCallKitUUID: jest.fn(),
+      queueAnswerFromCallKit: jest.fn(),
+      handlePushNotification: jest.fn().mockResolvedValue(undefined),
+    };
+    coordinator.voipClient = voipClient;
+    coordinator.autoAnswerCallUUIDs.add('callkit-b');
+
+    await callKitCoordinator.handleCallKitPushReceived('callkit-b');
+
+    expect(voipClient.queueAnswerFromCallKit).toHaveBeenCalledWith('callkit-b');
+    expect(voipClient.handlePushNotification).toHaveBeenCalledWith({
+      metadata: expect.objectContaining({
+        call_id: 'callkit-b',
+        from_callkit: true,
+      }),
+    });
+    expect(voipClient.handlePushNotification.mock.calls[0][0]).not.toHaveProperty(
+      'from_notification'
+    );
+    expect(voipClient.handlePushNotification.mock.calls[0][0]).not.toHaveProperty('action');
+  });
+
+  it('processes the persisted push immediately when CallKit is answered before its INVITE', async () => {
+    (VoicePnBridge.clearPendingVoipPush as jest.Mock).mockClear();
+    (VoicePnBridge.getPendingVoipPush as jest.Mock).mockResolvedValue(
+      JSON.stringify({
+        payload: { metadata: { call_id: 'callkit-b', voice_sdk_id: 'voice-sdk-b' } },
+      })
+    );
+    const voipClient = {
+      setPushNotificationCallKitUUID: jest.fn(),
+      queueAnswerFromCallKit: jest.fn(),
+      handlePushNotification: jest.fn().mockResolvedValue(undefined),
+    };
+    coordinator.voipClient = voipClient;
+
+    await coordinator.handlePushNotificationAnswer('callkit-b');
+
+    expect(voipClient.queueAnswerFromCallKit).toHaveBeenCalledWith('callkit-b');
+    expect(voipClient.handlePushNotification).toHaveBeenCalledTimes(1);
+    expect(VoicePnBridge.clearPendingVoipPush).not.toHaveBeenCalled();
+  });
+});

--- a/react-voice-commons-sdk/__tests__/internal/callkit-coordinator-call-waiting.test.ts
+++ b/react-voice-commons-sdk/__tests__/internal/callkit-coordinator-call-waiting.test.ts
@@ -38,6 +38,7 @@ describe('CallKitCoordinator UUID-targeted call waiting', () => {
   const coordinator = callKitCoordinator as any;
 
   beforeEach(() => {
+    jest.clearAllMocks();
     coordinator.callMap.clear();
     coordinator.processingCalls.clear();
     coordinator.endedCalls.clear();
@@ -123,6 +124,25 @@ describe('CallKitCoordinator UUID-targeted call waiting', () => {
     expect(call.answer).not.toHaveBeenCalled();
     expect(call.hangup).toHaveBeenCalledTimes(1);
     expect(coordinator.callMap.has('callkit-focus')).toBe(false);
+  });
+
+  it('clears the matching persisted push after an in-app answer succeeds', async () => {
+    const call = lowLevelCall('signal-b', 'ringing');
+    (call as any)._callKitUUID = 'callkit-b';
+    coordinator.callMap.set('callkit-b', call);
+    coordinator.pendingPushCallUUIDs.add('callkit-b');
+    (VoicePnBridge.getPendingVoipPush as jest.Mock).mockResolvedValue(
+      JSON.stringify({
+        payload: { metadata: { call_id: 'CALLKIT-B', voice_sdk_id: 'voice-sdk-b' } },
+      })
+    );
+    jest.spyOn(CallKit, 'answerCall').mockResolvedValue(true);
+
+    await expect(callKitCoordinator.answerCallFromUI(call)).resolves.toBe(true);
+
+    expect(call.answer).toHaveBeenCalledTimes(1);
+    expect(VoicePnBridge.clearPendingVoipPush).toHaveBeenCalledTimes(1);
+    expect(coordinator.pendingPushCallUUIDs.has('callkit-b')).toBe(false);
   });
 
   it('selects the exact call after a successful resume', async () => {

--- a/react-voice-commons-sdk/__tests__/internal/session-manager.test.ts
+++ b/react-voice-commons-sdk/__tests__/internal/session-manager.test.ts
@@ -13,6 +13,24 @@ describe('SessionManager', () => {
     jest.restoreAllMocks();
   });
 
+  it('passes push-when-active through to the low-level SDK client', async () => {
+    const manager = new SessionManager();
+    const config = createCredentialConfig('sip-user', 'sip-password', {
+      pushNotificationDeviceToken: 'push-token',
+      pushWhenActive: true,
+    });
+
+    await manager.connectWithCredential(config);
+
+    const TelnyxRTCMock = TelnyxSDK.TelnyxRTC as unknown as jest.Mock;
+    expect(TelnyxRTCMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pushNotificationDeviceToken: 'push-token',
+        pushWhenActive: true,
+      })
+    );
+  });
+
   it('disconnects the underlying TelnyxRTC client before marking itself disposed', async () => {
     const manager = new SessionManager();
 
@@ -195,4 +213,28 @@ describe('SessionManager', () => {
     ).rejects.toThrow('prior disconnect failed');
     expect(manager.telnyxClient).toBe(telnyxClient);
   });
+
+  it.each(['active', 'held'])(
+    'preserves the client for a second push while a call is %s',
+    async (state) => {
+      const manager = new SessionManager();
+      await manager.connectWithCredential(createCredentialConfig('sip-user', 'sip-password'));
+
+      const TelnyxRTCMock = TelnyxSDK.TelnyxRTC as unknown as jest.Mock;
+      const telnyxClient = TelnyxRTCMock.mock.results[0]?.value;
+      telnyxClient.getActiveCalls = jest.fn(() => [{ callId: 'first-call', state }]);
+      telnyxClient.processVoIPNotification = jest.fn();
+
+      await manager.handlePushNotification({
+        metadata: { call_id: 'second-call', voice_sdk_id: 'second-voice-sdk-id' },
+      });
+
+      expect(telnyxClient.disconnect).not.toHaveBeenCalled();
+      expect(manager.telnyxClient).toBe(telnyxClient);
+      expect(telnyxClient.processVoIPNotification).toHaveBeenCalledWith({
+        call_id: 'second-call',
+        voice_sdk_id: 'second-voice-sdk-id',
+      });
+    }
+  );
 });

--- a/react-voice-commons-sdk/__tests__/models/call-held-state.test.ts
+++ b/react-voice-commons-sdk/__tests__/models/call-held-state.test.ts
@@ -1,0 +1,58 @@
+import { Call } from '../../src/models/call';
+import { callKitCoordinator } from '../../src/callkit/callkit-coordinator';
+
+describe('Commons Call held state', () => {
+  it('emits true for HELD and false after returning to ACTIVE', () => {
+    let stateListener: ((call: any, state: string) => void) | undefined;
+    const telnyxCall = {
+      callId: 'signaling-call-id',
+      state: 'active',
+      direction: 'inbound',
+      inviteCustomHeaders: null,
+      answerCustomHeaders: null,
+      on: jest.fn((event: string, listener: (call: any, state: string) => void) => {
+        if (event === 'telnyx.call.state') stateListener = listener;
+      }),
+    };
+    const call = new Call(telnyxCall as any, 'call-id', '+15551234567', true);
+    const heldValues: boolean[] = [];
+    call.isHeld$.subscribe((held) => heldValues.push(held));
+
+    stateListener?.(telnyxCall, 'held');
+    stateListener?.(telnyxCall, 'active');
+
+    expect(heldValues).toEqual([false, true, false]);
+    expect(call.currentIsHeld).toBe(false);
+    call.dispose();
+  });
+
+  it('routes app hold and resume actions through CallKit on iOS', async () => {
+    let stateListener: ((call: any, state: string) => void) | undefined;
+    const telnyxCall = {
+      callId: 'signaling-call-id',
+      state: 'active',
+      direction: 'inbound',
+      inviteCustomHeaders: null,
+      answerCustomHeaders: null,
+      hold: jest.fn(),
+      unhold: jest.fn(),
+      on: jest.fn((event: string, listener: (call: any, state: string) => void) => {
+        if (event === 'telnyx.call.state') stateListener = listener;
+      }),
+    };
+    const call = new Call(telnyxCall as any, 'call-id', '+15551234567', true);
+    jest.spyOn(callKitCoordinator, 'isAvailable').mockReturnValue(true);
+    const setHeld = jest.spyOn(callKitCoordinator, 'setHeldFromUI').mockResolvedValue(true);
+
+    stateListener?.(telnyxCall, 'active');
+    await call.hold();
+    stateListener?.(telnyxCall, 'held');
+    await call.resume();
+
+    expect(setHeld).toHaveBeenNthCalledWith(1, telnyxCall, true);
+    expect(setHeld).toHaveBeenNthCalledWith(2, telnyxCall, false);
+    expect(telnyxCall.hold).not.toHaveBeenCalled();
+    expect(telnyxCall.unhold).not.toHaveBeenCalled();
+    call.dispose();
+  });
+});

--- a/react-voice-commons-sdk/__tests__/push-when-active-config.test.ts
+++ b/react-voice-commons-sdk/__tests__/push-when-active-config.test.ts
@@ -1,0 +1,134 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { TelnyxVoipClient } from '../src/telnyx-voip-client';
+import { createCredentialConfig, createTokenConfig } from '../src/models/config';
+import { VoicePnBridge } from '../src/internal/voice-pn-bridge';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(),
+    setItem: jest.fn().mockResolvedValue(undefined),
+    removeItem: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
+describe('push-when-active configuration persistence', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(VoicePnBridge, 'getVoipToken').mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('stores the opt-in for cold-start push login', async () => {
+    const client = new TelnyxVoipClient();
+    jest
+      .spyOn((client as any)._sessionManager, 'connectWithCredential')
+      .mockResolvedValue(undefined);
+
+    await client.login(
+      createCredentialConfig('sip-user', 'sip-password', {
+        pushNotificationDeviceToken: 'push-token',
+        pushWhenActive: true,
+      })
+    );
+
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith('@push_when_active', 'true');
+  });
+
+  it('restores the opt-in when reconnecting from stored credentials', async () => {
+    const storedValues: Record<string, string> = {
+      '@telnyx_username': 'sip-user',
+      '@telnyx_password': 'sip-password',
+      '@push_token': 'push-token',
+      '@push_when_active': 'true',
+    };
+    (AsyncStorage.getItem as jest.Mock).mockImplementation(
+      async (key: string) => storedValues[key] ?? null
+    );
+    const client = new TelnyxVoipClient();
+    const connect = jest
+      .spyOn((client as any)._sessionManager, 'connectWithCredential')
+      .mockResolvedValue(undefined);
+
+    await expect(client.loginFromStoredConfig()).resolves.toBe(true);
+    expect(connect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pushNotificationDeviceToken: 'push-token',
+        pushWhenActive: true,
+      })
+    );
+  });
+
+  it('hydrates a missing credential-login token from native PushKit storage', async () => {
+    jest.spyOn(VoicePnBridge, 'getVoipToken').mockResolvedValue('native-push-token');
+    const client = new TelnyxVoipClient();
+    const connect = jest
+      .spyOn((client as any)._sessionManager, 'connectWithCredential')
+      .mockResolvedValue(undefined);
+
+    await client.login(
+      createCredentialConfig('sip-user', 'sip-password', {
+        pushWhenActive: true,
+      })
+    );
+
+    expect(connect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pushNotificationDeviceToken: 'native-push-token',
+        pushWhenActive: true,
+      })
+    );
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith('@push_token', 'native-push-token');
+  });
+
+  it('hydrates a missing token-login token from native PushKit storage', async () => {
+    jest.spyOn(VoicePnBridge, 'getVoipToken').mockResolvedValue('native-push-token');
+    const client = new TelnyxVoipClient();
+    const connect = jest
+      .spyOn((client as any)._sessionManager, 'connectWithToken')
+      .mockResolvedValue(undefined);
+
+    await client.loginWithToken(
+      createTokenConfig('credential-token', {
+        pushWhenActive: true,
+      })
+    );
+
+    expect(connect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pushNotificationDeviceToken: 'native-push-token',
+        pushWhenActive: true,
+      })
+    );
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith('@push_token', 'native-push-token');
+  });
+
+  it('refreshes a stale stored push token before reconnecting', async () => {
+    const storedValues: Record<string, string> = {
+      '@telnyx_username': 'sip-user',
+      '@telnyx_password': 'sip-password',
+      '@push_token': 'stale-push-token',
+      '@push_when_active': 'true',
+    };
+    (AsyncStorage.getItem as jest.Mock).mockImplementation(
+      async (key: string) => storedValues[key] ?? null
+    );
+    jest.spyOn(VoicePnBridge, 'getVoipToken').mockResolvedValue('current-native-token');
+    const client = new TelnyxVoipClient();
+    const connect = jest
+      .spyOn((client as any)._sessionManager, 'connectWithCredential')
+      .mockResolvedValue(undefined);
+
+    await expect(client.loginFromStoredConfig()).resolves.toBe(true);
+
+    expect(connect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pushNotificationDeviceToken: 'current-native-token',
+      })
+    );
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith('@push_token', 'current-native-token');
+  });
+});

--- a/react-voice-commons-sdk/__tests__/telnyx-voip-client.test.ts
+++ b/react-voice-commons-sdk/__tests__/telnyx-voip-client.test.ts
@@ -3,6 +3,8 @@ import {
   createTelnyxVoipClient,
   destroyTelnyxVoipClient,
 } from '../src/telnyx-voip-client';
+import { callKitCoordinator } from '../src/callkit/callkit-coordinator';
+import { TelnyxCallState } from '../src/models/call-state';
 
 const flushMicrotasks = async (): Promise<void> => {
   await Promise.resolve();
@@ -89,5 +91,29 @@ describe('TelnyxVoipClient singleton lifecycle', () => {
 
     expect(setActiveCall).toHaveBeenCalledWith('call-2');
     expect(clearActiveCall).toHaveBeenCalledTimes(1);
+  });
+
+  it('coordinates an iOS swap using the current active call and requested held call', async () => {
+    const client = new TelnyxVoipClient();
+    const activeTelnyxCall = { callId: 'active-signal' };
+    const heldTelnyxCall = { callId: 'held-signal' };
+    const activeCall = {
+      callId: 'active',
+      currentState: TelnyxCallState.ACTIVE,
+      telnyxCall: activeTelnyxCall,
+    };
+    const heldCall = {
+      callId: 'held',
+      currentState: TelnyxCallState.HELD,
+      telnyxCall: heldTelnyxCall,
+    };
+    jest.spyOn(client, 'currentActiveCall', 'get').mockReturnValue(activeCall as any);
+    jest.spyOn(client, 'getCall').mockReturnValue(heldCall as any);
+    jest.spyOn(callKitCoordinator, 'isAvailable').mockReturnValue(true);
+    const swap = jest.spyOn(callKitCoordinator, 'swapCallsFromUI').mockResolvedValue(true);
+
+    await client.swapCalls('held');
+
+    expect(swap).toHaveBeenCalledWith(activeTelnyxCall, heldTelnyxCall);
   });
 });

--- a/react-voice-commons-sdk/__tests__/telnyx-voip-client.test.ts
+++ b/react-voice-commons-sdk/__tests__/telnyx-voip-client.test.ts
@@ -93,6 +93,31 @@ describe('TelnyxVoipClient singleton lifecycle', () => {
     expect(clearActiveCall).toHaveBeenCalledTimes(1);
   });
 
+  it('retains a cold-start CallKit answer until TelnyxRTC is created', () => {
+    const client = new TelnyxVoipClient();
+    const queueAnswerFromCallKit = jest.fn();
+    const sessionManager = (client as any)._sessionManager;
+
+    client.queueAnswerFromCallKit('CALLKIT-B', { 'X-Test': 'cold-start' });
+
+    expect((client as any)._pendingCallKitAnswers.has('callkit-b')).toBe(true);
+
+    sessionManager._telnyxClient = {
+      queueAnswerFromCallKit,
+      on: jest.fn(),
+      off: jest.fn(),
+      listenerCount: jest.fn().mockReturnValue(1),
+    };
+    sessionManager._onClientReady();
+    sessionManager._onClientReady();
+
+    expect(queueAnswerFromCallKit).toHaveBeenCalledTimes(1);
+    expect(queueAnswerFromCallKit).toHaveBeenCalledWith('callkit-b', {
+      'X-Test': 'cold-start',
+    });
+    expect((client as any)._pendingCallKitAnswers.size).toBe(0);
+  });
+
   it('coordinates an iOS swap using the current active call and requested held call', async () => {
     const client = new TelnyxVoipClient();
     const activeTelnyxCall = { callId: 'active-signal' };

--- a/react-voice-commons-sdk/ios/CallKitBridge.m
+++ b/react-voice-commons-sdk/ios/CallKitBridge.m
@@ -15,12 +15,31 @@ RCT_EXTERN_METHOD(reportIncomingCall:(NSString *)callUUID
                   resolver:(RCTPromiseResolveBlock)resolve 
                   rejecter:(RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(isCallRegistered:(NSString *)callUUID
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
 RCT_EXTERN_METHOD(answerCall:(NSString *)callUUID 
                   resolver:(RCTPromiseResolveBlock)resolve 
                   rejecter:(RCTPromiseRejectBlock)reject)
 
 RCT_EXTERN_METHOD(endCall:(NSString *)callUUID 
                   resolver:(RCTPromiseResolveBlock)resolve 
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(completeHeldCallAction:(NSString *)callUUID
+                  success:(BOOL)success
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(setCallHeld:(NSString *)callUUID
+                  isOnHold:(BOOL)isOnHold
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(swapCalls:(NSString *)activeCallUUID
+                  heldCallUUID:(NSString *)heldCallUUID
+                  resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 
 RCT_EXTERN_METHOD(reportCallConnected:(NSString *)callUUID 

--- a/react-voice-commons-sdk/ios/CallKitBridge.swift
+++ b/react-voice-commons-sdk/ios/CallKitBridge.swift
@@ -9,6 +9,49 @@ import React
     import UserNotifications
     import WebRTC
 
+    /// Small synchronized dictionary used because React Native module methods
+    /// and CXProvider delegate callbacks are not guaranteed to share a queue.
+    public final class LockedDictionary<Key: Hashable, Value> {
+        private var storage: [Key: Value] = [:]
+        private let lock: NSRecursiveLock
+
+        init(lock: NSRecursiveLock) {
+            self.lock = lock
+        }
+
+        public subscript(key: Key) -> Value? {
+            get {
+                lock.lock()
+                defer { lock.unlock() }
+                return storage[key]
+            }
+            set {
+                lock.lock()
+                defer { lock.unlock() }
+                storage[key] = newValue
+            }
+        }
+
+        public var values: [Value] {
+            lock.lock()
+            defer { lock.unlock() }
+            return Array(storage.values)
+        }
+
+        @discardableResult
+        public func removeValue(forKey key: Key) -> Value? {
+            lock.lock()
+            defer { lock.unlock() }
+            return storage.removeValue(forKey: key)
+        }
+
+        public func removeAll() {
+            lock.lock()
+            defer { lock.unlock() }
+            storage.removeAll()
+        }
+    }
+
     @objc(CallKitBridge)
     class CallKitBridge: RCTEventEmitter {
 
@@ -29,6 +72,7 @@ import React
                 "CallKitDidReceiveStartCallAction",
                 "CallKitDidPerformAnswerCallAction",
                 "CallKitDidPerformEndCallAction",
+                "CallKitDidPerformHeldCallAction",
                 "CallKitDidReceivePush",
                 "AudioSessionActivated",
                 "AudioSessionDeactivated",
@@ -61,6 +105,21 @@ import React
             sendEvent(withName: eventName, body: eventData)
         }
 
+        @discardableResult
+        public func emitHeldCallEvent(
+            callUUID: UUID, isOnHold: Bool, callData: [String: Any]?
+        ) -> Bool {
+            guard hasListeners else { return false }
+
+            let eventData: [String: Any] = [
+                "callUUID": callUUID.uuidString,
+                "isOnHold": isOnHold,
+                "callData": callData ?? [:],
+            ]
+            sendEvent(withName: "CallKitDidPerformHeldCallAction", body: eventData)
+            return true
+        }
+
         // Event emission method for audio session changes
         public func emitAudioSessionEvent(_ eventName: String, data: [String: Any]) {
             guard hasListeners else { return }
@@ -90,8 +149,17 @@ import React
             let startCallAction = CXStartCallAction(call: uuid, handle: callHandle)
             let transaction = CXTransaction(action: startCallAction)
 
+            manager.activeCalls[uuid] = [
+                "caller": displayName,
+                "handle": handle,
+                "uuid": uuid.uuidString,
+                "direction": "outgoing",
+                "source": "react_native",
+            ]
+
             callController.request(transaction) { error in
                 if let error = error {
+                    manager.activeCalls.removeValue(forKey: uuid)
                     reject("START_CALL_ERROR", error.localizedDescription, error)
                 } else {
                     resolve(["success": true, "callUUID": callUUID])
@@ -120,11 +188,23 @@ import React
             callUpdate.remoteHandle = callHandle
             callUpdate.hasVideo = false
             callUpdate.localizedCallerName = displayName
+            callUpdate.supportsHolding = true
+
+            manager.activeCalls[uuid] = [
+                "caller": displayName,
+                "handle": handle,
+                "uuid": uuid.uuidString,
+                "direction": "incoming",
+                "source": "react_native",
+                "isCallKitRegistered": false,
+            ]
 
             provider.reportNewIncomingCall(with: uuid, update: callUpdate) { error in
                 if let error = error {
+                    manager.activeCalls.removeValue(forKey: uuid)
                     reject("INCOMING_CALL_ERROR", error.localizedDescription, error)
                 } else {
+                    manager.markCallKitRegistered(uuid)
                     resolve(["success": true, "callUUID": callUUID])
                 }
             }
@@ -157,6 +237,127 @@ import React
             }
         }
 
+        @objc func completeHeldCallAction(
+            _ callUUID: String, success: Bool,
+            resolver resolve: @escaping RCTPromiseResolveBlock,
+            rejecter reject: @escaping RCTPromiseRejectBlock
+        ) {
+            guard let uuid = UUID(uuidString: callUUID) else {
+                reject("INVALID_UUID", "Invalid UUID format", nil)
+                return
+            }
+
+            let manager = getCallKitManager()
+            let completeAction = {
+                guard let action = manager.pendingHeldActions.removeValue(forKey: uuid) else {
+                    reject("NO_PENDING_HELD_ACTION", "No pending held action for UUID", nil)
+                    return
+                }
+
+                if success {
+                    if var callData = manager.activeCalls[uuid] {
+                        callData["isOnHold"] = action.isOnHold
+                        manager.activeCalls[uuid] = callData
+                    }
+                    action.fulfill()
+                } else {
+                    action.fail()
+                }
+                resolve(["success": success, "callUUID": callUUID])
+            }
+
+            if Thread.isMainThread {
+                completeAction()
+            } else {
+                DispatchQueue.main.async(execute: completeAction)
+            }
+        }
+
+        @objc func setCallHeld(
+            _ callUUID: String, isOnHold: Bool,
+            resolver resolve: @escaping RCTPromiseResolveBlock,
+            rejecter reject: @escaping RCTPromiseRejectBlock
+        ) {
+            guard let uuid = UUID(uuidString: callUUID) else {
+                reject("INVALID_UUID", "Invalid UUID format", nil)
+                return
+            }
+
+            let manager = getCallKitManager()
+            guard let callController = manager.callKitController else {
+                reject("NO_CALLKIT", "CallKit not available", nil)
+                return
+            }
+
+            guard manager.activeCalls[uuid] != nil else {
+                reject("UNKNOWN_CALL", "Call must be registered with CallKit", nil)
+                return
+            }
+
+            let action = CXSetHeldCallAction(call: uuid, onHold: isOnHold)
+            let transaction = CXTransaction(action: action)
+            callController.request(transaction) { error in
+                if let error = error {
+                    reject("SET_HELD_ERROR", error.localizedDescription, error)
+                } else {
+                    resolve([
+                        "success": true,
+                        "callUUID": callUUID,
+                        "isOnHold": isOnHold,
+                    ])
+                }
+            }
+        }
+
+        @objc func swapCalls(
+            _ activeCallUUID: String, heldCallUUID: String,
+            resolver resolve: @escaping RCTPromiseResolveBlock,
+            rejecter reject: @escaping RCTPromiseRejectBlock
+        ) {
+            guard let activeUUID = UUID(uuidString: activeCallUUID),
+                let heldUUID = UUID(uuidString: heldCallUUID)
+            else {
+                reject("INVALID_UUID", "Invalid UUID format", nil)
+                return
+            }
+
+            guard activeUUID != heldUUID else {
+                reject("INVALID_SWAP", "Active and held call UUIDs must be different", nil)
+                return
+            }
+
+            let manager = getCallKitManager()
+            guard let callController = manager.callKitController else {
+                reject("NO_CALLKIT", "CallKit not available", nil)
+                return
+            }
+
+            guard manager.activeCalls[activeUUID] != nil,
+                manager.activeCalls[heldUUID] != nil
+            else {
+                reject("UNKNOWN_CALL", "Both calls must be registered with CallKit", nil)
+                return
+            }
+
+            let actions: [CXAction] = [
+                CXSetHeldCallAction(call: activeUUID, onHold: true),
+                CXSetHeldCallAction(call: heldUUID, onHold: false),
+            ]
+            let transaction = CXTransaction(actions: actions)
+
+            callController.request(transaction) { error in
+                if let error = error {
+                    reject("SWAP_CALLS_ERROR", error.localizedDescription, error)
+                } else {
+                    resolve([
+                        "success": true,
+                        "activeCallUUID": activeCallUUID,
+                        "heldCallUUID": heldCallUUID,
+                    ])
+                }
+            }
+        }
+
         @objc func answerCall(
             _ callUUID: String, resolver resolve: @escaping RCTPromiseResolveBlock,
             rejecter reject: @escaping RCTPromiseRejectBlock
@@ -169,6 +370,15 @@ import React
             let manager = getCallKitManager()
             guard let callController = manager.callKitController else {
                 reject("NO_CALLKIT", "CallKit not available", nil)
+                return
+            }
+
+            guard manager.isCallKitRegistered(uuid) else {
+                reject(
+                    "UNKNOWN_CALL",
+                    "Call was not registered with CallKit or its registration was rejected",
+                    nil
+                )
                 return
             }
 
@@ -190,6 +400,22 @@ import React
             }
         }
 
+        @objc func isCallRegistered(
+            _ callUUID: String, resolver resolve: @escaping RCTPromiseResolveBlock,
+            rejecter reject: @escaping RCTPromiseRejectBlock
+        ) {
+            guard let uuid = UUID(uuidString: callUUID) else {
+                reject("INVALID_UUID", "Invalid UUID format", nil)
+                return
+            }
+
+            let registered = getCallKitManager().isCallKitRegistered(uuid)
+            resolve([
+                "registered": registered,
+                "callUUID": callUUID,
+            ])
+        }
+
         @objc func reportCallConnected(
             _ callUUID: String, resolver resolve: @escaping RCTPromiseResolveBlock,
             rejecter reject: @escaping RCTPromiseRejectBlock
@@ -208,10 +434,9 @@ import React
             provider.reportOutgoingCall(with: uuid, connectedAt: Date())
 
             // Fulfill deferred CXAnswerCallAction now that peer connection is ready
-            if let pendingAction = manager.pendingAnswerAction {
+            if let pendingAction = manager.pendingAnswerActions.removeValue(forKey: uuid) {
                 NSLog("TelnyxVoice: reportCallConnected - fulfilling deferred CXAnswerCallAction")
                 pendingAction.fulfill()
-                manager.pendingAnswerAction = nil
             } else {
                 // Fallback: ensure audio is enabled for non-push or already-fulfilled cases
                 let rtcAudioSession = RTCAudioSession.sharedInstance()
@@ -254,6 +479,9 @@ import React
 
             let endReason = CXCallEndedReason(rawValue: reason.intValue) ?? .remoteEnded
             provider.reportCall(with: uuid, endedAt: Date(), reason: endReason)
+            manager.activeCalls.removeValue(forKey: uuid)
+            manager.pendingAnswerActions.removeValue(forKey: uuid)?.fail()
+            manager.pendingHeldActions.removeValue(forKey: uuid)?.fail()
             resolve(["success": true])
         }
 
@@ -286,6 +514,7 @@ import React
             let callUpdate = CXCallUpdate()
             callUpdate.remoteHandle = callHandle
             callUpdate.localizedCallerName = displayName
+            callUpdate.supportsHolding = true
 
             provider.reportCall(with: uuid, updated: callUpdate)
             resolve(["success": true])
@@ -507,8 +736,33 @@ import React
         public var voipRegistry: PKPushRegistry?
         public var callKitProvider: CXProvider?
         public var callKitController: CXCallController?
-        public var activeCalls: [UUID: [String: Any]] = [:]
-        public var pendingAnswerAction: CXAnswerCallAction?
+        private let stateLock = NSRecursiveLock()
+        public lazy var activeCalls = LockedDictionary<UUID, [String: Any]>(lock: stateLock)
+        public lazy var pendingAnswerActions = LockedDictionary<UUID, CXAnswerCallAction>(
+            lock: stateLock)
+        public lazy var pendingHeldActions = LockedDictionary<UUID, CXSetHeldCallAction>(
+            lock: stateLock)
+
+        fileprivate func markCallKitRegistered(_ callUUID: UUID) {
+            guard var callData = activeCalls[callUUID] else {
+                return
+            }
+
+            callData["isCallKitRegistered"] = true
+            activeCalls[callUUID] = callData
+        }
+
+        fileprivate func isCallKitRegistered(_ callUUID: UUID) -> Bool {
+            guard let callData = activeCalls[callUUID] else {
+                return false
+            }
+
+            if callData["direction"] as? String == "incoming" {
+                return callData["isCallKitRegistered"] as? Bool == true
+            }
+
+            return true
+        }
 
         private override init() {
             super.init()
@@ -592,7 +846,7 @@ import React
 
             let configuration = CXProviderConfiguration(localizedName: appName)
             configuration.supportsVideo = false
-            configuration.maximumCallGroups = 1
+            configuration.maximumCallGroups = 2
             configuration.maximumCallsPerCallGroup = 1
             configuration.supportedHandleTypes = [.phoneNumber, .generic]
             configuration.includesCallsInRecents = true
@@ -632,6 +886,7 @@ import React
             callUpdate.remoteHandle = handle
             callUpdate.hasVideo = false
             callUpdate.localizedCallerName = callerName
+            callUpdate.supportsHolding = true
 
             callKitProvider.reportNewIncomingCall(with: callUUID, update: callUpdate) { error in
                 if let error = error {
@@ -645,10 +900,8 @@ import React
                 callKitProvider.reportCall(with: callUUID, endedAt: Date(), reason: endedReason)
                 self.activeCalls.removeValue(forKey: callUUID)
 
-                if self.pendingAnswerAction?.callUUID == callUUID {
-                    self.pendingAnswerAction?.fail()
-                    self.pendingAnswerAction = nil
-                }
+                self.pendingAnswerActions.removeValue(forKey: callUUID)?.fail()
+                self.pendingHeldActions.removeValue(forKey: callUUID)?.fail()
 
                 completion?()
             }
@@ -707,10 +960,8 @@ import React
                 callKitProvider.reportCall(with: callUUID, endedAt: Date(), reason: .remoteEnded)
                 self.activeCalls.removeValue(forKey: callUUID)
 
-                if self.pendingAnswerAction?.callUUID == callUUID {
-                    self.pendingAnswerAction?.fail()
-                    self.pendingAnswerAction = nil
-                }
+                self.pendingAnswerActions.removeValue(forKey: callUUID)?.fail()
+                self.pendingHeldActions.removeValue(forKey: callUUID)?.fail()
 
                 NSLog("TelnyxVoice: Ended stale CallKit call for missed call UUID: \(callUUID)")
                 self.clearPendingPushData(for: callId)
@@ -766,6 +1017,7 @@ import React
             callUpdate.remoteHandle = handle
             callUpdate.hasVideo = false
             callUpdate.localizedCallerName = callerName
+            callUpdate.supportsHolding = true
 
             callKitProvider.reportNewIncomingCall(with: callUUID, update: callUpdate) { error in
                 if let error = error {
@@ -783,7 +1035,7 @@ import React
             return true
         }
 
-        private func clearPendingPushData(for callId: String?) {
+        fileprivate func clearPendingPushData(for callId: String?) {
             if hasPendingPushData(forDifferentCallThan: callId) {
                 NSLog("TelnyxVoice: Skipping pending push cleanup for missed call; pending data belongs to a different call")
                 return
@@ -808,7 +1060,9 @@ import React
                 UserDefaults.standard.string(forKey: "@pending_callkit_uuid"),
             ].compactMap { $0 }
 
-            return pendingIds.contains { !$0.isEmpty && $0 != missedCallId }
+            return pendingIds.contains {
+                !$0.isEmpty && $0.caseInsensitiveCompare(missedCallId) != .orderedSame
+            }
         }
 
         private func pendingCallId(fromJsonForKey key: String) -> String? {
@@ -1005,6 +1259,7 @@ import React
                 "uuid": callUUID.uuidString,
                 "direction": "incoming",
                 "source": "push",
+                "isCallKitRegistered": false,
             ]
 
             let handle = CXHandle(type: .phoneNumber, value: caller)
@@ -1012,6 +1267,7 @@ import React
             callUpdate.remoteHandle = handle
             callUpdate.hasVideo = false
             callUpdate.localizedCallerName = caller
+            callUpdate.supportsHolding = true
 
             callKitProvider?.reportNewIncomingCall(with: callUUID, update: callUpdate) {
                 [weak self] error in
@@ -1019,6 +1275,7 @@ import React
                     NSLog("TelnyxVoice: CallKit error: \(error.localizedDescription)")
                     self?.activeCalls.removeValue(forKey: callUUID)
                 } else {
+                    self?.markCallKitRegistered(callUUID)
                     NSLog("TelnyxVoice: CallKit incoming call reported successfully")
                 }
                 completion()
@@ -1033,6 +1290,10 @@ import React
             NSLog("📞 TelnyxVoice: CALLKIT PROVIDER RESET - Provider: \(provider)")
             NSLog("TelnyxVoice: CallKit provider reset - ending all active calls")
             activeCalls.removeAll()
+            pendingAnswerActions.values.forEach { $0.fail() }
+            pendingAnswerActions.removeAll()
+            pendingHeldActions.values.forEach { $0.fail() }
+            pendingHeldActions.removeAll()
         }
 
         public func provider(_ provider: CXProvider, perform action: CXAnswerCallAction) {
@@ -1042,6 +1303,18 @@ import React
             if activeCalls[action.callUUID]?["watchdogPlaceholder"] as? Bool == true {
                 NSLog("TelnyxVoice: Failing answer for watchdog placeholder call: \(action.callUUID)")
                 activeCalls.removeValue(forKey: action.callUUID)
+                action.fail()
+                return
+            }
+
+            guard isCallKitRegistered(action.callUUID) else {
+                NSLog("TelnyxVoice: Failing answer for unknown UUID: \(action.callUUID)")
+                action.fail()
+                return
+            }
+
+            guard pendingAnswerActions[action.callUUID] == nil else {
+                NSLog("TelnyxVoice: Failing duplicate answer for UUID: \(action.callUUID)")
                 action.fail()
                 return
             }
@@ -1062,18 +1335,67 @@ import React
 
             // Defer action.fulfill() until reportCallConnected when peer connection is ready
             NSLog("TelnyxVoice: Deferring CXAnswerCallAction.fulfill() until peer connection is ready")
-            self.pendingAnswerAction = action
+            self.pendingAnswerActions[action.callUUID] = action
+        }
+
+        public func provider(_ provider: CXProvider, perform action: CXSetHeldCallAction) {
+            NSLog(
+                "TelnyxVoice: User requested held=\(action.isOnHold) for UUID: \(action.callUUID)"
+            )
+
+            guard activeCalls[action.callUUID] != nil else {
+                NSLog("TelnyxVoice: Failing held action for unknown UUID: \(action.callUUID)")
+                action.fail()
+                return
+            }
+
+            guard pendingHeldActions[action.callUUID] == nil else {
+                NSLog("TelnyxVoice: Failing duplicate held action for UUID: \(action.callUUID)")
+                action.fail()
+                return
+            }
+
+            pendingHeldActions[action.callUUID] = action
+            let emitted = CallKitBridge.shared?.emitHeldCallEvent(
+                callUUID: action.callUUID,
+                isOnHold: action.isOnHold,
+                callData: activeCalls[action.callUUID]
+            ) ?? false
+
+            guard emitted else {
+                pendingHeldActions.removeValue(forKey: action.callUUID)
+                action.fail()
+                return
+            }
+
+            DispatchQueue.main.asyncAfter(deadline: .now() + 10) { [weak self, weak action] in
+                guard let self = self, let action = action,
+                    self.pendingHeldActions[action.callUUID] === action
+                else { return }
+
+                NSLog("TelnyxVoice: Held action timed out for UUID: \(action.callUUID)")
+                self.pendingHeldActions.removeValue(forKey: action.callUUID)
+                action.fail()
+            }
         }
 
         public func provider(_ provider: CXProvider, perform action: CXEndCallAction) {
             NSLog("TelnyxVoice: User ended call with UUID: \(action.callUUID)")
 
+            guard let callData = activeCalls[action.callUUID] else {
+                NSLog("TelnyxVoice: Failing end action for unknown UUID: \(action.callUUID)")
+                action.fail()
+                return
+            }
+
             // Notify React Native via CallKit bridge
             CallKitBridge.shared?.emitCallEvent(
                 "CallKitDidPerformEndCallAction", callUUID: action.callUUID,
-                callData: activeCalls[action.callUUID])
+                callData: callData)
 
             activeCalls.removeValue(forKey: action.callUUID)
+            pendingAnswerActions.removeValue(forKey: action.callUUID)?.fail()
+            pendingHeldActions.removeValue(forKey: action.callUUID)?.fail()
             NSLog("📞 TelnyxVoice: Fulfilling CXEndCallAction for call UUID: \(action.callUUID)")
             action.fulfill()
             NSLog("📞 TelnyxVoice: ✅ CXEndCallAction fulfilled successfully")
@@ -1087,9 +1409,24 @@ import React
                 "CallKitDidReceiveStartCallAction", callUUID: action.callUUID,
                 callData: activeCalls[action.callUUID])
 
+            let callUpdate = CXCallUpdate()
+            callUpdate.remoteHandle = action.handle
+            callUpdate.hasVideo = false
+            callUpdate.supportsHolding = true
+            provider.reportCall(with: action.callUUID, updated: callUpdate)
+
             NSLog("📞 TelnyxVoice: Fulfilling CXStartCallAction for call UUID: \(action.callUUID)")
             action.fulfill()
             NSLog("📞 TelnyxVoice: ✅ CXStartCallAction fulfilled successfully")
+        }
+
+        public func provider(_ provider: CXProvider, timedOutPerforming action: CXAction) {
+            if let answerAction = action as? CXAnswerCallAction {
+                pendingAnswerActions.removeValue(forKey: answerAction.callUUID)
+            } else if let heldAction = action as? CXSetHeldCallAction {
+                pendingHeldActions.removeValue(forKey: heldAction.callUUID)
+            }
+            action.fail()
         }
 
         public func provider(_ provider: CXProvider, didActivate audioSession: AVAudioSession) {
@@ -1176,6 +1513,33 @@ import React
 
         private override init() {
             super.init()
+        }
+
+        private func storePendingVoipPush(_ payload: [AnyHashable: Any]) {
+            do {
+                let jsonData = try JSONSerialization.data(withJSONObject: payload)
+                let jsonString = String(data: jsonData, encoding: .utf8) ?? ""
+
+                UserDefaults.standard.set("incoming_call", forKey: "pending_push_action")
+                UserDefaults.standard.set(jsonString, forKey: "pending_push_metadata")
+
+                let voipPushData = [
+                    "payload": payload
+                ]
+                let voipJsonData = try JSONSerialization.data(withJSONObject: voipPushData)
+                let voipJsonString = String(data: voipJsonData, encoding: .utf8) ?? ""
+                UserDefaults.standard.set(voipJsonString, forKey: "pending_voip_push")
+                UserDefaults.standard.synchronize()
+                NSLog(
+                    "[TelnyxVoipPushHandler] Stored VoIP push data after CallKit registration succeeded"
+                )
+            } catch {
+                NSLog("[TelnyxVoipPushHandler] Error converting VoIP payload to JSON: \(error)")
+                UserDefaults.standard.set("incoming_call", forKey: "pending_push_action")
+                UserDefaults.standard.set("{}", forKey: "pending_push_metadata")
+                UserDefaults.standard.set("{\"payload\":{}}", forKey: "pending_voip_push")
+                UserDefaults.standard.synchronize()
+            }
         }
 
         /**
@@ -1267,36 +1631,6 @@ import React
                 "[TelnyxVoipPushHandler] Processing call - Call ID as UUID: \(callUUID.uuidString), Caller: \(callerName), Number: \(callerNumber)"
             )
 
-            // Store the VoIP push data for VoicePnBridge
-            do {
-                let jsonData = try JSONSerialization.data(withJSONObject: payload.dictionaryPayload)
-                let jsonString = String(data: jsonData, encoding: .utf8) ?? ""
-
-                // Store for TelnyxVoiceApp (push action flow)
-                UserDefaults.standard.set("incoming_call", forKey: "pending_push_action")
-                UserDefaults.standard.set(jsonString, forKey: "pending_push_metadata")
-
-                // ALSO store for VoicePnBridge.getPendingVoipPush() (CallKit coordinator flow)
-                // This creates a structured object with payload property
-                let voipPushData = [
-                    "payload": payload.dictionaryPayload
-                ]
-                let voipJsonData = try JSONSerialization.data(withJSONObject: voipPushData)
-                let voipJsonString = String(data: voipJsonData, encoding: .utf8) ?? ""
-                UserDefaults.standard.set(voipJsonString, forKey: "pending_voip_push")
-
-                UserDefaults.standard.synchronize()
-                NSLog(
-                    "[TelnyxVoipPushHandler] Stored VoIP push data for both TelnyxVoiceApp and VoicePnBridge"
-                )
-            } catch {
-                NSLog("[TelnyxVoipPushHandler] Error converting VoIP payload to JSON: \(error)")
-                UserDefaults.standard.set("incoming_call", forKey: "pending_push_action")
-                UserDefaults.standard.set("{}", forKey: "pending_push_metadata")
-                UserDefaults.standard.set("{\"payload\":{}}", forKey: "pending_voip_push")
-                UserDefaults.standard.synchronize()
-            }
-
             // Use unified CallKit handling path that works for both running and terminated app scenarios
             NSLog("[TelnyxVoipPushHandler] Using unified CallKit handling path")
 
@@ -1319,6 +1653,7 @@ import React
                 "uuid": callUUID.uuidString,
                 "direction": "incoming",
                 "source": isAppRunning ? "push_notification" : "terminated_app_push",
+                "isCallKitRegistered": false,
             ]
 
             // Report to CallKit immediately
@@ -1327,17 +1662,26 @@ import React
             callUpdate.remoteHandle = handle
             callUpdate.hasVideo = false
             callUpdate.localizedCallerName = callerName
+            callUpdate.supportsHolding = true
 
             callKitProvider.reportNewIncomingCall(with: callUUID, update: callUpdate) { error in
                 if let error = error {
+                    let nsError = error as NSError
+                    let reason =
+                        nsError.domain == CXErrorDomainIncomingCall && nsError.code == 3
+                        ? "filteredByDoNotDisturb" : "registrationRejected"
                     NSLog(
-                        "[TelnyxVoipPushHandler] ❌ CallKit error during terminated app handling: \(error.localizedDescription)"
+                        "[TelnyxVoipPushHandler] CallKit incoming registration rejected: domain=\(nsError.domain), code=\(nsError.code), reason=\(reason)"
                     )
                     callKitManager.activeCalls.removeValue(forKey: callUUID)
+                    callKitManager.clearPendingPushData(for: callUUID.uuidString)
                 } else {
                     NSLog(
                         "[TelnyxVoipPushHandler] ✅ CallKit call reported successfully via unified path"
                     )
+
+                    callKitManager.markCallKitRegistered(callUUID)
+                    self.storePendingVoipPush(payload.dictionaryPayload)
 
                     // CRITICAL: Store the CallKit UUID for the React Native CallKitCoordinator
                     // This allows the coordinator to find the existing CallKit call instead of creating a duplicate

--- a/react-voice-commons-sdk/ios/README.md
+++ b/react-voice-commons-sdk/ios/README.md
@@ -62,7 +62,7 @@ class AppDelegate: ExpoAppDelegate, TelnyxVoiceAppDelegate {
     override func customCallKitConfiguration() -> CXProviderConfiguration {
         let configuration = CXProviderConfiguration(localizedName: "My App Voice")
         configuration.supportsVideo = false
-        configuration.maximumCallGroups = 1
+        configuration.maximumCallGroups = 2
         configuration.maximumCallsPerCallGroup = 1
         configuration.supportedHandleTypes = [.phoneNumber, .generic]
         configuration.includesCallsInRecents = true
@@ -113,7 +113,7 @@ class AppDelegate: ExpoAppDelegate {
     private func setupCallKit() {
         let configuration = CXProviderConfiguration(localizedName: "Voice Call")
         configuration.supportsVideo = false
-        configuration.maximumCallGroups = 1
+        configuration.maximumCallGroups = 2
         configuration.maximumCallsPerCallGroup = 1
         configuration.supportedHandleTypes = [.phoneNumber, .generic]
         configuration.includesCallsInRecents = true

--- a/react-voice-commons-sdk/lib/callkit/callkit-coordinator.d.ts
+++ b/react-voice-commons-sdk/lib/callkit/callkit-coordinator.d.ts
@@ -1,5 +1,5 @@
 import { Call } from '@telnyx/react-native-voice-sdk';
-import { TelnyxVoipClient } from '../telnyx-voip-client';
+import type { TelnyxVoipClient } from '../telnyx-voip-client';
 /**
  * CallKit Coordinator - Manages the proper CallKit-first flow for iOS
  *
@@ -14,7 +14,12 @@ declare class CallKitCoordinator {
   private endedCalls;
   private connectedCalls;
   private isCallFromPush;
-  private shouldAutoAnswerNextCall;
+  private pendingPushCallUUIDs;
+  private selectedCallKitUUID;
+  private restoreHeldCallPromise;
+  private pendingSwap;
+  private pendingHeldRequests;
+  private autoAnswerCallUUIDs;
   private voipClient;
   static getInstance(): CallKitCoordinator;
   private constructor();
@@ -37,6 +42,17 @@ declare class CallKitCoordinator {
    */
   answerCallFromUI(call: Call): Promise<boolean>;
   /**
+   * Change held state from app UI through CallKit, then wait for signaling and
+   * the corresponding CXSetHeldCallAction to complete.
+   */
+  setHeldFromUI(call: Call, isOnHold: boolean): Promise<boolean>;
+  /**
+   * Swap an active call with a held call through one CallKit transaction.
+   * The promise settles only after both corresponding WebRTC state changes
+   * have completed and their CallKit actions have been fulfilled.
+   */
+  swapCallsFromUI(activeCall: Call, heldCall: Call): Promise<boolean>;
+  /**
    * End a call from the app UI (CallKit-first approach)
    */
   endCallFromUI(call: Call): Promise<boolean>;
@@ -44,6 +60,8 @@ declare class CallKitCoordinator {
    * Handle CallKit answer action (triggered by CallKit)
    */
   handleCallKitAnswer(callKitUUID: string, event?: any): Promise<void>;
+  /** Handle a UUID-targeted CallKit hold or resume action. */
+  handleCallKitHeld(callKitUUID: string, isOnHold: boolean): Promise<void>;
   /**
    * Handle CallKit end action (triggered by CallKit)
    */
@@ -99,10 +117,23 @@ declare class CallKitCoordinator {
    * Helper method to clean up push notification state
    */
   private cleanupPushNotificationState;
+  private rejectUnregisteredIncomingCall;
+  private clearMatchingPendingVoipPush;
   /**
    * Get reference to the SDK client (for queuing actions when call doesn't exist yet)
    */
   private getSDKClient;
+  private normalizeUUID;
+  private actionKey;
+  private selectCall;
+  private isSelectedCall;
+  private recordPendingSwapAction;
+  private createPendingSwap;
+  private beginSwapRollback;
+  private restoreOriginalWebRTCStates;
+  private finishPendingSwap;
+  private finishPendingHeldRequest;
+  private restoreRemainingHeldCall;
   /**
    * Check if app is in background and disconnect client if no active calls
    */

--- a/react-voice-commons-sdk/lib/callkit/callkit-coordinator.d.ts
+++ b/react-voice-commons-sdk/lib/callkit/callkit-coordinator.d.ts
@@ -73,8 +73,13 @@ declare class CallKitCoordinator {
   /**
    * Handle CallKit push received event
    * This allows us to coordinate between the push notification and any subsequent WebRTC calls
+   *
+   * Returns `true` when the push was accepted and call processing was started,
+   * or `false` when the push was filtered, rejected, or otherwise ignored so
+   * that callers can clean up any foreground-push lifecycle flags they set
+   * before calling this method.
    */
-  handleCallKitPushReceived(callKitUUID: string, event?: any): Promise<void>;
+  handleCallKitPushReceived(callKitUUID: string, event?: any): Promise<boolean>;
   /**
    * Handle push notification answer - when user answers from CallKit but we don't have a WebRTC call yet
    * This is the iOS equivalent of the Android FCM handler

--- a/react-voice-commons-sdk/lib/callkit/callkit-coordinator.js
+++ b/react-voice-commons-sdk/lib/callkit/callkit-coordinator.js
@@ -73,15 +73,21 @@ class CallKitCoordinator {
   constructor() {
     // Maps CallKit UUIDs to WebRTC calls
     this.callMap = new Map();
-    // Tracks calls that are being processed to prevent duplicates
+    // Tracks action+UUID pairs so an end action is not dropped merely because
+    // an answer or held action for the same call is still completing.
     this.processingCalls = new Set();
     // Tracks calls that have already been ended in CallKit to prevent duplicate reports
     this.endedCalls = new Set();
     // Tracks calls that have already been reported as connected to prevent duplicate reports
     this.connectedCalls = new Set();
     this.isCallFromPush = false;
-    // Flag to auto-answer the next incoming call (set when answering push notifications via CallKit)
-    this.shouldAutoAnswerNextCall = false;
+    this.pendingPushCallUUIDs = new Set();
+    this.selectedCallKitUUID = null;
+    this.restoreHeldCallPromise = null;
+    this.pendingSwap = null;
+    this.pendingHeldRequests = new Map();
+    // Push answers are keyed so answering B cannot auto-answer another invite.
+    this.autoAnswerCallUUIDs = new Set();
     // Reference to the VoIP client for triggering reconnection when needed
     this.voipClient = null;
     if (react_native_1.Platform.OS === 'ios' && callkit_1.default.isAvailable()) {
@@ -96,6 +102,9 @@ class CallKitCoordinator {
     // Handle CallKit end actions
     callkit_1.default.onEndCall((event) => {
       this.handleCallKitEnd(event.callUUID, event);
+    });
+    callkit_1.default.onHeldCall((event) => {
+      void this.handleCallKitHeld(event.callUUID, Boolean(event.isOnHold));
     });
     // Handle CallKit start actions (for outgoing calls)
     callkit_1.default.onStartCall((event) => {
@@ -114,8 +123,13 @@ class CallKitCoordinator {
     if (react_native_1.Platform.OS !== 'ios' || !callkit_1.default.isAvailable()) {
       return null;
     }
-    // This is a new call - report it to CallKit using the WebRTC call ID as CallKit UUID
-    const callKitUUID = call.callId;
+    const existingCallKitUUID = this.getCallKitUUID(call);
+    if (existingCallKitUUID) {
+      this.linkExistingCallKitCall(call, existingCallKitUUID);
+      return existingCallKitUUID;
+    }
+    // Socket-only incoming calls use their signaling ID as the app-facing ID.
+    const callKitUUID = this.normalizeUUID(call.callId);
     console.log('CallKitCoordinator: Report Called called', {
       callKitUUID,
       webrtcCallId: call.callId,
@@ -140,12 +154,15 @@ class CallKitCoordinator {
           callerName
         );
         if (success) {
+          call._callKitUUID = callKitUUID;
           return callKitUUID;
         }
+        await this.rejectUnregisteredIncomingCall(callKitUUID, call);
       }
       return null;
     } catch (error) {
       console.error('CallKitCoordinator: Failed to report incoming call', error);
+      await this.rejectUnregisteredIncomingCall(callKitUUID, call);
       return null;
     }
   }
@@ -156,7 +173,7 @@ class CallKitCoordinator {
     if (react_native_1.Platform.OS !== 'ios' || !callkit_1.default.isAvailable()) {
       return null;
     }
-    const callKitUUID = call.callId;
+    const callKitUUID = this.normalizeUUID(call.callId);
     console.log('CallKitCoordinator: Starting outgoing call through CallKit', {
       callKitUUID,
       webrtcCallId: call.callId,
@@ -187,30 +204,140 @@ class CallKitCoordinator {
   async answerCallFromUI(call) {
     // Use comprehensive UUID lookup that checks both maps and call properties
     const callKitUUID = this.getCallKitUUID(call);
+    if (!callKitUUID) {
+      console.warn('CallKitCoordinator: Cannot answer call - no CallKit UUID found');
+      return false;
+    }
     console.log(
       'CallKitCoordinator: Answering call from UI using CallKit answer simulation',
       callKitUUID
     );
+    const isRegistered = await callkit_1.default.isCallRegistered(callKitUUID);
+    if (!isRegistered) {
+      console.warn(
+        'CallKitCoordinator: Suppressing answer because CallKit rejected or removed the call',
+        { callKitUUID }
+      );
+      await this.rejectUnregisteredIncomingCall(callKitUUID, call);
+      return false;
+    }
     // Mark as processing to prevent duplicate actions
-    this.processingCalls.add(callKitUUID);
+    const processingKey = this.actionKey('answer', callKitUUID);
+    this.processingCalls.add(processingKey);
     try {
       // Simulate the CallKit answer action, which will trigger our answer handler
       const success = await callkit_1.default.answerCall(callKitUUID);
       if (success) {
-        // If CallKit answer fails, fallback to direct WebRTC answer
-        if (this.isCallFromPush) {
-          call.answer();
-          this.isCallFromPush = false;
+        if (call.direction === 'inbound' && call.state !== 'active') {
+          await call.answer();
         }
+        this.selectCall(call);
+        this.pendingPushCallUUIDs.delete(callKitUUID);
+        this.isCallFromPush = this.pendingPushCallUUIDs.size > 0;
         console.log('CallKitCoordinator: CallKit answer success');
       }
       return success;
     } catch (error) {
       console.error('CallKitCoordinator: Error answering call from UI', error);
+      await callkit_1.default.reportCallEnded(callKitUUID, callkit_1.CallEndReason.Failed);
+      this.cleanupCall(callKitUUID);
       return false;
     } finally {
-      this.processingCalls.delete(callKitUUID);
+      this.processingCalls.delete(processingKey);
     }
+  }
+  /**
+   * Change held state from app UI through CallKit, then wait for signaling and
+   * the corresponding CXSetHeldCallAction to complete.
+   */
+  async setHeldFromUI(call, isOnHold) {
+    const callKitUUID = this.getCallKitUUID(call);
+    if (!callKitUUID) {
+      console.warn('CallKitCoordinator: Cannot change held state without a CallKit UUID');
+      return false;
+    }
+    const desiredState = isOnHold ? 'held' : 'active';
+    if (call.state === desiredState) {
+      if (!isOnHold) {
+        this.selectCall(call);
+      }
+      return true;
+    }
+    const requiredState = isOnHold ? 'active' : 'held';
+    if (call.state !== requiredState || this.pendingSwap) {
+      console.warn('CallKitCoordinator: Cannot change held state in current state', {
+        callKitUUID,
+        currentState: call.state,
+        desiredState,
+        hasPendingSwap: Boolean(this.pendingSwap),
+      });
+      return false;
+    }
+    const requestKey = this.actionKey(isOnHold ? 'hold' : 'unhold', callKitUUID);
+    if (this.pendingHeldRequests.has(requestKey) || this.processingCalls.has(requestKey)) {
+      return false;
+    }
+    let resolveRequest;
+    const completion = new Promise((resolve) => {
+      resolveRequest = resolve;
+    });
+    const timeout = setTimeout(() => {
+      console.error('CallKitCoordinator: Held-state request timed out', {
+        callKitUUID,
+        isOnHold,
+      });
+      this.finishPendingHeldRequest(requestKey, false);
+    }, 12000);
+    this.pendingHeldRequests.set(requestKey, {
+      resolve: resolveRequest,
+      timeout,
+    });
+    const accepted = await callkit_1.default.setCallHeld(callKitUUID, isOnHold);
+    if (!accepted) {
+      this.finishPendingHeldRequest(requestKey, false);
+    }
+    return completion;
+  }
+  /**
+   * Swap an active call with a held call through one CallKit transaction.
+   * The promise settles only after both corresponding WebRTC state changes
+   * have completed and their CallKit actions have been fulfilled.
+   */
+  async swapCallsFromUI(activeCall, heldCall) {
+    const activeCallKitUUID = this.getCallKitUUID(activeCall);
+    const heldCallKitUUID = this.getCallKitUUID(heldCall);
+    if (!activeCallKitUUID || !heldCallKitUUID || activeCallKitUUID === heldCallKitUUID) {
+      console.warn('CallKitCoordinator: Cannot swap calls without two distinct CallKit UUIDs');
+      return false;
+    }
+    if (activeCall.state !== 'active' || heldCall.state !== 'held') {
+      console.warn('CallKitCoordinator: Cannot swap calls in their current states', {
+        activeCallState: activeCall.state,
+        heldCallState: heldCall.state,
+      });
+      return false;
+    }
+    if (this.pendingSwap) {
+      console.warn('CallKitCoordinator: A call swap is already in progress');
+      return false;
+    }
+    let resolveSwap;
+    const swapCompletion = new Promise((resolve) => {
+      resolveSwap = resolve;
+    });
+    this.pendingSwap = this.createPendingSwap({
+      mode: 'swap',
+      originalActiveCallKitUUID: activeCallKitUUID,
+      originalHeldCallKitUUID: heldCallKitUUID,
+      activeCallKitUUID,
+      heldCallKitUUID,
+      resolve: resolveSwap,
+    });
+    const accepted = await callkit_1.default.swapCalls(activeCallKitUUID, heldCallKitUUID);
+    if (!accepted) {
+      await this.beginSwapRollback(this.pendingSwap);
+    }
+    return swapCompletion;
   }
   /**
    * End a call from the app UI (CallKit-first approach)
@@ -224,29 +351,32 @@ class CallKitCoordinator {
       call.hangup();
       return false;
     }
-    console.log(
-      'CallKitCoordinator: Ending call from UI - dismissing CallKit and hanging up WebRTC call',
-      callKitUUID
-    );
-    // Track this call as ended to prevent duplicate end actions
-    this.endedCalls.add(callKitUUID);
+    console.log('CallKitCoordinator: Requesting CallKit end action from app UI', callKitUUID);
     try {
-      // End the call in CallKit - endCall returns false on failure (doesn't throw)
+      // Let the resulting CXEndCallAction drive signaling, cleanup and survivor
+      // restoration. Marking the call ended here would suppress that event.
       const endCallSuccess = await callkit_1.default.endCall(callKitUUID);
-      if (!endCallSuccess) {
-        // Fallback: use reportCallEnded to dismiss CallKit UI when endCall fails
-        // (e.g., unknownCallUUID error from duplicate CXProvider)
-        await callkit_1.default.reportCallEnded(callKitUUID, callkit_1.CallEndReason.RemoteEnded);
+      if (endCallSuccess) {
+        return true;
       }
-      this.isCallFromPush = false;
+      const shouldRestoreRemainingCall = this.isSelectedCall(call);
+      this.endedCalls.add(callKitUUID);
+      await callkit_1.default.reportCallEnded(callKitUUID, callkit_1.CallEndReason.RemoteEnded);
+      this.pendingPushCallUUIDs.delete(callKitUUID);
+      this.isCallFromPush = this.pendingPushCallUUIDs.size > 0;
       call.hangup();
       this.cleanupCall(callKitUUID);
-      return true;
+      if (shouldRestoreRemainingCall) {
+        await this.restoreRemainingHeldCall();
+      }
+      return false;
     } catch (error) {
       console.error('CallKitCoordinator: Error ending call from UI', error);
-      this.isCallFromPush = false;
+      this.pendingPushCallUUIDs.delete(callKitUUID);
+      this.isCallFromPush = this.pendingPushCallUUIDs.size > 0;
       call.hangup();
       this.cleanupCall(callKitUUID);
+      await this.restoreRemainingHeldCall();
       return false;
     }
   }
@@ -254,7 +384,9 @@ class CallKitCoordinator {
    * Handle CallKit answer action (triggered by CallKit)
    */
   async handleCallKitAnswer(callKitUUID, event) {
-    if (this.processingCalls.has(callKitUUID)) {
+    callKitUUID = this.normalizeUUID(callKitUUID);
+    const processingKey = this.actionKey('answer', callKitUUID);
+    if (this.processingCalls.has(processingKey)) {
       console.log('CallKitCoordinator: Answer action already being processed, skipping duplicate');
       return;
     }
@@ -277,9 +409,10 @@ class CallKitCoordinator {
     });
     if (call.state === 'active') {
       console.log('CallKitCoordinator: Call already active, skipping duplicate answer action');
+      this.selectCall(call);
       return;
     }
-    this.processingCalls.add(callKitUUID);
+    this.processingCalls.add(processingKey);
     try {
       if (call.direction === 'inbound') {
         const voipClient = this.getSDKClient();
@@ -289,22 +422,8 @@ class CallKitCoordinator {
           );
           voipClient.setCallConnecting(call.callId);
         }
-        // Report call as connected to CallKit to trigger audio session activation
-        setTimeout(async () => {
-          try {
-            await callkit_1.default.reportCallConnected(callKitUUID);
-            console.log('CallKitCoordinator: Reported call connected to activate audio session');
-            this.connectedCalls.add(callKitUUID);
-          } catch (error) {
-            console.error(
-              'CallKitCoordinator: Error reporting call connected for audio session:',
-              error
-            );
-          }
-        }, 200);
-        setTimeout(() => {
-          call.answer();
-        }, 500);
+        await call.answer();
+        this.selectCall(call);
       } else {
         console.log('CallKitCoordinator: Outgoing call, skipping answer and CONNECTING state');
       }
@@ -324,15 +443,54 @@ class CallKitCoordinator {
         await voice_pn_bridge_1.VoicePnBridge.clearPendingVoipPush();
       } catch (_) {}
     } finally {
-      this.processingCalls.delete(callKitUUID);
+      this.processingCalls.delete(processingKey);
+    }
+  }
+  /** Handle a UUID-targeted CallKit hold or resume action. */
+  async handleCallKitHeld(callKitUUID, isOnHold) {
+    callKitUUID = this.normalizeUUID(callKitUUID);
+    const processingKey = this.actionKey(isOnHold ? 'hold' : 'unhold', callKitUUID);
+    if (this.processingCalls.has(processingKey)) {
+      return;
+    }
+    const call = this.callMap.get(callKitUUID);
+    if (!call) {
+      console.warn('CallKitCoordinator: No WebRTC call found for held action', { callKitUUID });
+      await callkit_1.default.completeHeldCallAction(callKitUUID, false);
+      this.finishPendingHeldRequest(processingKey, false);
+      return;
+    }
+    this.processingCalls.add(processingKey);
+    try {
+      if (isOnHold && call.state !== 'held') {
+        await call.hold();
+      } else if (!isOnHold && call.state !== 'active') {
+        await call.unhold();
+      }
+      if (!isOnHold) {
+        this.selectCall(call);
+      }
+      const completed = await callkit_1.default.completeHeldCallAction(callKitUUID, true);
+      this.recordPendingSwapAction(callKitUUID, isOnHold, completed);
+      this.finishPendingHeldRequest(processingKey, completed);
+    } catch (error) {
+      console.error('CallKitCoordinator: Held action failed', { callKitUUID, isOnHold, error });
+      await callkit_1.default.completeHeldCallAction(callKitUUID, false);
+      this.recordPendingSwapAction(callKitUUID, isOnHold, false);
+      this.finishPendingHeldRequest(processingKey, false);
+    } finally {
+      this.processingCalls.delete(processingKey);
     }
   }
   /**
    * Handle CallKit end action (triggered by CallKit)
    */
   async handleCallKitEnd(callKitUUID, event) {
-    this.isCallFromPush = false;
-    if (this.processingCalls.has(callKitUUID)) {
+    callKitUUID = this.normalizeUUID(callKitUUID);
+    const wasPendingPush = this.pendingPushCallUUIDs.delete(callKitUUID);
+    this.isCallFromPush = this.pendingPushCallUUIDs.size > 0;
+    const processingKey = this.actionKey('end', callKitUUID);
+    if (this.processingCalls.has(processingKey)) {
       console.log('CallKitCoordinator: End action already being processed, skipping duplicate');
       return;
     }
@@ -360,19 +518,23 @@ class CallKitCoordinator {
       callKitUUID,
       webrtcCallId: call.callId,
     });
-    this.processingCalls.add(callKitUUID);
+    const shouldRestoreRemainingCall = this.isSelectedCall(call);
+    this.processingCalls.add(processingKey);
     try {
       call.hangup();
     } catch (error) {
       console.error('CallKitCoordinator: Error hanging up WebRTC call', error);
     } finally {
-      this.processingCalls.delete(callKitUUID);
+      this.processingCalls.delete(processingKey);
       this.cleanupCall(callKitUUID);
-      // Clear push data now that end action is fulfilled
-      try {
-        await voice_pn_bridge_1.VoicePnBridge.clearPendingVoipPush();
-        console.log('CallKitCoordinator: Cleared pending VoIP push after end fulfilled');
-      } catch (_) {}
+      if (shouldRestoreRemainingCall) {
+        await this.restoreRemainingHeldCall();
+      }
+      if (wasPendingPush) {
+        await voice_pn_bridge_1.VoicePnBridge.clearPendingVoipPush().catch((error) => {
+          console.warn('CallKitCoordinator: Failed to clear ended call push data', error);
+        });
+      }
       // Check if app is in background and no more calls - disconnect client
       await this.checkBackgroundDisconnection();
     }
@@ -401,9 +563,19 @@ class CallKitCoordinator {
    * This allows us to coordinate between the push notification and any subsequent WebRTC calls
    */
   async handleCallKitPushReceived(callKitUUID, event) {
-    if (this.isCallFromPush) {
-      this.isCallFromPush = false;
-      console.log('CallKitCoordinator: Ignoring push received event (already processed)');
+    callKitUUID = this.normalizeUUID(callKitUUID);
+    if (this.pendingPushCallUUIDs.has(callKitUUID)) {
+      console.log('CallKitCoordinator: Ignoring duplicate push UUID', callKitUUID);
+      return;
+    }
+    const isRegistered = await callkit_1.default.isCallRegistered(callKitUUID);
+    if (!isRegistered) {
+      console.warn(
+        'CallKitCoordinator: Ignoring push because its CallKit registration was rejected',
+        { callKitUUID }
+      );
+      this.getSDKClient()?.queueEndFromCallKit(callKitUUID);
+      await this.clearMatchingPendingVoipPush(callKitUUID);
       return;
     }
     console.log('CallKitCoordinator: Processing push received event', {
@@ -411,6 +583,7 @@ class CallKitCoordinator {
       source: event?.callData?.source,
     });
     this.isCallFromPush = true;
+    this.pendingPushCallUUIDs.add(callKitUUID);
     console.log('CallKitCoordinator: Processing push received event', {
       callKitUUID,
       source: event?.callData?.source,
@@ -420,36 +593,36 @@ class CallKitCoordinator {
       // Get VoIP client instance
       const voipClient = this.getSDKClient();
       if (!voipClient) {
-        console.error('CallKitCoordinator: VoIP client not available');
-        return;
+        throw new Error('CallKitCoordinator: VoIP client not available');
       }
       // Retrieve pending push data from VoIP bridge
       const pendingPushJson = await voice_pn_bridge_1.VoicePnBridge.getPendingVoipPush();
       if (!pendingPushJson) {
-        console.warn('CallKitCoordinator: No pending push data found');
-        return;
+        throw new Error('CallKitCoordinator: No pending push data found');
       }
       const pendingPush = JSON.parse(pendingPushJson);
       const realPushData = pendingPush?.payload;
       if (!realPushData?.metadata) {
-        console.warn('CallKitCoordinator: Invalid push data structure');
-        return;
+        throw new Error('CallKitCoordinator: Invalid push data structure');
       }
       // Prepare push metadata with CallKit flag
       const enhancedMetadata = {
         ...realPushData.metadata,
         from_callkit: true,
       };
-      // Check if auto-answer is set and add from_notification flag
-      const shouldAddFromNotification = this.shouldAutoAnswerNextCall;
+      // This app-facing UUID is attached to the next inbound Call while the
+      // socket INVITE retains its own signaling callID.
+      voipClient.setPushNotificationCallKitUUID(callKitUUID);
+      // A pre-INVITE CallKit answer is represented only by the UUID-keyed
+      // pending action. Do not also add legacy notification flags.
+      const shouldAddFromNotification = this.autoAnswerCallUUIDs.has(callKitUUID);
       let pushData;
       if (shouldAddFromNotification) {
         pushData = {
           metadata: enhancedMetadata,
-          from_notification: true,
-          action: 'answer',
         };
-        voipClient.queueAnswerFromCallKit();
+        voipClient.queueAnswerFromCallKit(callKitUUID);
+        this.autoAnswerCallUUIDs.delete(callKitUUID);
       } else {
         pushData = {
           metadata: enhancedMetadata,
@@ -459,6 +632,8 @@ class CallKitCoordinator {
       await voipClient.handlePushNotification(pushData);
       console.log('CallKitCoordinator: Push notification processed successfully');
     } catch (error) {
+      this.pendingPushCallUUIDs.delete(callKitUUID);
+      this.isCallFromPush = this.pendingPushCallUUIDs.size > 0;
       console.error('CallKitCoordinator: Error processing push received event:', error);
     }
   }
@@ -474,68 +649,28 @@ class CallKitCoordinator {
       );
       if (react_native_1.Platform.OS === 'ios') {
         console.log('CallKitCoordinator: Processing iOS push notification answer');
-        // Set auto-answer flag so when the WebRTC call comes in, it will be answered automatically
-        this.shouldAutoAnswerNextCall = true;
-        console.log('CallKitCoordinator: ✅ Set auto-answer flag for next incoming call');
+        this.autoAnswerCallUUIDs.add(callKitUUID);
+        console.log('CallKitCoordinator: Set UUID-targeted auto-answer', callKitUUID);
         // Try to get VoIP client - it may not be wired yet if user answered
         // from CallKit before React Native finished initializing
         const voipClient = this.getSDKClient();
         if (!voipClient) {
           // voipClient not ready yet - DON'T fail the call.
-          // shouldAutoAnswerNextCall is already set to true above.
+          // The UUID-targeted auto-answer is already stored above.
           // checkForInitialPushNotification() will run after setVoipClient()
           // and will find the push data still intact, call handleCallKitPushReceived()
-          // which checks shouldAutoAnswerNextCall and queues the auto-answer.
+          // which queues the matching auto-answer.
           return;
         }
-        // voipClient is available - queue the answer action on the TelnyxRTC client
-        // so when the INVITE arrives after WebSocket login, processInvite() sees
-        // pendingAnswerAction=true and auto-answers the call.
-        voipClient.queueAnswerFromCallKit();
-        // Get the real push data that was stored by the VoIP push handler
-        let realPushData = null;
-        try {
-          const pendingPushJson = await voice_pn_bridge_1.VoicePnBridge.getPendingVoipPush();
-          if (pendingPushJson) {
-            const pendingPush = JSON.parse(pendingPushJson);
-            if (pendingPush && pendingPush.payload) {
-              console.log('CallKitCoordinator: ✅ Found real push data');
-              realPushData = pendingPush.payload;
-            }
-          }
-        } catch (error) {
-          console.warn('CallKitCoordinator: Could not get real push data:', error);
+        // Queue one UUID-targeted answer. If the push is already being
+        // processed, its eventual INVITE will consume this action. Otherwise
+        // process the still-persisted VoIP payload now.
+        voipClient.queueAnswerFromCallKit(callKitUUID);
+        if (this.pendingPushCallUUIDs.has(callKitUUID)) {
+          this.autoAnswerCallUUIDs.delete(callKitUUID);
+          return;
         }
-        // Create push notification payload - use real data if available, fallback to placeholder
-        const pushAction = 'incoming_call';
-        let pushMetadata;
-        if (realPushData && realPushData.metadata) {
-          // Use the real push metadata
-          console.log('CallKitCoordinator: 🎯 Using REAL push metadata for immediate handling');
-          pushMetadata = JSON.stringify({
-            ...realPushData.metadata,
-            from_callkit: true, // Add flag to indicate this was answered via CallKit
-          });
-        } else {
-          // Fallback to placeholder (this should rarely happen)
-          console.warn('CallKitCoordinator: ⚠️ No real push data found, using placeholder');
-          pushMetadata = JSON.stringify({
-            call_id: callKitUUID,
-            caller_name: 'Incoming Call',
-            caller_number: 'Unknown',
-            voice_sdk_id: 'unknown',
-            sent_time: new Date().toISOString(),
-            from_callkit: true,
-          });
-        }
-        // Set the pending push action to be handled when app comes to foreground
-        await voice_pn_bridge_1.VoicePnBridge.setPendingPushAction(pushAction, pushMetadata);
-        console.log('CallKitCoordinator: ✅ Set pending push action');
-        // Clear push data now that push notification answer is handled
-        try {
-          await voice_pn_bridge_1.VoicePnBridge.clearPendingVoipPush();
-          console.log('CallKitCoordinator: Cleared pending VoIP push after push answer handled');
-        } catch (_) {}
+        await this.handleCallKitPushReceived(callKitUUID, event);
         return;
       }
       // For other platforms (shouldn't happen on iOS)
@@ -560,7 +695,7 @@ class CallKitCoordinator {
       );
       if (react_native_1.Platform.OS === 'ios') {
         console.log('CallKitCoordinator: Processing iOS push notification rejection');
-        this.voipClient.queueEndFromCallKit();
+        this.getSDKClient()?.queueEndFromCallKit(callKitUUID);
         // Clean up push notification state
         await this.cleanupPushNotificationState();
         // Clear push data now that rejection is handled
@@ -591,6 +726,10 @@ class CallKitCoordinator {
       });
       switch (state) {
         case 'active':
+          this.selectCall(call);
+          this.pendingPushCallUUIDs.delete(callKitUUID);
+          this.autoAnswerCallUUIDs.delete(callKitUUID);
+          this.isCallFromPush = this.pendingPushCallUUIDs.size > 0;
           // When WebRTC call becomes active, just report as connected
           // (CallKit call was already answered in answerCallFromUI)
           if (!this.connectedCalls.has(callKitUUID)) {
@@ -604,7 +743,10 @@ class CallKitCoordinator {
           }
           break;
         case 'ended':
-        case 'failed':
+        case 'failed': {
+          const shouldRestoreRemainingCall =
+            this.selectedCallKitUUID === callKitUUID &&
+            !this.processingCalls.has(this.actionKey('end', callKitUUID));
           // Report call ended to CallKit (if not already ended)
           if (!this.endedCalls.has(callKitUUID)) {
             console.log('CallKitCoordinator: Reporting call ended to CallKit');
@@ -617,7 +759,11 @@ class CallKitCoordinator {
           }
           // Clean up the call mapping
           this.cleanupCall(callKitUUID);
+          if (shouldRestoreRemainingCall) {
+            await this.restoreRemainingHeldCall();
+          }
           break;
+        }
         case 'ringing':
           // For outgoing calls, we might want to update CallKit with additional info
           // For incoming calls, CallKit already knows about the call
@@ -634,8 +780,26 @@ class CallKitCoordinator {
    * Clean up call mappings and listeners
    */
   cleanupCall(callKitUUID) {
-    this.processingCalls.delete(callKitUUID);
+    callKitUUID = this.normalizeUUID(callKitUUID);
+    if (
+      this.pendingSwap?.activeCallKitUUID === callKitUUID ||
+      this.pendingSwap?.heldCallKitUUID === callKitUUID
+    ) {
+      this.finishPendingSwap(false);
+    }
+    for (const processingKey of this.processingCalls) {
+      if (processingKey.endsWith(`:${callKitUUID}`)) {
+        this.processingCalls.delete(processingKey);
+      }
+    }
+    for (const requestKey of this.pendingHeldRequests.keys()) {
+      if (requestKey.endsWith(`:${callKitUUID}`)) {
+        this.finishPendingHeldRequest(requestKey, false);
+      }
+    }
     this.connectedCalls.delete(callKitUUID);
+    this.pendingPushCallUUIDs.delete(callKitUUID);
+    this.autoAnswerCallUUIDs.delete(callKitUUID);
     // Get the call before removing it
     const call = this.callMap.get(callKitUUID);
     // Clean up state listeners
@@ -645,21 +809,14 @@ class CallKitCoordinator {
     }
     // Remove from mapping
     this.callMap.delete(callKitUUID);
-    if (call) {
-      // Clean up the stored UUID on the call
-      delete call._callKitUUID;
+    if (this.selectedCallKitUUID === callKitUUID) {
+      this.selectedCallKitUUID = null;
     }
     // Reset flags if no more active calls
     if (this.callMap.size === 0) {
       this.resetFlags();
     }
-    // Clear VoIP push data now that the call is done
-    if (react_native_1.Platform.OS === 'ios') {
-      voice_pn_bridge_1.VoicePnBridge.clearPendingVoipPush().catch((error) => {
-        console.warn('CallKitCoordinator: Error clearing VoIP push data on call cleanup:', error);
-      });
-      console.log('CallKitCoordinator: ✅ Cleared VoIP push data after call ended');
-    }
+    this.isCallFromPush = this.pendingPushCallUUIDs.size > 0;
   }
   /**
    * Get CallKit UUID for a WebRTC call
@@ -668,14 +825,16 @@ class CallKitCoordinator {
     // First check if the call has the UUID stored on it
     const storedUUID = call._callKitUUID;
     if (storedUUID) {
-      return storedUUID;
+      return this.normalizeUUID(storedUUID);
     }
     // Search through all call mappings
     for (const [uuid, mappedCall] of this.callMap.entries()) {
       if (mappedCall.callId === call.callId) {
         // Store UUID on the call for faster future lookups
-        call._callKitUUID = uuid;
-        return uuid;
+        if (!call._callKitUUID) {
+          call._callKitUUID = uuid;
+        }
+        return this.normalizeUUID(uuid);
       }
     }
     return null;
@@ -684,23 +843,28 @@ class CallKitCoordinator {
    * Get WebRTC call for a CallKit UUID
    */
   getWebRTCCall(callKitUUID) {
-    return this.callMap.get(callKitUUID) || null;
+    return this.callMap.get(this.normalizeUUID(callKitUUID)) || null;
   }
   /**
    * Link an existing CallKit call (from push notification) with a WebRTC call
    * This should be called when a WebRTC call arrives that corresponds to an existing CallKit call
    */
   linkExistingCallKitCall(call, callKitUUID) {
+    callKitUUID = this.normalizeUUID(callKitUUID);
     console.log('CallKitCoordinator: Linking existing CallKit call with WebRTC call', {
       callKitUUID,
       webrtcCallId: call.callId,
     });
     // Store the mappings
     this.callMap.set(callKitUUID, call);
-    // Store UUID on the call for quick access
-    call._callKitUUID = callKitUUID;
+    // Push-created calls already carry a durable, non-configurable UUID.
+    if (!call._callKitUUID) {
+      call._callKitUUID = callKitUUID;
+    }
     // Set up state listeners
-    this.setupWebRTCCallListeners(call, callKitUUID);
+    if (!call._callKitStateListener) {
+      this.setupWebRTCCallListeners(call, callKitUUID);
+    }
   }
   /**
    * Set the VoIP client reference for triggering reconnection.
@@ -715,14 +879,228 @@ class CallKitCoordinator {
    * Helper method to clean up push notification state
    */
   async cleanupPushNotificationState() {
-    console.log('CallKitCoordinator: ✅ Cleared auto-answer flag');
-    this.shouldAutoAnswerNextCall = false;
+    console.log('CallKitCoordinator: Push notification state cleaned up');
+  }
+  async rejectUnregisteredIncomingCall(callKitUUID, call) {
+    callKitUUID = this.normalizeUUID(callKitUUID);
+    console.warn('CallKitCoordinator: Cleaning up unregistered incoming call', {
+      callKitUUID,
+      webrtcCallId: call.callId,
+    });
+    this.cleanupCall(callKitUUID);
+    try {
+      await call.hangup();
+    } catch (error) {
+      console.warn('CallKitCoordinator: Failed to end unregistered signaling call', error);
+    }
+    await this.clearMatchingPendingVoipPush(callKitUUID);
+  }
+  async clearMatchingPendingVoipPush(callKitUUID) {
+    try {
+      const pendingPushJson = await voice_pn_bridge_1.VoicePnBridge.getPendingVoipPush();
+      if (!pendingPushJson) {
+        return;
+      }
+      const pendingPush = JSON.parse(pendingPushJson);
+      const pendingCallId =
+        pendingPush?.payload?.metadata?.call_id ??
+        pendingPush?.payload?.call_id ??
+        pendingPush?.metadata?.call_id ??
+        pendingPush?.call_id;
+      if (
+        typeof pendingCallId === 'string' &&
+        this.normalizeUUID(pendingCallId) === this.normalizeUUID(callKitUUID)
+      ) {
+        await voice_pn_bridge_1.VoicePnBridge.clearPendingVoipPush();
+      }
+    } catch (error) {
+      console.warn('CallKitCoordinator: Failed to clear rejected call push state', error);
+    }
   }
   /**
    * Get reference to the SDK client (for queuing actions when call doesn't exist yet)
    */
   getSDKClient() {
     return this.voipClient;
+  }
+  normalizeUUID(callKitUUID) {
+    return callKitUUID.toLowerCase();
+  }
+  actionKey(action, callKitUUID) {
+    return `${action}:${this.normalizeUUID(callKitUUID)}`;
+  }
+  selectCall(call) {
+    const callKitUUID = this.getCallKitUUID(call);
+    const wrapperCall = this.voipClient?.findCallByTelnyxCall(call);
+    if (!callKitUUID || !wrapperCall || !this.voipClient) {
+      return;
+    }
+    this.selectedCallKitUUID = callKitUUID;
+    this.voipClient.setActiveCall(wrapperCall.callId);
+  }
+  isSelectedCall(call) {
+    const callKitUUID = this.getCallKitUUID(call);
+    return callKitUUID !== null && callKitUUID === this.selectedCallKitUUID;
+  }
+  recordPendingSwapAction(callKitUUID, isOnHold, success) {
+    const pendingSwap = this.pendingSwap;
+    if (!pendingSwap || pendingSwap.mode === 'restoring') {
+      return;
+    }
+    const isExpectedAction =
+      (callKitUUID === pendingSwap.activeCallKitUUID && isOnHold) ||
+      (callKitUUID === pendingSwap.heldCallKitUUID && !isOnHold);
+    if (!isExpectedAction) {
+      return;
+    }
+    pendingSwap.failed || (pendingSwap.failed = !success);
+    pendingSwap.completedCallKitUUIDs.add(callKitUUID);
+    if (pendingSwap.completedCallKitUUIDs.size === 2) {
+      if (pendingSwap.mode === 'swap' && pendingSwap.failed) {
+        void this.beginSwapRollback(pendingSwap);
+      } else {
+        this.finishPendingSwap(pendingSwap.mode === 'swap');
+      }
+    }
+  }
+  createPendingSwap({
+    mode,
+    originalActiveCallKitUUID,
+    originalHeldCallKitUUID,
+    activeCallKitUUID,
+    heldCallKitUUID,
+    resolve,
+  }) {
+    const pendingSwap = {
+      mode,
+      originalActiveCallKitUUID,
+      originalHeldCallKitUUID,
+      activeCallKitUUID,
+      heldCallKitUUID,
+      completedCallKitUUIDs: new Set(),
+      failed: false,
+      resolve,
+      timeout: undefined,
+    };
+    pendingSwap.timeout = setTimeout(() => {
+      if (this.pendingSwap !== pendingSwap) {
+        return;
+      }
+      console.error(`CallKitCoordinator: Call ${mode} timed out`);
+      if (mode === 'swap') {
+        void this.beginSwapRollback(pendingSwap);
+      } else {
+        this.finishPendingSwap(false);
+      }
+    }, 12000);
+    return pendingSwap;
+  }
+  async beginSwapRollback(pendingSwap) {
+    if (!pendingSwap || this.pendingSwap !== pendingSwap || pendingSwap.mode !== 'swap') {
+      return;
+    }
+    clearTimeout(pendingSwap.timeout);
+    // Keep the operation installed while restoring WebRTC state so another
+    // hold or swap cannot enter and have its pending promise overwritten.
+    pendingSwap.mode = 'restoring';
+    await this.restoreOriginalWebRTCStates(
+      pendingSwap.originalActiveCallKitUUID,
+      pendingSwap.originalHeldCallKitUUID
+    );
+    // A call may have ended while restoration was in flight, in which case
+    // cleanup already resolved and removed this operation.
+    if (this.pendingSwap !== pendingSwap) {
+      return;
+    }
+    const rollback = this.createPendingSwap({
+      mode: 'rollback',
+      originalActiveCallKitUUID: pendingSwap.originalActiveCallKitUUID,
+      originalHeldCallKitUUID: pendingSwap.originalHeldCallKitUUID,
+      // A reverse swap requests the original held call to remain held and the
+      // original active call to become active again.
+      activeCallKitUUID: pendingSwap.originalHeldCallKitUUID,
+      heldCallKitUUID: pendingSwap.originalActiveCallKitUUID,
+      resolve: pendingSwap.resolve,
+    });
+    this.pendingSwap = rollback;
+    const accepted = await callkit_1.default.swapCalls(
+      rollback.activeCallKitUUID,
+      rollback.heldCallKitUUID
+    );
+    if (!accepted && this.pendingSwap === rollback) {
+      console.error('CallKitCoordinator: Compensating swap transaction was rejected');
+      this.finishPendingSwap(false);
+    }
+  }
+  async restoreOriginalWebRTCStates(activeCallKitUUID, heldCallKitUUID) {
+    const originalActive = this.callMap.get(activeCallKitUUID);
+    const originalHeld = this.callMap.get(heldCallKitUUID);
+    try {
+      if (originalHeld?.state === 'active') {
+        await originalHeld.hold();
+      }
+      if (originalActive?.state === 'held') {
+        await originalActive.unhold();
+      }
+      if (originalActive?.state === 'active') {
+        this.selectCall(originalActive);
+      }
+    } catch (error) {
+      console.error('CallKitCoordinator: Failed to restore WebRTC state before swap rollback', {
+        activeCallKitUUID,
+        heldCallKitUUID,
+        error,
+      });
+    }
+  }
+  finishPendingSwap(success) {
+    const pendingSwap = this.pendingSwap;
+    if (!pendingSwap) {
+      return;
+    }
+    this.pendingSwap = null;
+    clearTimeout(pendingSwap.timeout);
+    pendingSwap.resolve(success);
+  }
+  finishPendingHeldRequest(requestKey, success) {
+    const request = this.pendingHeldRequests.get(requestKey);
+    if (!request) {
+      return;
+    }
+    this.pendingHeldRequests.delete(requestKey);
+    clearTimeout(request.timeout);
+    request.resolve(success);
+  }
+  async restoreRemainingHeldCall() {
+    if (this.restoreHeldCallPromise) {
+      return this.restoreHeldCallPromise;
+    }
+    this.restoreHeldCallPromise = (async () => {
+      const heldEntry = Array.from(this.callMap.entries()).find(
+        ([, call]) => call.state === 'held'
+      );
+      if (!heldEntry) {
+        return;
+      }
+      const [callKitUUID, heldCall] = heldEntry;
+      try {
+        const restored = await this.setHeldFromUI(heldCall, false);
+        if (!restored) {
+          throw new Error('CallKit rejected survivor resume');
+        }
+        console.log('CallKitCoordinator: Restored remaining held call', callKitUUID);
+      } catch (error) {
+        console.error('CallKitCoordinator: Failed to restore remaining held call', {
+          callKitUUID,
+          error,
+        });
+      }
+    })();
+    try {
+      await this.restoreHeldCallPromise;
+    } finally {
+      this.restoreHeldCallPromise = null;
+    }
   }
   /**
    * Check if app is in background and disconnect client if no active calls
@@ -757,10 +1135,7 @@ class CallKitCoordinator {
    */
   resetFlags() {
     console.log('CallKitCoordinator: Resetting coordinator flags');
-    // Reset push notification flag
-    this.isCallFromPush = false;
-    // Reset auto-answer flag
-    this.shouldAutoAnswerNextCall = false;
+    this.isCallFromPush = this.pendingPushCallUUIDs.size > 0;
     console.log('CallKitCoordinator: ✅ Coordinator flags reset');
   }
   /**

--- a/react-voice-commons-sdk/lib/callkit/callkit-coordinator.js
+++ b/react-voice-commons-sdk/lib/callkit/callkit-coordinator.js
@@ -409,8 +409,26 @@ class CallKitCoordinator {
       currentState: call.state,
     });
     if (call.state === 'active') {
-      console.log('CallKitCoordinator: Call already active, skipping duplicate answer action');
+      console.log(
+        'CallKitCoordinator: Call already active, completing pending CallKit answer action'
+      );
       this.selectCall(call);
+      // The native CXAnswerCallAction is fulfilled only after JS reports the
+      // call as connected. If the WebRTC call already reached active before
+      // the CallKit answer event arrived, we must still report connected so
+      // iOS does not time out the pending answer action.
+      if (!this.connectedCalls.has(callKitUUID)) {
+        try {
+          await callkit_1.default.reportCallConnected(callKitUUID);
+          this.connectedCalls.add(callKitUUID);
+          console.log('CallKitCoordinator: Reported call connected for already-active call');
+        } catch (error) {
+          console.error(
+            'CallKitCoordinator: Error reporting connected for already-active call:',
+            error
+          );
+        }
+      }
       return;
     }
     this.processingCalls.add(processingKey);
@@ -562,12 +580,17 @@ class CallKitCoordinator {
   /**
    * Handle CallKit push received event
    * This allows us to coordinate between the push notification and any subsequent WebRTC calls
+   *
+   * Returns `true` when the push was accepted and call processing was started,
+   * or `false` when the push was filtered, rejected, or otherwise ignored so
+   * that callers can clean up any foreground-push lifecycle flags they set
+   * before calling this method.
    */
   async handleCallKitPushReceived(callKitUUID, event) {
     callKitUUID = this.normalizeUUID(callKitUUID);
     if (this.pendingPushCallUUIDs.has(callKitUUID)) {
       console.log('CallKitCoordinator: Ignoring duplicate push UUID', callKitUUID);
-      return;
+      return false;
     }
     const isRegistered = await callkit_1.default.isCallRegistered(callKitUUID);
     if (!isRegistered) {
@@ -577,7 +600,7 @@ class CallKitCoordinator {
       );
       this.getSDKClient()?.queueEndFromCallKit(callKitUUID);
       await this.clearMatchingPendingVoipPush(callKitUUID);
-      return;
+      return false;
     }
     console.log('CallKitCoordinator: Processing push received event', {
       callKitUUID,
@@ -632,10 +655,12 @@ class CallKitCoordinator {
       // Process the push notification
       await voipClient.handlePushNotification(pushData);
       console.log('CallKitCoordinator: Push notification processed successfully');
+      return true;
     } catch (error) {
       this.pendingPushCallUUIDs.delete(callKitUUID);
       this.isCallFromPush = this.pendingPushCallUUIDs.size > 0;
       console.error('CallKitCoordinator: Error processing push received event:', error);
+      return false;
     }
   }
   /**

--- a/react-voice-commons-sdk/lib/callkit/callkit-coordinator.js
+++ b/react-voice-commons-sdk/lib/callkit/callkit-coordinator.js
@@ -234,6 +234,7 @@ class CallKitCoordinator {
         this.selectCall(call);
         this.pendingPushCallUUIDs.delete(callKitUUID);
         this.isCallFromPush = this.pendingPushCallUUIDs.size > 0;
+        await this.clearMatchingPendingVoipPush(callKitUUID);
         console.log('CallKitCoordinator: CallKit answer success');
       }
       return success;
@@ -914,7 +915,7 @@ class CallKitCoordinator {
         await voice_pn_bridge_1.VoicePnBridge.clearPendingVoipPush();
       }
     } catch (error) {
-      console.warn('CallKitCoordinator: Failed to clear rejected call push state', error);
+      console.warn('CallKitCoordinator: Failed to clear matching pending VoIP push', error);
     }
   }
   /**

--- a/react-voice-commons-sdk/lib/callkit/callkit.d.ts
+++ b/react-voice-commons-sdk/lib/callkit/callkit.d.ts
@@ -7,6 +7,7 @@ export declare enum CallEndReason {
 }
 export interface CallKitEvent {
   callUUID: string;
+  isOnHold?: boolean;
   [key: string]: any;
 }
 declare class CallKitManager {
@@ -33,7 +34,11 @@ declare class CallKitManager {
   startOutgoingCall(callUUID: string, handle: string, displayName: string): Promise<boolean>;
   reportIncomingCall(callUUID: string, handle: string, displayName: string): Promise<boolean>;
   answerCall(callUUID: string): Promise<boolean>;
+  isCallRegistered(callUUID: string): Promise<boolean>;
   endCall(callUUID: string): Promise<boolean>;
+  completeHeldCallAction(callUUID: string, success: boolean): Promise<boolean>;
+  setCallHeld(callUUID: string, isOnHold: boolean): Promise<boolean>;
+  swapCalls(activeCallUUID: string, heldCallUUID: string): Promise<boolean>;
   reportCallConnected(callUUID: string): Promise<boolean>;
   reportCallEnded(callUUID: string, reason?: CallEndReason): Promise<boolean>;
   updateCall(callUUID: string, displayName: string, handle: string): Promise<boolean>;
@@ -41,7 +46,9 @@ declare class CallKitManager {
   onStartCall(listener: (event: CallKitEvent) => void): () => void;
   onAnswerCall(listener: (event: CallKitEvent) => void): () => void;
   onEndCall(listener: (event: CallKitEvent) => void): () => void;
+  onHeldCall(listener: (event: CallKitEvent) => void): () => void;
   onReceivePush(listener: (event: CallKitEvent) => void): () => void;
+  private addListener;
   generateCallUUID(): string;
   isAvailable(): boolean;
 }

--- a/react-voice-commons-sdk/lib/callkit/callkit.js
+++ b/react-voice-commons-sdk/lib/callkit/callkit.js
@@ -68,6 +68,11 @@ class CallKitManager {
       console.log('CallKit: Received end call action', normalizedEvent);
       this.notifyListeners('endCall', normalizedEvent);
     });
+    this.eventEmitter.addListener('CallKitDidPerformHeldCallAction', (event) => {
+      const normalizedEvent = this.normalizeEvent(event);
+      console.log('CallKit: Received held call action', normalizedEvent);
+      this.notifyListeners('heldCall', normalizedEvent);
+    });
     this.eventEmitter.addListener('CallKitDidReceivePush', (event) => {
       const normalizedEvent = this.normalizeEvent(event);
       console.log('CallKit: Received push notification event', normalizedEvent);
@@ -75,9 +80,11 @@ class CallKitManager {
     });
   }
   notifyListeners(eventType, event) {
-    const listener = this.listeners.get(eventType);
-    if (listener) {
-      listener(event);
+    const listeners = this.listeners.get(eventType);
+    if (listeners) {
+      for (const listener of listeners) {
+        listener(event);
+      }
     }
   }
   // Public API methods
@@ -140,6 +147,21 @@ class CallKitManager {
       return false;
     }
   }
+  async isCallRegistered(callUUID) {
+    if (!this.bridge || react_native_1.Platform.OS !== 'ios') {
+      return false;
+    }
+    try {
+      const result = await this.bridge.isCallRegistered(this.denormalizeUUID(callUUID));
+      return result.registered;
+    } catch (error) {
+      console.error('CallKit: Failed to check incoming call registration', {
+        callUUID,
+        error,
+      });
+      return false;
+    }
+  }
   async endCall(callUUID) {
     if (!this.bridge || react_native_1.Platform.OS !== 'ios') {
       console.warn('CallKit: Not available on this platform');
@@ -154,6 +176,46 @@ class CallKitManager {
       return result.success;
     } catch (error) {
       console.error('CallKit: Failed to end call', error);
+      return false;
+    }
+  }
+  async completeHeldCallAction(callUUID, success) {
+    if (!this.bridge || react_native_1.Platform.OS !== 'ios') {
+      return false;
+    }
+    try {
+      const uppercaseUUID = this.denormalizeUUID(callUUID);
+      const result = await this.bridge.completeHeldCallAction(uppercaseUUID, success);
+      return result.success;
+    } catch (error) {
+      console.error('CallKit: Failed to complete held call action', error);
+      return false;
+    }
+  }
+  async setCallHeld(callUUID, isOnHold) {
+    if (!this.bridge || react_native_1.Platform.OS !== 'ios') {
+      return false;
+    }
+    try {
+      const result = await this.bridge.setCallHeld(this.denormalizeUUID(callUUID), isOnHold);
+      return result.success;
+    } catch (error) {
+      console.error('CallKit: Failed to change held state', { callUUID, isOnHold, error });
+      return false;
+    }
+  }
+  async swapCalls(activeCallUUID, heldCallUUID) {
+    if (!this.bridge || react_native_1.Platform.OS !== 'ios') {
+      return false;
+    }
+    try {
+      const result = await this.bridge.swapCalls(
+        this.denormalizeUUID(activeCallUUID),
+        this.denormalizeUUID(heldCallUUID)
+      );
+      return result.success;
+    } catch (error) {
+      console.error('CallKit: Failed to swap calls', error);
       return false;
     }
   }
@@ -220,20 +282,30 @@ class CallKitManager {
   }
   // Event listener management
   onStartCall(listener) {
-    this.listeners.set('startCall', listener);
-    return () => this.listeners.delete('startCall');
+    return this.addListener('startCall', listener);
   }
   onAnswerCall(listener) {
-    this.listeners.set('answerCall', listener);
-    return () => this.listeners.delete('answerCall');
+    return this.addListener('answerCall', listener);
   }
   onEndCall(listener) {
-    this.listeners.set('endCall', listener);
-    return () => this.listeners.delete('endCall');
+    return this.addListener('endCall', listener);
+  }
+  onHeldCall(listener) {
+    return this.addListener('heldCall', listener);
   }
   onReceivePush(listener) {
-    this.listeners.set('receivePush', listener);
-    return () => this.listeners.delete('receivePush');
+    return this.addListener('receivePush', listener);
+  }
+  addListener(eventType, listener) {
+    const listeners = this.listeners.get(eventType) ?? new Set();
+    listeners.add(listener);
+    this.listeners.set(eventType, listeners);
+    return () => {
+      listeners.delete(listener);
+      if (listeners.size === 0) {
+        this.listeners.delete(eventType);
+      }
+    };
   }
   // Utility methods
   generateCallUUID() {

--- a/react-voice-commons-sdk/lib/internal/calls/call-state-controller.d.ts
+++ b/react-voice-commons-sdk/lib/internal/calls/call-state-controller.d.ts
@@ -65,7 +65,14 @@ export declare class CallStateController {
    * @param telnyxCall The Telnyx call object to find
    */
   findCallByTelnyxCall(telnyxCall: any): Call | null;
+  /**
+   * Select the active call, preferring the explicitly-tracked call ID
+   * over the first-match heuristic.
+   */
   private _selectActiveCall;
+  /**
+   * Check if a call is in a non-terminal (active or connecting) state.
+   */
   private _isNonTerminal;
   /**
    * Initialize client listeners when the Telnyx client becomes available

--- a/react-voice-commons-sdk/lib/internal/calls/call-state-controller.js
+++ b/react-voice-commons-sdk/lib/internal/calls/call-state-controller.js
@@ -6,7 +6,6 @@ const operators_1 = require('rxjs/operators');
 const call_1 = require('../../models/call');
 const call_state_1 = require('../../models/call-state');
 const callkit_coordinator_1 = require('../../callkit/callkit-coordinator');
-const voice_pn_bridge_1 = require('../voice-pn-bridge');
 /**
  * Central state machine for call management.
  *
@@ -19,6 +18,10 @@ class CallStateController {
     this._calls = new rxjs_1.BehaviorSubject([]);
     this._callMap = new Map();
     this._disposed = false;
+    // Explicitly-tracked active call ID for multi-call scenarios.
+    // When set, activeCall$/currentActiveCall prefer this call over the
+    // first-match heuristic. Cleared automatically when the call reaches
+    // a terminal state, or manually via clearActiveCall().
     this._activeCallId = null;
     this._handleTelnyxIncomingCall = (telnyxCall, msg) => {
       console.log('CallStateController: Incoming call received:', telnyxCall.callId);
@@ -407,7 +410,11 @@ class CallStateController {
         callkit_coordinator_1.callKitCoordinator.getCallKitUUID(telnyxCall);
       if (existingCallKitUUID) {
         console.log(
-          'CallStateController: Call already has CallKit integration, skipping duplicate report:',
+          'CallStateController: Linking push-created CallKit call to its signaling call:',
+          existingCallKitUUID
+        );
+        callkit_coordinator_1.callKitCoordinator.linkExistingCallKitCall(
+          telnyxCall,
           existingCallKitUUID
         );
       } else if (call.isIncoming) {
@@ -446,10 +453,6 @@ class CallStateController {
         if (this._activeCallId === call.callId) {
           this._activeCallId = null;
         }
-        // Clear pending push data so the next app launch isn't mistaken for a push launch
-        voice_pn_bridge_1.VoicePnBridge.clearPendingVoipPush().catch((e) =>
-          console.warn('CallStateController: Failed to clear pending voip push:', e)
-        );
         setTimeout(() => this._removeCall(call.callId), 0);
       }
     });

--- a/react-voice-commons-sdk/lib/internal/session/session-manager.d.ts
+++ b/react-voice-commons-sdk/lib/internal/session/session-manager.d.ts
@@ -80,6 +80,7 @@ export declare class SessionManager {
    * Handle push notification (async version)
    */
   handlePushNotification(payload: Record<string, any>): Promise<void>;
+  private _hasActiveOrHeldCall;
   /**
    * Dispose of the session manager and clean up resources
    */

--- a/react-voice-commons-sdk/lib/internal/session/session-manager.js
+++ b/react-voice-commons-sdk/lib/internal/session/session-manager.js
@@ -60,6 +60,7 @@ const pkg = __importStar(require('../../../package.json'));
 const connection_state_1 = require('../../models/connection-state');
 const config_1 = require('../../models/config');
 const USE_TRICKLE_ICE_STORAGE_KEY = '@use_trickle_ice';
+const PUSH_WHEN_ACTIVE_STORAGE_KEY = '@push_when_active';
 const MISSED_CALL_NOTIFICATIONS_STORAGE_KEY = '@enable_missed_call_notifications';
 /**
  * Manages the connection lifecycle to the Telnyx platform.
@@ -205,11 +206,24 @@ class SessionManager {
     );
     // Store the push notification payload for when the client is created
     this._pendingPushPayload = payload;
-    // Each push always rebuilds the TelnyxRTC client. The voice_sdk_id is
-    // baked into the WebSocket URL at socket-open time and can't be mutated
-    // mid-flight; reusing a connection from a previous push means the
-    // gateway routes THIS push's INVITE to a different (correctly-stamped)
-    // client and we sit on the wrong socket forever.
+    // A second-call push must stay on the client that owns the active/held
+    // call. Tearing it down destroys the first signaling session and clears
+    // the call collection before CallKit can complete Hold & Accept.
+    if (this._telnyxClient && this._hasActiveOrHeldCall(this._telnyxClient)) {
+      const actualPayload = this._extractPushPayload(payload);
+      const processVoIPNotification = this._telnyxClient.processVoIPNotification;
+      if (typeof processVoIPNotification !== 'function') {
+        throw new Error('TelnyxRTC client cannot process an active-call VoIP notification');
+      }
+      console.log(
+        'SessionManager: Preserving active client while processing second-call push notification'
+      );
+      processVoIPNotification.call(this._telnyxClient, actualPayload);
+      this._pendingPushPayload = null;
+      return;
+    }
+    // The cold/no-active-call path still rebuilds the client so the socket is
+    // stamped with the push voice_sdk_id before connecting.
     if (this._telnyxClient) {
       await this._disconnectAndForgetClient(
         this._telnyxClient,
@@ -236,10 +250,12 @@ class SessionManager {
         const storedCredentialToken = await AsyncStorage.getItem('@credential_token');
         const storedPushToken = await AsyncStorage.getItem('@push_token');
         const storedUseTrickleIce = await AsyncStorage.getItem(USE_TRICKLE_ICE_STORAGE_KEY);
+        const storedPushWhenActive = await AsyncStorage.getItem(PUSH_WHEN_ACTIVE_STORAGE_KEY);
         const storedMissedCallNotifications = await AsyncStorage.getItem(
           MISSED_CALL_NOTIFICATIONS_STORAGE_KEY
         );
         const useTrickleIce = storedUseTrickleIce === 'true';
+        const pushWhenActive = storedPushWhenActive === 'true';
         const enableMissedCallNotifications = storedMissedCallNotifications === 'true';
         if (this._isTeardownActive()) {
           return;
@@ -251,6 +267,7 @@ class SessionManager {
           this._currentConfig = createCredentialConfig(storedUsername, storedPassword, {
             pushNotificationDeviceToken: storedPushToken,
             useTrickleIce,
+            pushWhenActive,
             enableMissedCallNotifications,
           });
         }
@@ -261,6 +278,7 @@ class SessionManager {
           this._currentConfig = createTokenConfig(storedCredentialToken, {
             pushNotificationDeviceToken: storedPushToken,
             useTrickleIce,
+            pushWhenActive,
             enableMissedCallNotifications,
           });
         }
@@ -351,6 +369,13 @@ class SessionManager {
     }
     console.log('SessionManager: RELEASE DEBUG - Push notification handling complete');
   }
+  _hasActiveOrHeldCall(client) {
+    const calls =
+      typeof client.getActiveCalls === 'function'
+        ? client.getActiveCalls()
+        : Array.from(client.calls?.values?.() || []);
+    return calls.some((call) => call?.state === 'active' || call?.state === 'held');
+  }
   /**
    * Dispose of the session manager and clean up resources
    */
@@ -435,6 +460,7 @@ class SessionManager {
           logLevel: config.debug ? 'debug' : 'warn',
           debug: config.debug ?? false,
           pushNotificationDeviceToken: config.pushNotificationDeviceToken,
+          pushWhenActive: config.pushWhenActive,
           enableMissedCallNotifications: config.enableMissedCallNotifications ?? false,
           useTrickleIce: config.useTrickleIce,
           enableCallReports: config.enableCallReports,
@@ -455,6 +481,7 @@ class SessionManager {
           logLevel: config.debug ? 'debug' : 'warn',
           debug: config.debug ?? false,
           pushNotificationDeviceToken: config.pushNotificationDeviceToken,
+          pushWhenActive: config.pushWhenActive,
           enableMissedCallNotifications: config.enableMissedCallNotifications ?? false,
           useTrickleIce: config.useTrickleIce,
           enableCallReports: config.enableCallReports,

--- a/react-voice-commons-sdk/lib/models/call.js
+++ b/react-voice-commons-sdk/lib/models/call.js
@@ -314,6 +314,18 @@ class Call {
       throw new Error(`Cannot hold call in state: ${this.currentState}`);
     }
     try {
+      if (react_native_1.Platform.OS === 'ios') {
+        const { callKitCoordinator } = await Promise.resolve().then(() =>
+          __importStar(require('../callkit/callkit-coordinator'))
+        );
+        if (callKitCoordinator.isAvailable()) {
+          const success = await callKitCoordinator.setHeldFromUI(this._telnyxCall, true);
+          if (!success) {
+            throw new Error('CallKit failed to hold call');
+          }
+          return;
+        }
+      }
       await this._telnyxCall.hold();
     } catch (error) {
       console.error('Failed to hold call:', error);
@@ -328,6 +340,18 @@ class Call {
       throw new Error(`Cannot resume call in state: ${this.currentState}`);
     }
     try {
+      if (react_native_1.Platform.OS === 'ios') {
+        const { callKitCoordinator } = await Promise.resolve().then(() =>
+          __importStar(require('../callkit/callkit-coordinator'))
+        );
+        if (callKitCoordinator.isAvailable()) {
+          const success = await callKitCoordinator.setHeldFromUI(this._telnyxCall, false);
+          if (!success) {
+            throw new Error('CallKit failed to resume call');
+          }
+          return;
+        }
+      }
       await this._telnyxCall.unhold();
     } catch (error) {
       console.error('Failed to resume call:', error);
@@ -422,6 +446,17 @@ class Call {
     this._telnyxCall.on('telnyx.call.state', (call, state) => {
       const telnyxState = this._mapToTelnyxCallState(state);
       this._callState.next(telnyxState);
+      // Keep the dedicated held observable derived from call state. Updating
+      // this only after the low-level SDK emits its successful transition
+      // preserves the previous value when hold/unhold signaling fails.
+      if (telnyxState === call_state_1.TelnyxCallState.HELD) {
+        this._isHeld.next(true);
+      } else if (
+        telnyxState === call_state_1.TelnyxCallState.ACTIVE ||
+        call_state_1.CallStateHelpers.isTerminated(telnyxState)
+      ) {
+        this._isHeld.next(false);
+      }
       // Start duration timer when call becomes active
       if (telnyxState === call_state_1.TelnyxCallState.ACTIVE && !this._startTime) {
         this._startDurationTimer();

--- a/react-voice-commons-sdk/lib/models/config.d.ts
+++ b/react-voice-commons-sdk/lib/models/config.d.ts
@@ -7,6 +7,8 @@ export interface CredentialConfig {
   sipPassword: string;
   debug?: boolean;
   pushNotificationDeviceToken?: string;
+  /** Receive PushKit calls while the WebSocket session is active. Default: false */
+  pushWhenActive?: boolean;
   /** Enable native missed call push notifications. Default: false */
   enableMissedCallNotifications?: boolean;
   /** Enable Trickle ICE. Default: false */
@@ -28,6 +30,8 @@ export interface TokenConfig {
   token: string;
   debug?: boolean;
   pushNotificationDeviceToken?: string;
+  /** Receive PushKit calls while the WebSocket session is active. Default: false */
+  pushWhenActive?: boolean;
   /** Enable native missed call push notifications. Default: false */
   enableMissedCallNotifications?: boolean;
   /** Enable Trickle ICE. Default: false */
@@ -73,6 +77,7 @@ export declare function validateConfig(config: Config): string[];
  * @param options - Optional configuration settings
  * @param options.debug - Enable debug logging (sets SDK logLevel to 'debug')
  * @param options.pushNotificationDeviceToken - Device token for push notifications
+ * @param options.pushWhenActive - Keep active PushKit devices eligible for incoming calls
  * @returns Complete credential configuration object
  */
 export declare function createCredentialConfig(
@@ -87,6 +92,7 @@ export declare function createCredentialConfig(
  * @param options - Optional configuration settings
  * @param options.debug - Enable debug logging (sets SDK logLevel to 'debug')
  * @param options.pushNotificationDeviceToken - Device token for push notifications
+ * @param options.pushWhenActive - Keep active PushKit devices eligible for incoming calls
  * @returns Complete token configuration object
  */
 export declare function createTokenConfig(

--- a/react-voice-commons-sdk/lib/models/config.js
+++ b/react-voice-commons-sdk/lib/models/config.js
@@ -62,6 +62,7 @@ function validateConfig(config) {
  * @param options - Optional configuration settings
  * @param options.debug - Enable debug logging (sets SDK logLevel to 'debug')
  * @param options.pushNotificationDeviceToken - Device token for push notifications
+ * @param options.pushWhenActive - Keep active PushKit devices eligible for incoming calls
  * @returns Complete credential configuration object
  */
 function createCredentialConfig(sipUser, sipPassword, options) {
@@ -79,6 +80,7 @@ function createCredentialConfig(sipUser, sipPassword, options) {
  * @param options - Optional configuration settings
  * @param options.debug - Enable debug logging (sets SDK logLevel to 'debug')
  * @param options.pushNotificationDeviceToken - Device token for push notifications
+ * @param options.pushWhenActive - Keep active PushKit devices eligible for incoming calls
  * @returns Complete token configuration object
  */
 function createTokenConfig(sipToken, options) {

--- a/react-voice-commons-sdk/lib/telnyx-voice-app.js
+++ b/react-voice-commons-sdk/lib/telnyx-voice-app.js
@@ -6,6 +6,7 @@ const react_1 = require('react');
 const react_native_1 = require('react-native');
 const telnyx_voip_client_1 = require('./telnyx-voip-client');
 const connection_state_1 = require('./models/connection-state');
+const call_state_1 = require('./models/call-state');
 const TelnyxVoiceContext_1 = require('./context/TelnyxVoiceContext');
 let sharedBackgroundClient = null;
 let sharedBackgroundDisposePromise = null;
@@ -344,11 +345,20 @@ const TelnyxVoiceAppComponent = ({
         // Prevent duplicate processing if already connected or connecting.
         // Since push data is no longer cleared on read, this guard prevents
         // re-processing when checkForInitialPushNotification fires again on app resume.
-        if (
+        const isConnectedOrConnecting =
           voipClient.currentConnectionState ===
             connection_state_1.TelnyxConnectionState.CONNECTED ||
-          voipClient.currentConnectionState === connection_state_1.TelnyxConnectionState.CONNECTING
-        ) {
+          voipClient.currentConnectionState === connection_state_1.TelnyxConnectionState.CONNECTING;
+        const isActiveIOSCallWaitingPush =
+          react_native_1.Platform.OS === 'ios' &&
+          voipClient.currentConnectionState ===
+            connection_state_1.TelnyxConnectionState.CONNECTED &&
+          voipClient.currentCalls.some(
+            (call) =>
+              call.currentState === call_state_1.TelnyxCallState.ACTIVE ||
+              call.currentState === call_state_1.TelnyxCallState.HELD
+          );
+        if (isConnectedOrConnecting && !isActiveIOSCallWaitingPush) {
           log(
             `SKIPPING - Already ${voipClient.currentConnectionState}, preventing duplicate processing`
           );

--- a/react-voice-commons-sdk/lib/telnyx-voice-app.js
+++ b/react-voice-commons-sdk/lib/telnyx-voice-app.js
@@ -376,10 +376,19 @@ const TelnyxVoiceAppComponent = ({
           if (callId) {
             const { callKitCoordinator } = require('./callkit/callkit-coordinator');
             log('Notifying CallKit coordinator about push notification:', callId);
-            await callKitCoordinator.handleCallKitPushReceived(callId, {
+            const processed = await callKitCoordinator.handleCallKitPushReceived(callId, {
               callData: { source: 'push_notification' },
               pushData: pushData,
             });
+            if (!processed) {
+              // The push was filtered, rejected, or otherwise ignored by
+              // CallKit. Reset the foreground-push lifecycle flags so the
+              // app does not stay in a state that skips background
+              // disconnect/reconnect handling.
+              log('CallKit push was not processed - resetting foreground flags');
+              setIsHandlingForegroundCall(false);
+              backgroundDetectorIgnore.current = false;
+            }
           } else {
             log('No call_id found in push data, falling back to direct handling');
             await voipClient.handlePushNotification(pushData);

--- a/react-voice-commons-sdk/lib/telnyx-voip-client.d.ts
+++ b/react-voice-commons-sdk/lib/telnyx-voip-client.d.ts
@@ -28,6 +28,7 @@ export declare class TelnyxVoipClient {
   private readonly _sessionManager;
   private readonly _callStateController;
   private readonly _options;
+  private readonly _pendingCallKitAnswers;
   private _disposed;
   private _disposePromise?;
   /**
@@ -237,6 +238,13 @@ export declare class TelnyxVoipClient {
    * disposed after handling push notifications.
    */
   dispose(): Promise<void>;
+  /**
+   * Forward answers captured during cold start as soon as SessionManager has
+   * created the TelnyxRTC instance. SessionManager invokes its ready callback
+   * before connect(), so the UUID-keyed action is present when the INVITE
+   * arrives.
+   */
+  private _flushPendingCallKitAnswers;
   /**
    * Prefer an explicitly supplied token, otherwise hydrate it from PushKit's
    * native storage. PushKit registration starts in AppDelegate before React

--- a/react-voice-commons-sdk/lib/telnyx-voip-client.d.ts
+++ b/react-voice-commons-sdk/lib/telnyx-voip-client.d.ts
@@ -113,6 +113,13 @@ export declare class TelnyxVoipClient {
    */
   clearActiveCall(): void;
   /**
+   * Swap the current active call with a held call.
+   * On iOS this is coordinated through CallKit so native and SDK state stay aligned.
+   *
+   * @param targetCallId ID of the held call to make active
+   */
+  swapCalls(targetCallId: string): Promise<void>;
+  /**
    * Current session ID (UUID) for this connection.
    */
   get sessionId(): string;
@@ -207,12 +214,21 @@ export declare class TelnyxVoipClient {
    * This should be called when the user answers from CallKit before the socket connection is established
    * @param customHeaders Optional custom headers to include with the answer
    */
-  queueAnswerFromCallKit(customHeaders?: Record<string, string>): void;
+  queueAnswerFromCallKit(
+    callKitUUIDOrHeaders?: string | Record<string, string>,
+    customHeaders?: Record<string, string>
+  ): void;
   /**
    * Queue an end action for when the call invite arrives (for CallKit integration)
    * This should be called when the user ends from CallKit before the socket connection is established
    */
-  queueEndFromCallKit(): void;
+  queueEndFromCallKit(callKitUUID?: string): void;
+  /**
+   * Associate the next push-delivered INVITE with its app-facing CallKit UUID.
+   * The underlying signaling call ID remains unchanged.
+   * @internal
+   */
+  setPushNotificationCallKitUUID(callKitUUID: string | null): void;
   /**
    * Dispose of the client and clean up all resources.
    *
@@ -221,6 +237,12 @@ export declare class TelnyxVoipClient {
    * disposed after handling push notifications.
    */
   dispose(): Promise<void>;
+  /**
+   * Prefer an explicitly supplied token, otherwise hydrate it from PushKit's
+   * native storage. PushKit registration starts in AppDelegate before React
+   * mounts, so this removes the race between the JS token event and login.
+   */
+  private _withNativeVoipPushToken;
   /**
    * Store credential configuration for automatic reconnection
    */

--- a/react-voice-commons-sdk/lib/telnyx-voip-client.js
+++ b/react-voice-commons-sdk/lib/telnyx-voip-client.js
@@ -66,6 +66,7 @@ const voice_pn_bridge_1 = require('./internal/voice-pn-bridge');
 const USE_TRICKLE_ICE_STORAGE_KEY = '@use_trickle_ice';
 const PUSH_WHEN_ACTIVE_STORAGE_KEY = '@push_when_active';
 const MISSED_CALL_NOTIFICATIONS_STORAGE_KEY = '@enable_missed_call_notifications';
+const LEGACY_CALLKIT_ANSWER_KEY = '__legacy_callkit_answer__';
 /**
  * The main public interface for the react-voice-commons module.
  *
@@ -104,6 +105,7 @@ class TelnyxVoipClient {
    * @param options Configuration options for the client
    */
   constructor(options = {}) {
+    this._pendingCallKitAnswers = new Map();
     this._disposed = false;
     this._options = {
       enableAppStateManagement: true,
@@ -121,6 +123,7 @@ class TelnyxVoipClient {
       console.log(
         '🔧 TelnyxVoipClient: Client ready, initializing call state controller listeners'
       );
+      this._flushPendingCallKitAnswers();
       this._callStateController.initializeClientListeners();
     });
     // Clear any tracked calls when the session disconnects, so ghosts
@@ -541,9 +544,17 @@ class TelnyxVoipClient {
     if (telnyxClient && typeof telnyxClient.queueAnswerFromCallKit === 'function') {
       telnyxClient.queueAnswerFromCallKit(callKitUUIDOrHeaders, customHeaders);
     } else {
-      console.warn(
-        'TelnyxVoipClient: TelnyxRTC client not available or method not found for queueAnswerFromCallKit'
-      );
+      const normalizedUUID =
+        typeof callKitUUIDOrHeaders === 'string' ? callKitUUIDOrHeaders.toLowerCase() : undefined;
+      const actionKey = normalizedUUID ?? LEGACY_CALLKIT_ANSWER_KEY;
+      let retainedUUIDOrHeaders = normalizedUUID;
+      if (callKitUUIDOrHeaders && typeof callKitUUIDOrHeaders !== 'string') {
+        retainedUUIDOrHeaders = { ...callKitUUIDOrHeaders };
+      }
+      this._pendingCallKitAnswers.set(actionKey, {
+        callKitUUIDOrHeaders: retainedUUIDOrHeaders,
+        customHeaders: { ...customHeaders },
+      });
     }
   }
   /**
@@ -595,12 +606,39 @@ class TelnyxVoipClient {
       try {
         await this._sessionManager.dispose();
       } finally {
+        this._pendingCallKitAnswers.clear();
         this._callStateController.dispose();
       }
     })();
     return this._disposePromise;
   }
   // ========== Private Methods ==========
+  /**
+   * Forward answers captured during cold start as soon as SessionManager has
+   * created the TelnyxRTC instance. SessionManager invokes its ready callback
+   * before connect(), so the UUID-keyed action is present when the INVITE
+   * arrives.
+   */
+  _flushPendingCallKitAnswers() {
+    const telnyxClient = this._sessionManager.telnyxClient;
+    if (!telnyxClient || typeof telnyxClient.queueAnswerFromCallKit !== 'function') {
+      return;
+    }
+    for (const [actionKey, pendingAnswer] of this._pendingCallKitAnswers) {
+      try {
+        telnyxClient.queueAnswerFromCallKit(
+          pendingAnswer.callKitUUIDOrHeaders,
+          pendingAnswer.customHeaders
+        );
+        this._pendingCallKitAnswers.delete(actionKey);
+      } catch (error) {
+        console.error('TelnyxVoipClient: Failed to restore pending CallKit answer', {
+          actionKey,
+          error,
+        });
+      }
+    }
+  }
   /**
    * Prefer an explicitly supplied token, otherwise hydrate it from PushKit's
    * native storage. PushKit registration starts in AppDelegate before React

--- a/react-voice-commons-sdk/lib/telnyx-voip-client.js
+++ b/react-voice-commons-sdk/lib/telnyx-voip-client.js
@@ -1,9 +1,62 @@
 'use strict';
+var __createBinding =
+  (this && this.__createBinding) ||
+  (Object.create
+    ? function (o, m, k, k2) {
+        if (k2 === undefined) k2 = k;
+        var desc = Object.getOwnPropertyDescriptor(m, k);
+        if (!desc || ('get' in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+          desc = {
+            enumerable: true,
+            get: function () {
+              return m[k];
+            },
+          };
+        }
+        Object.defineProperty(o, k2, desc);
+      }
+    : function (o, m, k, k2) {
+        if (k2 === undefined) k2 = k;
+        o[k2] = m[k];
+      });
+var __setModuleDefault =
+  (this && this.__setModuleDefault) ||
+  (Object.create
+    ? function (o, v) {
+        Object.defineProperty(o, 'default', { enumerable: true, value: v });
+      }
+    : function (o, v) {
+        o['default'] = v;
+      });
+var __importStar =
+  (this && this.__importStar) ||
+  (function () {
+    var ownKeys = function (o) {
+      ownKeys =
+        Object.getOwnPropertyNames ||
+        function (o) {
+          var ar = [];
+          for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+          return ar;
+        };
+      return ownKeys(o);
+    };
+    return function (mod) {
+      if (mod && mod.__esModule) return mod;
+      var result = {};
+      if (mod != null)
+        for (var k = ownKeys(mod), i = 0; i < k.length; i++)
+          if (k[i] !== 'default') __createBinding(result, mod, k[i]);
+      __setModuleDefault(result, mod);
+      return result;
+    };
+  })();
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.TelnyxVoipClient = void 0;
 exports.createTelnyxVoipClient = createTelnyxVoipClient;
 exports.destroyTelnyxVoipClient = destroyTelnyxVoipClient;
 exports.createBackgroundTelnyxVoipClient = createBackgroundTelnyxVoipClient;
+const react_native_1 = require('react-native');
 const connection_state_1 = require('./models/connection-state');
 const call_state_1 = require('./models/call-state');
 const config_1 = require('./models/config');
@@ -11,6 +64,7 @@ const session_manager_1 = require('./internal/session/session-manager');
 const call_state_controller_1 = require('./internal/calls/call-state-controller');
 const voice_pn_bridge_1 = require('./internal/voice-pn-bridge');
 const USE_TRICKLE_ICE_STORAGE_KEY = '@use_trickle_ice';
+const PUSH_WHEN_ACTIVE_STORAGE_KEY = '@push_when_active';
 const MISSED_CALL_NOTIFICATIONS_STORAGE_KEY = '@enable_missed_call_notifications';
 /**
  * The main public interface for the react-voice-commons module.
@@ -173,6 +227,51 @@ class TelnyxVoipClient {
     this._callStateController.clearActiveCall();
   }
   /**
+   * Swap the current active call with a held call.
+   * On iOS this is coordinated through CallKit so native and SDK state stay aligned.
+   *
+   * @param targetCallId ID of the held call to make active
+   */
+  async swapCalls(targetCallId) {
+    this._throwIfDisposed();
+    const activeCall = this.currentActiveCall;
+    const heldCall = this.getCall(targetCallId);
+    if (!activeCall || !heldCall || activeCall.callId === heldCall.callId) {
+      throw new Error('An active call and a different held call are required to swap calls');
+    }
+    if (activeCall.currentState !== call_state_1.TelnyxCallState.ACTIVE) {
+      throw new Error(`Cannot swap active call in state: ${activeCall.currentState}`);
+    }
+    if (heldCall.currentState !== call_state_1.TelnyxCallState.HELD) {
+      throw new Error(`Cannot swap target call in state: ${heldCall.currentState}`);
+    }
+    if (react_native_1.Platform.OS === 'ios') {
+      const { callKitCoordinator } = await Promise.resolve().then(() =>
+        __importStar(require('./callkit/callkit-coordinator'))
+      );
+      if (callKitCoordinator.isAvailable()) {
+        const success = await callKitCoordinator.swapCallsFromUI(
+          activeCall.telnyxCall,
+          heldCall.telnyxCall
+        );
+        if (!success) {
+          throw new Error('CallKit failed to swap calls');
+        }
+        return;
+      }
+    }
+    await activeCall.hold();
+    try {
+      await heldCall.resume();
+      this.setActiveCall(heldCall.callId);
+    } catch (error) {
+      await activeCall.resume().catch((resumeError) => {
+        console.error('Failed to restore active call after swap failure', resumeError);
+      });
+      throw error;
+    }
+  }
+  /**
    * Current session ID (UUID) for this connection.
    */
   get sessionId() {
@@ -203,10 +302,10 @@ class TelnyxVoipClient {
     if (this._options.debug) {
       console.log('TelnyxVoipClient: Logging in with credentials for user:', config.sipUser);
     }
-    const loginConfig = {
+    const loginConfig = await this._withNativeVoipPushToken({
       ...config,
       useTrickleIce: config.useTrickleIce ?? this._options.useTrickleIce,
-    };
+    });
     // Store credentials for future reconnection
     await this._storeCredentials(loginConfig);
     await this._sessionManager.connectWithCredential(loginConfig);
@@ -229,10 +328,10 @@ class TelnyxVoipClient {
     if (this._options.debug) {
       console.log('TelnyxVoipClient: Logging in with token');
     }
-    const loginConfig = {
+    const loginConfig = await this._withNativeVoipPushToken({
       ...config,
       useTrickleIce: config.useTrickleIce ?? this._options.useTrickleIce,
-    };
+    });
     // Store token for future reconnection
     await this._storeToken(loginConfig);
     await this._sessionManager.connectWithToken(loginConfig);
@@ -273,19 +372,30 @@ class TelnyxVoipClient {
       const storedCredentialToken = await AsyncStorage.getItem('@credential_token');
       const storedPushToken = await AsyncStorage.getItem('@push_token');
       const storedUseTrickleIce = await AsyncStorage.getItem(USE_TRICKLE_ICE_STORAGE_KEY);
+      const storedPushWhenActive = await AsyncStorage.getItem(PUSH_WHEN_ACTIVE_STORAGE_KEY);
       const storedMissedCallNotifications = await AsyncStorage.getItem(
         MISSED_CALL_NOTIFICATIONS_STORAGE_KEY
       );
       const useTrickleIce =
         storedUseTrickleIce === null ? this._options.useTrickleIce : storedUseTrickleIce === 'true';
+      const pushWhenActive = storedPushWhenActive === 'true';
       const enableMissedCallNotifications = storedMissedCallNotifications === 'true';
+      const nativePushToken =
+        react_native_1.Platform.OS === 'ios'
+          ? (await voice_pn_bridge_1.VoicePnBridge.getVoipToken())?.trim()
+          : null;
+      const pushNotificationDeviceToken = nativePushToken || storedPushToken;
+      if (nativePushToken && nativePushToken !== storedPushToken) {
+        await AsyncStorage.setItem('@push_token', nativePushToken);
+      }
       // Check if we have credential-based authentication data
       if (storedUsername && storedPassword) {
         // Create credential config from stored data
         const { createCredentialConfig } = require('./models/config');
         const config = createCredentialConfig(storedUsername, storedPassword, {
-          pushNotificationDeviceToken: storedPushToken,
+          pushNotificationDeviceToken,
           useTrickleIce,
+          pushWhenActive,
           enableMissedCallNotifications,
         });
         if (this._options.debug) {
@@ -302,8 +412,9 @@ class TelnyxVoipClient {
         // Create token config from stored data
         const { createTokenConfig } = require('./models/config');
         const config = createTokenConfig(storedCredentialToken, {
-          pushNotificationDeviceToken: storedPushToken,
+          pushNotificationDeviceToken,
           useTrickleIce,
+          pushWhenActive,
           enableMissedCallNotifications,
         });
         if (this._options.debug) {
@@ -418,14 +529,17 @@ class TelnyxVoipClient {
    * This should be called when the user answers from CallKit before the socket connection is established
    * @param customHeaders Optional custom headers to include with the answer
    */
-  queueAnswerFromCallKit(customHeaders = {}) {
+  queueAnswerFromCallKit(callKitUUIDOrHeaders, customHeaders = {}) {
     this._throwIfDisposed();
     if (this._options.debug) {
-      console.log('TelnyxVoipClient: Queuing answer action from CallKit', customHeaders);
+      console.log('TelnyxVoipClient: Queuing answer action from CallKit', {
+        callKitUUIDOrHeaders,
+        customHeaders,
+      });
     }
     const telnyxClient = this._sessionManager.telnyxClient;
     if (telnyxClient && typeof telnyxClient.queueAnswerFromCallKit === 'function') {
-      telnyxClient.queueAnswerFromCallKit(customHeaders);
+      telnyxClient.queueAnswerFromCallKit(callKitUUIDOrHeaders, customHeaders);
     } else {
       console.warn(
         'TelnyxVoipClient: TelnyxRTC client not available or method not found for queueAnswerFromCallKit'
@@ -436,18 +550,29 @@ class TelnyxVoipClient {
    * Queue an end action for when the call invite arrives (for CallKit integration)
    * This should be called when the user ends from CallKit before the socket connection is established
    */
-  queueEndFromCallKit() {
+  queueEndFromCallKit(callKitUUID) {
     this._throwIfDisposed();
     if (this._options.debug) {
       console.log('TelnyxVoipClient: Queuing end action from CallKit');
     }
     const telnyxClient = this._sessionManager.telnyxClient;
     if (telnyxClient && typeof telnyxClient.queueEndFromCallKit === 'function') {
-      telnyxClient.queueEndFromCallKit();
+      telnyxClient.queueEndFromCallKit(callKitUUID);
     } else {
       console.warn(
         'TelnyxVoipClient: TelnyxRTC client not available or method not found for queueEndFromCallKit'
       );
+    }
+  }
+  /**
+   * Associate the next push-delivered INVITE with its app-facing CallKit UUID.
+   * The underlying signaling call ID remains unchanged.
+   * @internal
+   */
+  setPushNotificationCallKitUUID(callKitUUID) {
+    const telnyxClient = this._sessionManager.telnyxClient;
+    if (telnyxClient && typeof telnyxClient.setPushNotificationCallKitUUID === 'function') {
+      telnyxClient.setPushNotificationCallKitUUID(callKitUUID);
     }
   }
   // ========== Lifecycle Methods ==========
@@ -477,6 +602,27 @@ class TelnyxVoipClient {
   }
   // ========== Private Methods ==========
   /**
+   * Prefer an explicitly supplied token, otherwise hydrate it from PushKit's
+   * native storage. PushKit registration starts in AppDelegate before React
+   * mounts, so this removes the race between the JS token event and login.
+   */
+  async _withNativeVoipPushToken(config) {
+    if (react_native_1.Platform.OS !== 'ios' || config.pushNotificationDeviceToken?.trim()) {
+      return config;
+    }
+    const nativePushToken = (await voice_pn_bridge_1.VoicePnBridge.getVoipToken())?.trim();
+    if (!nativePushToken) {
+      return config;
+    }
+    if (this._options.debug) {
+      console.log('TelnyxVoipClient: Using PushKit token from native storage');
+    }
+    return {
+      ...config,
+      pushNotificationDeviceToken: nativePushToken,
+    };
+  }
+  /**
    * Store credential configuration for automatic reconnection
    */
   async _storeCredentials(config) {
@@ -487,6 +633,10 @@ class TelnyxVoipClient {
       await AsyncStorage.setItem(
         USE_TRICKLE_ICE_STORAGE_KEY,
         String(config.useTrickleIce ?? false)
+      );
+      await AsyncStorage.setItem(
+        PUSH_WHEN_ACTIVE_STORAGE_KEY,
+        String(config.pushWhenActive ?? false)
       );
       await AsyncStorage.setItem(
         MISSED_CALL_NOTIFICATIONS_STORAGE_KEY,
@@ -517,6 +667,10 @@ class TelnyxVoipClient {
       await AsyncStorage.setItem(
         USE_TRICKLE_ICE_STORAGE_KEY,
         String(config.useTrickleIce ?? false)
+      );
+      await AsyncStorage.setItem(
+        PUSH_WHEN_ACTIVE_STORAGE_KEY,
+        String(config.pushWhenActive ?? false)
       );
       await AsyncStorage.setItem(
         MISSED_CALL_NOTIFICATIONS_STORAGE_KEY,

--- a/react-voice-commons-sdk/src/callkit/callkit-coordinator.ts
+++ b/react-voice-commons-sdk/src/callkit/callkit-coordinator.ts
@@ -2,9 +2,24 @@ import { Platform, AppState } from 'react-native';
 import CallKit, { CallEndReason } from './callkit';
 import { Call } from '@telnyx/react-native-voice-sdk';
 import { VoicePnBridge } from '../internal/voice-pn-bridge';
-import { TelnyxVoipClient } from '../telnyx-voip-client';
-import { TelnyxConnectionState } from '../models/connection-state';
-import { act } from 'react';
+import type { TelnyxVoipClient } from '../telnyx-voip-client';
+
+type PendingSwap = {
+  mode: 'swap' | 'restoring' | 'rollback';
+  originalActiveCallKitUUID: string;
+  originalHeldCallKitUUID: string;
+  activeCallKitUUID: string;
+  heldCallKitUUID: string;
+  completedCallKitUUIDs: Set<string>;
+  failed: boolean;
+  resolve: (success: boolean) => void;
+  timeout: ReturnType<typeof setTimeout>;
+};
+
+type PendingHeldRequest = {
+  resolve: (success: boolean) => void;
+  timeout: ReturnType<typeof setTimeout>;
+};
 
 /**
  * CallKit Coordinator - Manages the proper CallKit-first flow for iOS
@@ -19,7 +34,8 @@ class CallKitCoordinator {
   // Maps CallKit UUIDs to WebRTC calls
   private callMap = new Map<string, Call>();
 
-  // Tracks calls that are being processed to prevent duplicates
+  // Tracks action+UUID pairs so an end action is not dropped merely because
+  // an answer or held action for the same call is still completing.
   private processingCalls = new Set<string>();
 
   // Tracks calls that have already been ended in CallKit to prevent duplicate reports
@@ -29,9 +45,14 @@ class CallKitCoordinator {
   private connectedCalls = new Set<string>();
 
   private isCallFromPush = false;
+  private pendingPushCallUUIDs = new Set<string>();
+  private selectedCallKitUUID: string | null = null;
+  private restoreHeldCallPromise: Promise<void> | null = null;
+  private pendingSwap: PendingSwap | null = null;
+  private pendingHeldRequests = new Map<string, PendingHeldRequest>();
 
-  // Flag to auto-answer the next incoming call (set when answering push notifications via CallKit)
-  private shouldAutoAnswerNextCall = false;
+  // Push answers are keyed so answering B cannot auto-answer another invite.
+  private autoAnswerCallUUIDs = new Set<string>();
 
   // Reference to the VoIP client for triggering reconnection when needed
   private voipClient: TelnyxVoipClient | null = null;
@@ -60,6 +81,10 @@ class CallKitCoordinator {
       this.handleCallKitEnd(event.callUUID, event);
     });
 
+    CallKit.onHeldCall((event) => {
+      void this.handleCallKitHeld(event.callUUID, Boolean(event.isOnHold));
+    });
+
     // Handle CallKit start actions (for outgoing calls)
     CallKit.onStartCall((event) => {
       this.handleCallKitStart(event.callUUID);
@@ -84,8 +109,14 @@ class CallKitCoordinator {
       return null;
     }
 
-    // This is a new call - report it to CallKit using the WebRTC call ID as CallKit UUID
-    const callKitUUID = call.callId;
+    const existingCallKitUUID = this.getCallKitUUID(call);
+    if (existingCallKitUUID) {
+      this.linkExistingCallKitCall(call, existingCallKitUUID);
+      return existingCallKitUUID;
+    }
+
+    // Socket-only incoming calls use their signaling ID as the app-facing ID.
+    const callKitUUID = this.normalizeUUID(call.callId);
 
     console.log('CallKitCoordinator: Report Called called', {
       callKitUUID,
@@ -109,13 +140,17 @@ class CallKitCoordinator {
         });
         const success = await CallKit.reportIncomingCall(callKitUUID, callerNumber, callerName);
         if (success) {
+          (call as any)._callKitUUID = callKitUUID;
           return callKitUUID;
         }
+
+        await this.rejectUnregisteredIncomingCall(callKitUUID, call);
       }
 
       return null;
     } catch (error) {
       console.error('CallKitCoordinator: Failed to report incoming call', error);
+      await this.rejectUnregisteredIncomingCall(callKitUUID, call);
       return null;
     }
   }
@@ -132,7 +167,7 @@ class CallKitCoordinator {
       return null;
     }
 
-    const callKitUUID = call.callId;
+    const callKitUUID = this.normalizeUUID(call.callId);
 
     console.log('CallKitCoordinator: Starting outgoing call through CallKit', {
       callKitUUID,
@@ -168,35 +203,161 @@ class CallKitCoordinator {
   async answerCallFromUI(call: Call): Promise<boolean> {
     // Use comprehensive UUID lookup that checks both maps and call properties
     const callKitUUID = this.getCallKitUUID(call);
+    if (!callKitUUID) {
+      console.warn('CallKitCoordinator: Cannot answer call - no CallKit UUID found');
+      return false;
+    }
 
     console.log(
       'CallKitCoordinator: Answering call from UI using CallKit answer simulation',
       callKitUUID
     );
 
+    const isRegistered = await CallKit.isCallRegistered(callKitUUID);
+    if (!isRegistered) {
+      console.warn(
+        'CallKitCoordinator: Suppressing answer because CallKit rejected or removed the call',
+        { callKitUUID }
+      );
+      await this.rejectUnregisteredIncomingCall(callKitUUID, call);
+      return false;
+    }
+
     // Mark as processing to prevent duplicate actions
-    this.processingCalls.add(callKitUUID);
+    const processingKey = this.actionKey('answer', callKitUUID);
+    this.processingCalls.add(processingKey);
 
     try {
       // Simulate the CallKit answer action, which will trigger our answer handler
       const success = await CallKit.answerCall(callKitUUID);
 
       if (success) {
-        // If CallKit answer fails, fallback to direct WebRTC answer
-        if (this.isCallFromPush) {
-          call.answer();
-          this.isCallFromPush = false;
+        if (call.direction === 'inbound' && call.state !== 'active') {
+          await call.answer();
         }
+        this.selectCall(call);
+        this.pendingPushCallUUIDs.delete(callKitUUID);
+        this.isCallFromPush = this.pendingPushCallUUIDs.size > 0;
         console.log('CallKitCoordinator: CallKit answer success');
       }
 
       return success;
     } catch (error) {
       console.error('CallKitCoordinator: Error answering call from UI', error);
+      await CallKit.reportCallEnded(callKitUUID, CallEndReason.Failed);
+      this.cleanupCall(callKitUUID);
       return false;
     } finally {
-      this.processingCalls.delete(callKitUUID);
+      this.processingCalls.delete(processingKey);
     }
+  }
+
+  /**
+   * Change held state from app UI through CallKit, then wait for signaling and
+   * the corresponding CXSetHeldCallAction to complete.
+   */
+  async setHeldFromUI(call: Call, isOnHold: boolean): Promise<boolean> {
+    const callKitUUID = this.getCallKitUUID(call);
+    if (!callKitUUID) {
+      console.warn('CallKitCoordinator: Cannot change held state without a CallKit UUID');
+      return false;
+    }
+
+    const desiredState = isOnHold ? 'held' : 'active';
+    if (call.state === desiredState) {
+      if (!isOnHold) {
+        this.selectCall(call);
+      }
+      return true;
+    }
+
+    const requiredState = isOnHold ? 'active' : 'held';
+    if (call.state !== requiredState || this.pendingSwap) {
+      console.warn('CallKitCoordinator: Cannot change held state in current state', {
+        callKitUUID,
+        currentState: call.state,
+        desiredState,
+        hasPendingSwap: Boolean(this.pendingSwap),
+      });
+      return false;
+    }
+
+    const requestKey = this.actionKey(isOnHold ? 'hold' : 'unhold', callKitUUID);
+    if (this.pendingHeldRequests.has(requestKey) || this.processingCalls.has(requestKey)) {
+      return false;
+    }
+
+    let resolveRequest!: (success: boolean) => void;
+    const completion = new Promise<boolean>((resolve) => {
+      resolveRequest = resolve;
+    });
+    const timeout = setTimeout(() => {
+      console.error('CallKitCoordinator: Held-state request timed out', {
+        callKitUUID,
+        isOnHold,
+      });
+      this.finishPendingHeldRequest(requestKey, false);
+    }, 12_000);
+
+    this.pendingHeldRequests.set(requestKey, {
+      resolve: resolveRequest,
+      timeout,
+    });
+
+    const accepted = await CallKit.setCallHeld(callKitUUID, isOnHold);
+    if (!accepted) {
+      this.finishPendingHeldRequest(requestKey, false);
+    }
+
+    return completion;
+  }
+
+  /**
+   * Swap an active call with a held call through one CallKit transaction.
+   * The promise settles only after both corresponding WebRTC state changes
+   * have completed and their CallKit actions have been fulfilled.
+   */
+  async swapCallsFromUI(activeCall: Call, heldCall: Call): Promise<boolean> {
+    const activeCallKitUUID = this.getCallKitUUID(activeCall);
+    const heldCallKitUUID = this.getCallKitUUID(heldCall);
+
+    if (!activeCallKitUUID || !heldCallKitUUID || activeCallKitUUID === heldCallKitUUID) {
+      console.warn('CallKitCoordinator: Cannot swap calls without two distinct CallKit UUIDs');
+      return false;
+    }
+
+    if (activeCall.state !== 'active' || heldCall.state !== 'held') {
+      console.warn('CallKitCoordinator: Cannot swap calls in their current states', {
+        activeCallState: activeCall.state,
+        heldCallState: heldCall.state,
+      });
+      return false;
+    }
+
+    if (this.pendingSwap) {
+      console.warn('CallKitCoordinator: A call swap is already in progress');
+      return false;
+    }
+
+    let resolveSwap!: (success: boolean) => void;
+    const swapCompletion = new Promise<boolean>((resolve) => {
+      resolveSwap = resolve;
+    });
+    this.pendingSwap = this.createPendingSwap({
+      mode: 'swap',
+      originalActiveCallKitUUID: activeCallKitUUID,
+      originalHeldCallKitUUID: heldCallKitUUID,
+      activeCallKitUUID,
+      heldCallKitUUID,
+      resolve: resolveSwap,
+    });
+
+    const accepted = await CallKit.swapCalls(activeCallKitUUID, heldCallKitUUID);
+    if (!accepted) {
+      await this.beginSwapRollback(this.pendingSwap);
+    }
+
+    return swapCompletion;
   }
 
   /**
@@ -212,34 +373,35 @@ class CallKitCoordinator {
       return false;
     }
 
-    console.log(
-      'CallKitCoordinator: Ending call from UI - dismissing CallKit and hanging up WebRTC call',
-      callKitUUID
-    );
-
-    // Track this call as ended to prevent duplicate end actions
-    this.endedCalls.add(callKitUUID);
+    console.log('CallKitCoordinator: Requesting CallKit end action from app UI', callKitUUID);
 
     try {
-      // End the call in CallKit - endCall returns false on failure (doesn't throw)
+      // Let the resulting CXEndCallAction drive signaling, cleanup and survivor
+      // restoration. Marking the call ended here would suppress that event.
       const endCallSuccess = await CallKit.endCall(callKitUUID);
 
-      if (!endCallSuccess) {
-        // Fallback: use reportCallEnded to dismiss CallKit UI when endCall fails
-        // (e.g., unknownCallUUID error from duplicate CXProvider)
-        await CallKit.reportCallEnded(callKitUUID, CallEndReason.RemoteEnded);
+      if (endCallSuccess) {
+        return true;
       }
 
-      this.isCallFromPush = false;
+      const shouldRestoreRemainingCall = this.isSelectedCall(call);
+      this.endedCalls.add(callKitUUID);
+      await CallKit.reportCallEnded(callKitUUID, CallEndReason.RemoteEnded);
+      this.pendingPushCallUUIDs.delete(callKitUUID);
+      this.isCallFromPush = this.pendingPushCallUUIDs.size > 0;
       call.hangup();
       this.cleanupCall(callKitUUID);
-
-      return true;
+      if (shouldRestoreRemainingCall) {
+        await this.restoreRemainingHeldCall();
+      }
+      return false;
     } catch (error) {
       console.error('CallKitCoordinator: Error ending call from UI', error);
-      this.isCallFromPush = false;
+      this.pendingPushCallUUIDs.delete(callKitUUID);
+      this.isCallFromPush = this.pendingPushCallUUIDs.size > 0;
       call.hangup();
       this.cleanupCall(callKitUUID);
+      await this.restoreRemainingHeldCall();
       return false;
     }
   }
@@ -248,7 +410,9 @@ class CallKitCoordinator {
    * Handle CallKit answer action (triggered by CallKit)
    */
   public async handleCallKitAnswer(callKitUUID: string, event?: any) {
-    if (this.processingCalls.has(callKitUUID)) {
+    callKitUUID = this.normalizeUUID(callKitUUID);
+    const processingKey = this.actionKey('answer', callKitUUID);
+    if (this.processingCalls.has(processingKey)) {
       console.log('CallKitCoordinator: Answer action already being processed, skipping duplicate');
       return;
     }
@@ -276,10 +440,11 @@ class CallKitCoordinator {
 
     if (call.state === 'active') {
       console.log('CallKitCoordinator: Call already active, skipping duplicate answer action');
+      this.selectCall(call);
       return;
     }
 
-    this.processingCalls.add(callKitUUID);
+    this.processingCalls.add(processingKey);
 
     try {
       if (call.direction === 'inbound') {
@@ -291,23 +456,8 @@ class CallKitCoordinator {
           voipClient.setCallConnecting(call.callId);
         }
 
-        // Report call as connected to CallKit to trigger audio session activation
-        setTimeout(async () => {
-          try {
-            await CallKit.reportCallConnected(callKitUUID);
-            console.log('CallKitCoordinator: Reported call connected to activate audio session');
-            this.connectedCalls.add(callKitUUID);
-          } catch (error) {
-            console.error(
-              'CallKitCoordinator: Error reporting call connected for audio session:',
-              error
-            );
-          }
-        }, 200);
-
-        setTimeout(() => {
-          call.answer();
-        }, 500);
+        await call.answer();
+        this.selectCall(call);
       } else {
         console.log('CallKitCoordinator: Outgoing call, skipping answer and CONNECTING state');
       }
@@ -327,7 +477,47 @@ class CallKitCoordinator {
         await VoicePnBridge.clearPendingVoipPush();
       } catch (_) {}
     } finally {
-      this.processingCalls.delete(callKitUUID);
+      this.processingCalls.delete(processingKey);
+    }
+  }
+
+  /** Handle a UUID-targeted CallKit hold or resume action. */
+  public async handleCallKitHeld(callKitUUID: string, isOnHold: boolean): Promise<void> {
+    callKitUUID = this.normalizeUUID(callKitUUID);
+    const processingKey = this.actionKey(isOnHold ? 'hold' : 'unhold', callKitUUID);
+
+    if (this.processingCalls.has(processingKey)) {
+      return;
+    }
+
+    const call = this.callMap.get(callKitUUID);
+    if (!call) {
+      console.warn('CallKitCoordinator: No WebRTC call found for held action', { callKitUUID });
+      await CallKit.completeHeldCallAction(callKitUUID, false);
+      this.finishPendingHeldRequest(processingKey, false);
+      return;
+    }
+
+    this.processingCalls.add(processingKey);
+    try {
+      if (isOnHold && call.state !== 'held') {
+        await call.hold();
+      } else if (!isOnHold && call.state !== 'active') {
+        await call.unhold();
+      }
+      if (!isOnHold) {
+        this.selectCall(call);
+      }
+      const completed = await CallKit.completeHeldCallAction(callKitUUID, true);
+      this.recordPendingSwapAction(callKitUUID, isOnHold, completed);
+      this.finishPendingHeldRequest(processingKey, completed);
+    } catch (error) {
+      console.error('CallKitCoordinator: Held action failed', { callKitUUID, isOnHold, error });
+      await CallKit.completeHeldCallAction(callKitUUID, false);
+      this.recordPendingSwapAction(callKitUUID, isOnHold, false);
+      this.finishPendingHeldRequest(processingKey, false);
+    } finally {
+      this.processingCalls.delete(processingKey);
     }
   }
 
@@ -335,9 +525,12 @@ class CallKitCoordinator {
    * Handle CallKit end action (triggered by CallKit)
    */
   private async handleCallKitEnd(callKitUUID: string, event?: any) {
-    this.isCallFromPush = false;
+    callKitUUID = this.normalizeUUID(callKitUUID);
+    const wasPendingPush = this.pendingPushCallUUIDs.delete(callKitUUID);
+    this.isCallFromPush = this.pendingPushCallUUIDs.size > 0;
 
-    if (this.processingCalls.has(callKitUUID)) {
+    const processingKey = this.actionKey('end', callKitUUID);
+    if (this.processingCalls.has(processingKey)) {
       console.log('CallKitCoordinator: End action already being processed, skipping duplicate');
       return;
     }
@@ -372,21 +565,25 @@ class CallKitCoordinator {
       webrtcCallId: call.callId,
     });
 
-    this.processingCalls.add(callKitUUID);
+    const shouldRestoreRemainingCall = this.isSelectedCall(call);
+    this.processingCalls.add(processingKey);
 
     try {
       call.hangup();
     } catch (error) {
       console.error('CallKitCoordinator: Error hanging up WebRTC call', error);
     } finally {
-      this.processingCalls.delete(callKitUUID);
+      this.processingCalls.delete(processingKey);
       this.cleanupCall(callKitUUID);
+      if (shouldRestoreRemainingCall) {
+        await this.restoreRemainingHeldCall();
+      }
 
-      // Clear push data now that end action is fulfilled
-      try {
-        await VoicePnBridge.clearPendingVoipPush();
-        console.log('CallKitCoordinator: Cleared pending VoIP push after end fulfilled');
-      } catch (_) {}
+      if (wasPendingPush) {
+        await VoicePnBridge.clearPendingVoipPush().catch((error) => {
+          console.warn('CallKitCoordinator: Failed to clear ended call push data', error);
+        });
+      }
 
       // Check if app is in background and no more calls - disconnect client
       await this.checkBackgroundDisconnection();
@@ -420,9 +617,20 @@ class CallKitCoordinator {
    * This allows us to coordinate between the push notification and any subsequent WebRTC calls
    */
   async handleCallKitPushReceived(callKitUUID: string, event?: any): Promise<void> {
-    if (this.isCallFromPush) {
-      this.isCallFromPush = false;
-      console.log('CallKitCoordinator: Ignoring push received event (already processed)');
+    callKitUUID = this.normalizeUUID(callKitUUID);
+    if (this.pendingPushCallUUIDs.has(callKitUUID)) {
+      console.log('CallKitCoordinator: Ignoring duplicate push UUID', callKitUUID);
+      return;
+    }
+
+    const isRegistered = await CallKit.isCallRegistered(callKitUUID);
+    if (!isRegistered) {
+      console.warn(
+        'CallKitCoordinator: Ignoring push because its CallKit registration was rejected',
+        { callKitUUID }
+      );
+      this.getSDKClient()?.queueEndFromCallKit(callKitUUID);
+      await this.clearMatchingPendingVoipPush(callKitUUID);
       return;
     }
 
@@ -432,6 +640,7 @@ class CallKitCoordinator {
     });
 
     this.isCallFromPush = true;
+    this.pendingPushCallUUIDs.add(callKitUUID);
 
     console.log('CallKitCoordinator: Processing push received event', {
       callKitUUID,
@@ -443,23 +652,20 @@ class CallKitCoordinator {
       // Get VoIP client instance
       const voipClient = this.getSDKClient();
       if (!voipClient) {
-        console.error('CallKitCoordinator: VoIP client not available');
-        return;
+        throw new Error('CallKitCoordinator: VoIP client not available');
       }
 
       // Retrieve pending push data from VoIP bridge
       const pendingPushJson = await VoicePnBridge.getPendingVoipPush();
       if (!pendingPushJson) {
-        console.warn('CallKitCoordinator: No pending push data found');
-        return;
+        throw new Error('CallKitCoordinator: No pending push data found');
       }
 
       const pendingPush = JSON.parse(pendingPushJson);
       const realPushData = pendingPush?.payload;
 
       if (!realPushData?.metadata) {
-        console.warn('CallKitCoordinator: Invalid push data structure');
-        return;
+        throw new Error('CallKitCoordinator: Invalid push data structure');
       }
 
       // Prepare push metadata with CallKit flag
@@ -468,17 +674,21 @@ class CallKitCoordinator {
         from_callkit: true,
       };
 
-      // Check if auto-answer is set and add from_notification flag
-      const shouldAddFromNotification = this.shouldAutoAnswerNextCall;
+      // This app-facing UUID is attached to the next inbound Call while the
+      // socket INVITE retains its own signaling callID.
+      voipClient.setPushNotificationCallKitUUID(callKitUUID);
+
+      // A pre-INVITE CallKit answer is represented only by the UUID-keyed
+      // pending action. Do not also add legacy notification flags.
+      const shouldAddFromNotification = this.autoAnswerCallUUIDs.has(callKitUUID);
 
       let pushData;
       if (shouldAddFromNotification) {
         pushData = {
           metadata: enhancedMetadata,
-          from_notification: true,
-          action: 'answer',
         };
-        voipClient.queueAnswerFromCallKit();
+        voipClient.queueAnswerFromCallKit(callKitUUID);
+        this.autoAnswerCallUUIDs.delete(callKitUUID);
       } else {
         pushData = {
           metadata: enhancedMetadata,
@@ -489,6 +699,8 @@ class CallKitCoordinator {
       await voipClient.handlePushNotification(pushData);
       console.log('CallKitCoordinator: Push notification processed successfully');
     } catch (error) {
+      this.pendingPushCallUUIDs.delete(callKitUUID);
+      this.isCallFromPush = this.pendingPushCallUUIDs.size > 0;
       console.error('CallKitCoordinator: Error processing push received event:', error);
     }
   }
@@ -507,75 +719,31 @@ class CallKitCoordinator {
       if (Platform.OS === 'ios') {
         console.log('CallKitCoordinator: Processing iOS push notification answer');
 
-        // Set auto-answer flag so when the WebRTC call comes in, it will be answered automatically
-        this.shouldAutoAnswerNextCall = true;
-        console.log('CallKitCoordinator: ✅ Set auto-answer flag for next incoming call');
+        this.autoAnswerCallUUIDs.add(callKitUUID);
+        console.log('CallKitCoordinator: Set UUID-targeted auto-answer', callKitUUID);
 
         // Try to get VoIP client - it may not be wired yet if user answered
         // from CallKit before React Native finished initializing
         const voipClient = this.getSDKClient();
         if (!voipClient) {
           // voipClient not ready yet - DON'T fail the call.
-          // shouldAutoAnswerNextCall is already set to true above.
+          // The UUID-targeted auto-answer is already stored above.
           // checkForInitialPushNotification() will run after setVoipClient()
           // and will find the push data still intact, call handleCallKitPushReceived()
-          // which checks shouldAutoAnswerNextCall and queues the auto-answer.
+          // which queues the matching auto-answer.
           return;
         }
 
-        // voipClient is available - queue the answer action on the TelnyxRTC client
-        // so when the INVITE arrives after WebSocket login, processInvite() sees
-        // pendingAnswerAction=true and auto-answers the call.
-        voipClient.queueAnswerFromCallKit();
-
-        // Get the real push data that was stored by the VoIP push handler
-        let realPushData = null;
-        try {
-          const pendingPushJson = await VoicePnBridge.getPendingVoipPush();
-          if (pendingPushJson) {
-            const pendingPush = JSON.parse(pendingPushJson);
-            if (pendingPush && pendingPush.payload) {
-              console.log('CallKitCoordinator: ✅ Found real push data');
-              realPushData = pendingPush.payload;
-            }
-          }
-        } catch (error) {
-          console.warn('CallKitCoordinator: Could not get real push data:', error);
+        // Queue one UUID-targeted answer. If the push is already being
+        // processed, its eventual INVITE will consume this action. Otherwise
+        // process the still-persisted VoIP payload now.
+        voipClient.queueAnswerFromCallKit(callKitUUID);
+        if (this.pendingPushCallUUIDs.has(callKitUUID)) {
+          this.autoAnswerCallUUIDs.delete(callKitUUID);
+          return;
         }
 
-        // Create push notification payload - use real data if available, fallback to placeholder
-        const pushAction = 'incoming_call';
-        let pushMetadata: string;
-
-        if (realPushData && realPushData.metadata) {
-          // Use the real push metadata
-          console.log('CallKitCoordinator: 🎯 Using REAL push metadata for immediate handling');
-          pushMetadata = JSON.stringify({
-            ...realPushData.metadata,
-            from_callkit: true, // Add flag to indicate this was answered via CallKit
-          });
-        } else {
-          // Fallback to placeholder (this should rarely happen)
-          console.warn('CallKitCoordinator: ⚠️ No real push data found, using placeholder');
-          pushMetadata = JSON.stringify({
-            call_id: callKitUUID,
-            caller_name: 'Incoming Call',
-            caller_number: 'Unknown',
-            voice_sdk_id: 'unknown',
-            sent_time: new Date().toISOString(),
-            from_callkit: true,
-          });
-        }
-
-        // Set the pending push action to be handled when app comes to foreground
-        await VoicePnBridge.setPendingPushAction(pushAction, pushMetadata);
-        console.log('CallKitCoordinator: ✅ Set pending push action');
-
-        // Clear push data now that push notification answer is handled
-        try {
-          await VoicePnBridge.clearPendingVoipPush();
-          console.log('CallKitCoordinator: Cleared pending VoIP push after push answer handled');
-        } catch (_) {}
+        await this.handleCallKitPushReceived(callKitUUID, event);
 
         return;
       }
@@ -605,7 +773,7 @@ class CallKitCoordinator {
       if (Platform.OS === 'ios') {
         console.log('CallKitCoordinator: Processing iOS push notification rejection');
 
-        this.voipClient.queueEndFromCallKit();
+        this.getSDKClient()?.queueEndFromCallKit(callKitUUID);
 
         // Clean up push notification state
         await this.cleanupPushNotificationState();
@@ -642,6 +810,10 @@ class CallKitCoordinator {
 
       switch (state) {
         case 'active':
+          this.selectCall(call);
+          this.pendingPushCallUUIDs.delete(callKitUUID);
+          this.autoAnswerCallUUIDs.delete(callKitUUID);
+          this.isCallFromPush = this.pendingPushCallUUIDs.size > 0;
           // When WebRTC call becomes active, just report as connected
           // (CallKit call was already answered in answerCallFromUI)
           if (!this.connectedCalls.has(callKitUUID)) {
@@ -657,7 +829,10 @@ class CallKitCoordinator {
           break;
 
         case 'ended':
-        case 'failed':
+        case 'failed': {
+          const shouldRestoreRemainingCall =
+            this.selectedCallKitUUID === callKitUUID &&
+            !this.processingCalls.has(this.actionKey('end', callKitUUID));
           // Report call ended to CallKit (if not already ended)
           if (!this.endedCalls.has(callKitUUID)) {
             console.log('CallKitCoordinator: Reporting call ended to CallKit');
@@ -668,7 +843,11 @@ class CallKitCoordinator {
 
           // Clean up the call mapping
           this.cleanupCall(callKitUUID);
+          if (shouldRestoreRemainingCall) {
+            await this.restoreRemainingHeldCall();
+          }
           break;
+        }
 
         case 'ringing':
           // For outgoing calls, we might want to update CallKit with additional info
@@ -689,8 +868,26 @@ class CallKitCoordinator {
    * Clean up call mappings and listeners
    */
   private cleanupCall(callKitUUID: string) {
-    this.processingCalls.delete(callKitUUID);
+    callKitUUID = this.normalizeUUID(callKitUUID);
+    if (
+      this.pendingSwap?.activeCallKitUUID === callKitUUID ||
+      this.pendingSwap?.heldCallKitUUID === callKitUUID
+    ) {
+      this.finishPendingSwap(false);
+    }
+    for (const processingKey of this.processingCalls) {
+      if (processingKey.endsWith(`:${callKitUUID}`)) {
+        this.processingCalls.delete(processingKey);
+      }
+    }
+    for (const requestKey of this.pendingHeldRequests.keys()) {
+      if (requestKey.endsWith(`:${callKitUUID}`)) {
+        this.finishPendingHeldRequest(requestKey, false);
+      }
+    }
     this.connectedCalls.delete(callKitUUID);
+    this.pendingPushCallUUIDs.delete(callKitUUID);
+    this.autoAnswerCallUUIDs.delete(callKitUUID);
 
     // Get the call before removing it
     const call = this.callMap.get(callKitUUID);
@@ -704,9 +901,8 @@ class CallKitCoordinator {
     // Remove from mapping
     this.callMap.delete(callKitUUID);
 
-    if (call) {
-      // Clean up the stored UUID on the call
-      delete (call as any)._callKitUUID;
+    if (this.selectedCallKitUUID === callKitUUID) {
+      this.selectedCallKitUUID = null;
     }
 
     // Reset flags if no more active calls
@@ -714,13 +910,7 @@ class CallKitCoordinator {
       this.resetFlags();
     }
 
-    // Clear VoIP push data now that the call is done
-    if (Platform.OS === 'ios') {
-      VoicePnBridge.clearPendingVoipPush().catch((error) => {
-        console.warn('CallKitCoordinator: Error clearing VoIP push data on call cleanup:', error);
-      });
-      console.log('CallKitCoordinator: ✅ Cleared VoIP push data after call ended');
-    }
+    this.isCallFromPush = this.pendingPushCallUUIDs.size > 0;
   }
 
   /**
@@ -730,15 +920,17 @@ class CallKitCoordinator {
     // First check if the call has the UUID stored on it
     const storedUUID = (call as any)._callKitUUID;
     if (storedUUID) {
-      return storedUUID;
+      return this.normalizeUUID(storedUUID);
     }
 
     // Search through all call mappings
     for (const [uuid, mappedCall] of this.callMap.entries()) {
       if (mappedCall.callId === call.callId) {
         // Store UUID on the call for faster future lookups
-        (call as any)._callKitUUID = uuid;
-        return uuid;
+        if (!(call as any)._callKitUUID) {
+          (call as any)._callKitUUID = uuid;
+        }
+        return this.normalizeUUID(uuid);
       }
     }
 
@@ -749,7 +941,7 @@ class CallKitCoordinator {
    * Get WebRTC call for a CallKit UUID
    */
   getWebRTCCall(callKitUUID: string): Call | null {
-    return this.callMap.get(callKitUUID) || null;
+    return this.callMap.get(this.normalizeUUID(callKitUUID)) || null;
   }
 
   /**
@@ -757,6 +949,7 @@ class CallKitCoordinator {
    * This should be called when a WebRTC call arrives that corresponds to an existing CallKit call
    */
   linkExistingCallKitCall(call: Call, callKitUUID: string): void {
+    callKitUUID = this.normalizeUUID(callKitUUID);
     console.log('CallKitCoordinator: Linking existing CallKit call with WebRTC call', {
       callKitUUID,
       webrtcCallId: call.callId,
@@ -765,11 +958,15 @@ class CallKitCoordinator {
     // Store the mappings
     this.callMap.set(callKitUUID, call);
 
-    // Store UUID on the call for quick access
-    (call as any)._callKitUUID = callKitUUID;
+    // Push-created calls already carry a durable, non-configurable UUID.
+    if (!(call as any)._callKitUUID) {
+      (call as any)._callKitUUID = callKitUUID;
+    }
 
     // Set up state listeners
-    this.setupWebRTCCallListeners(call, callKitUUID);
+    if (!(call as any)._callKitStateListener) {
+      this.setupWebRTCCallListeners(call, callKitUUID);
+    }
   }
 
   /**
@@ -786,8 +983,51 @@ class CallKitCoordinator {
    * Helper method to clean up push notification state
    */
   private async cleanupPushNotificationState(): Promise<void> {
-    console.log('CallKitCoordinator: ✅ Cleared auto-answer flag');
-    this.shouldAutoAnswerNextCall = false;
+    console.log('CallKitCoordinator: Push notification state cleaned up');
+  }
+
+  private async rejectUnregisteredIncomingCall(callKitUUID: string, call: Call): Promise<void> {
+    callKitUUID = this.normalizeUUID(callKitUUID);
+
+    console.warn('CallKitCoordinator: Cleaning up unregistered incoming call', {
+      callKitUUID,
+      webrtcCallId: call.callId,
+    });
+
+    this.cleanupCall(callKitUUID);
+
+    try {
+      await call.hangup();
+    } catch (error) {
+      console.warn('CallKitCoordinator: Failed to end unregistered signaling call', error);
+    }
+
+    await this.clearMatchingPendingVoipPush(callKitUUID);
+  }
+
+  private async clearMatchingPendingVoipPush(callKitUUID: string): Promise<void> {
+    try {
+      const pendingPushJson = await VoicePnBridge.getPendingVoipPush();
+      if (!pendingPushJson) {
+        return;
+      }
+
+      const pendingPush = JSON.parse(pendingPushJson);
+      const pendingCallId =
+        pendingPush?.payload?.metadata?.call_id ??
+        pendingPush?.payload?.call_id ??
+        pendingPush?.metadata?.call_id ??
+        pendingPush?.call_id;
+
+      if (
+        typeof pendingCallId === 'string' &&
+        this.normalizeUUID(pendingCallId) === this.normalizeUUID(callKitUUID)
+      ) {
+        await VoicePnBridge.clearPendingVoipPush();
+      }
+    } catch (error) {
+      console.warn('CallKitCoordinator: Failed to clear rejected call push state', error);
+    }
   }
 
   /**
@@ -795,6 +1035,213 @@ class CallKitCoordinator {
    */
   private getSDKClient(): TelnyxVoipClient | null {
     return this.voipClient;
+  }
+
+  private normalizeUUID(callKitUUID: string): string {
+    return callKitUUID.toLowerCase();
+  }
+
+  private actionKey(action: string, callKitUUID: string): string {
+    return `${action}:${this.normalizeUUID(callKitUUID)}`;
+  }
+
+  private selectCall(call: Call): void {
+    const callKitUUID = this.getCallKitUUID(call);
+    const wrapperCall = this.voipClient?.findCallByTelnyxCall(call);
+    if (!callKitUUID || !wrapperCall || !this.voipClient) {
+      return;
+    }
+
+    this.selectedCallKitUUID = callKitUUID;
+    this.voipClient.setActiveCall(wrapperCall.callId);
+  }
+
+  private isSelectedCall(call: Call): boolean {
+    const callKitUUID = this.getCallKitUUID(call);
+    return callKitUUID !== null && callKitUUID === this.selectedCallKitUUID;
+  }
+
+  private recordPendingSwapAction(callKitUUID: string, isOnHold: boolean, success: boolean): void {
+    const pendingSwap = this.pendingSwap;
+    if (!pendingSwap || pendingSwap.mode === 'restoring') {
+      return;
+    }
+
+    const isExpectedAction =
+      (callKitUUID === pendingSwap.activeCallKitUUID && isOnHold) ||
+      (callKitUUID === pendingSwap.heldCallKitUUID && !isOnHold);
+    if (!isExpectedAction) {
+      return;
+    }
+
+    pendingSwap.failed ||= !success;
+    pendingSwap.completedCallKitUUIDs.add(callKitUUID);
+    if (pendingSwap.completedCallKitUUIDs.size === 2) {
+      if (pendingSwap.mode === 'swap' && pendingSwap.failed) {
+        void this.beginSwapRollback(pendingSwap);
+      } else {
+        this.finishPendingSwap(pendingSwap.mode === 'swap');
+      }
+    }
+  }
+
+  private createPendingSwap({
+    mode,
+    originalActiveCallKitUUID,
+    originalHeldCallKitUUID,
+    activeCallKitUUID,
+    heldCallKitUUID,
+    resolve,
+  }: Omit<PendingSwap, 'completedCallKitUUIDs' | 'failed' | 'timeout'>): PendingSwap {
+    const pendingSwap = {
+      mode,
+      originalActiveCallKitUUID,
+      originalHeldCallKitUUID,
+      activeCallKitUUID,
+      heldCallKitUUID,
+      completedCallKitUUIDs: new Set<string>(),
+      failed: false,
+      resolve,
+      timeout: undefined as unknown as ReturnType<typeof setTimeout>,
+    };
+
+    pendingSwap.timeout = setTimeout(() => {
+      if (this.pendingSwap !== pendingSwap) {
+        return;
+      }
+
+      console.error(`CallKitCoordinator: Call ${mode} timed out`);
+      if (mode === 'swap') {
+        void this.beginSwapRollback(pendingSwap);
+      } else {
+        this.finishPendingSwap(false);
+      }
+    }, 12_000);
+
+    return pendingSwap;
+  }
+
+  private async beginSwapRollback(pendingSwap: PendingSwap | null): Promise<void> {
+    if (!pendingSwap || this.pendingSwap !== pendingSwap || pendingSwap.mode !== 'swap') {
+      return;
+    }
+
+    clearTimeout(pendingSwap.timeout);
+    // Keep the operation installed while restoring WebRTC state so another
+    // hold or swap cannot enter and have its pending promise overwritten.
+    pendingSwap.mode = 'restoring';
+
+    await this.restoreOriginalWebRTCStates(
+      pendingSwap.originalActiveCallKitUUID,
+      pendingSwap.originalHeldCallKitUUID
+    );
+
+    // A call may have ended while restoration was in flight, in which case
+    // cleanup already resolved and removed this operation.
+    if (this.pendingSwap !== pendingSwap) {
+      return;
+    }
+
+    const rollback = this.createPendingSwap({
+      mode: 'rollback',
+      originalActiveCallKitUUID: pendingSwap.originalActiveCallKitUUID,
+      originalHeldCallKitUUID: pendingSwap.originalHeldCallKitUUID,
+      // A reverse swap requests the original held call to remain held and the
+      // original active call to become active again.
+      activeCallKitUUID: pendingSwap.originalHeldCallKitUUID,
+      heldCallKitUUID: pendingSwap.originalActiveCallKitUUID,
+      resolve: pendingSwap.resolve,
+    });
+    this.pendingSwap = rollback;
+
+    const accepted = await CallKit.swapCalls(rollback.activeCallKitUUID, rollback.heldCallKitUUID);
+    if (!accepted && this.pendingSwap === rollback) {
+      console.error('CallKitCoordinator: Compensating swap transaction was rejected');
+      this.finishPendingSwap(false);
+    }
+  }
+
+  private async restoreOriginalWebRTCStates(
+    activeCallKitUUID: string,
+    heldCallKitUUID: string
+  ): Promise<void> {
+    const originalActive = this.callMap.get(activeCallKitUUID);
+    const originalHeld = this.callMap.get(heldCallKitUUID);
+
+    try {
+      if (originalHeld?.state === 'active') {
+        await originalHeld.hold();
+      }
+      if (originalActive?.state === 'held') {
+        await originalActive.unhold();
+      }
+      if (originalActive?.state === 'active') {
+        this.selectCall(originalActive);
+      }
+    } catch (error) {
+      console.error('CallKitCoordinator: Failed to restore WebRTC state before swap rollback', {
+        activeCallKitUUID,
+        heldCallKitUUID,
+        error,
+      });
+    }
+  }
+
+  private finishPendingSwap(success: boolean): void {
+    const pendingSwap = this.pendingSwap;
+    if (!pendingSwap) {
+      return;
+    }
+
+    this.pendingSwap = null;
+    clearTimeout(pendingSwap.timeout);
+    pendingSwap.resolve(success);
+  }
+
+  private finishPendingHeldRequest(requestKey: string, success: boolean): void {
+    const request = this.pendingHeldRequests.get(requestKey);
+    if (!request) {
+      return;
+    }
+
+    this.pendingHeldRequests.delete(requestKey);
+    clearTimeout(request.timeout);
+    request.resolve(success);
+  }
+
+  private async restoreRemainingHeldCall(): Promise<void> {
+    if (this.restoreHeldCallPromise) {
+      return this.restoreHeldCallPromise;
+    }
+
+    this.restoreHeldCallPromise = (async () => {
+      const heldEntry = Array.from(this.callMap.entries()).find(
+        ([, call]) => call.state === 'held'
+      );
+      if (!heldEntry) {
+        return;
+      }
+
+      const [callKitUUID, heldCall] = heldEntry;
+      try {
+        const restored = await this.setHeldFromUI(heldCall, false);
+        if (!restored) {
+          throw new Error('CallKit rejected survivor resume');
+        }
+        console.log('CallKitCoordinator: Restored remaining held call', callKitUUID);
+      } catch (error) {
+        console.error('CallKitCoordinator: Failed to restore remaining held call', {
+          callKitUUID,
+          error,
+        });
+      }
+    })();
+
+    try {
+      await this.restoreHeldCallPromise;
+    } finally {
+      this.restoreHeldCallPromise = null;
+    }
   }
 
   /**
@@ -834,11 +1281,7 @@ class CallKitCoordinator {
   resetFlags(): void {
     console.log('CallKitCoordinator: Resetting coordinator flags');
 
-    // Reset push notification flag
-    this.isCallFromPush = false;
-
-    // Reset auto-answer flag
-    this.shouldAutoAnswerNextCall = false;
+    this.isCallFromPush = this.pendingPushCallUUIDs.size > 0;
 
     console.log('CallKitCoordinator: ✅ Coordinator flags reset');
   }

--- a/react-voice-commons-sdk/src/callkit/callkit-coordinator.ts
+++ b/react-voice-commons-sdk/src/callkit/callkit-coordinator.ts
@@ -238,6 +238,7 @@ class CallKitCoordinator {
         this.selectCall(call);
         this.pendingPushCallUUIDs.delete(callKitUUID);
         this.isCallFromPush = this.pendingPushCallUUIDs.size > 0;
+        await this.clearMatchingPendingVoipPush(callKitUUID);
         console.log('CallKitCoordinator: CallKit answer success');
       }
 
@@ -1026,7 +1027,7 @@ class CallKitCoordinator {
         await VoicePnBridge.clearPendingVoipPush();
       }
     } catch (error) {
-      console.warn('CallKitCoordinator: Failed to clear rejected call push state', error);
+      console.warn('CallKitCoordinator: Failed to clear matching pending VoIP push', error);
     }
   }
 

--- a/react-voice-commons-sdk/src/callkit/callkit-coordinator.ts
+++ b/react-voice-commons-sdk/src/callkit/callkit-coordinator.ts
@@ -440,8 +440,26 @@ class CallKitCoordinator {
     });
 
     if (call.state === 'active') {
-      console.log('CallKitCoordinator: Call already active, skipping duplicate answer action');
+      console.log(
+        'CallKitCoordinator: Call already active, completing pending CallKit answer action'
+      );
       this.selectCall(call);
+      // The native CXAnswerCallAction is fulfilled only after JS reports the
+      // call as connected. If the WebRTC call already reached active before
+      // the CallKit answer event arrived, we must still report connected so
+      // iOS does not time out the pending answer action.
+      if (!this.connectedCalls.has(callKitUUID)) {
+        try {
+          await CallKit.reportCallConnected(callKitUUID);
+          this.connectedCalls.add(callKitUUID);
+          console.log('CallKitCoordinator: Reported call connected for already-active call');
+        } catch (error) {
+          console.error(
+            'CallKitCoordinator: Error reporting connected for already-active call:',
+            error
+          );
+        }
+      }
       return;
     }
 
@@ -616,12 +634,17 @@ class CallKitCoordinator {
   /**
    * Handle CallKit push received event
    * This allows us to coordinate between the push notification and any subsequent WebRTC calls
+   *
+   * Returns `true` when the push was accepted and call processing was started,
+   * or `false` when the push was filtered, rejected, or otherwise ignored so
+   * that callers can clean up any foreground-push lifecycle flags they set
+   * before calling this method.
    */
-  async handleCallKitPushReceived(callKitUUID: string, event?: any): Promise<void> {
+  async handleCallKitPushReceived(callKitUUID: string, event?: any): Promise<boolean> {
     callKitUUID = this.normalizeUUID(callKitUUID);
     if (this.pendingPushCallUUIDs.has(callKitUUID)) {
       console.log('CallKitCoordinator: Ignoring duplicate push UUID', callKitUUID);
-      return;
+      return false;
     }
 
     const isRegistered = await CallKit.isCallRegistered(callKitUUID);
@@ -632,7 +655,7 @@ class CallKitCoordinator {
       );
       this.getSDKClient()?.queueEndFromCallKit(callKitUUID);
       await this.clearMatchingPendingVoipPush(callKitUUID);
-      return;
+      return false;
     }
 
     console.log('CallKitCoordinator: Processing push received event', {
@@ -699,10 +722,12 @@ class CallKitCoordinator {
       // Process the push notification
       await voipClient.handlePushNotification(pushData);
       console.log('CallKitCoordinator: Push notification processed successfully');
+      return true;
     } catch (error) {
       this.pendingPushCallUUIDs.delete(callKitUUID);
       this.isCallFromPush = this.pendingPushCallUUIDs.size > 0;
       console.error('CallKitCoordinator: Error processing push received event:', error);
+      return false;
     }
   }
 

--- a/react-voice-commons-sdk/src/callkit/callkit.ts
+++ b/react-voice-commons-sdk/src/callkit/callkit.ts
@@ -11,8 +11,21 @@ interface CallKitBridgeInterface {
     handle: string,
     displayName: string
   ): Promise<{ success: boolean; callUUID: string }>;
+  isCallRegistered(callUUID: string): Promise<{ registered: boolean; callUUID: string }>;
   answerCall(callUUID: string): Promise<{ success: boolean; callUUID: string }>;
   endCall(callUUID: string): Promise<{ success: boolean; callUUID: string }>;
+  completeHeldCallAction(
+    callUUID: string,
+    success: boolean
+  ): Promise<{ success: boolean; callUUID: string }>;
+  setCallHeld(
+    callUUID: string,
+    isOnHold: boolean
+  ): Promise<{ success: boolean; callUUID: string; isOnHold: boolean }>;
+  swapCalls(
+    activeCallUUID: string,
+    heldCallUUID: string
+  ): Promise<{ success: boolean; activeCallUUID: string; heldCallUUID: string }>;
   reportCallConnected(callUUID: string): Promise<{ success: boolean }>;
   reportCallEnded(callUUID: string, reason: number): Promise<{ success: boolean }>;
   updateCall(callUUID: string, displayName: string, handle: string): Promise<{ success: boolean }>;
@@ -31,13 +44,14 @@ export enum CallEndReason {
 // CallKit event types
 export interface CallKitEvent {
   callUUID: string;
+  isOnHold?: boolean;
   [key: string]: any;
 }
 
 class CallKitManager {
   private bridge: CallKitBridgeInterface | null = null;
   private eventEmitter: NativeEventEmitter | null = null;
-  private listeners: Map<string, (event: CallKitEvent) => void> = new Map();
+  private listeners: Map<string, Set<(event: CallKitEvent) => void>> = new Map();
 
   /**
    * Normalize UUID to lowercase for consistent handling in React Native
@@ -100,6 +114,12 @@ class CallKitManager {
       this.notifyListeners('endCall', normalizedEvent);
     });
 
+    this.eventEmitter.addListener('CallKitDidPerformHeldCallAction', (event) => {
+      const normalizedEvent = this.normalizeEvent(event);
+      console.log('CallKit: Received held call action', normalizedEvent);
+      this.notifyListeners('heldCall', normalizedEvent);
+    });
+
     this.eventEmitter.addListener('CallKitDidReceivePush', (event) => {
       const normalizedEvent = this.normalizeEvent(event);
       console.log('CallKit: Received push notification event', normalizedEvent);
@@ -108,9 +128,11 @@ class CallKitManager {
   }
 
   private notifyListeners(eventType: string, event: CallKitEvent) {
-    const listener = this.listeners.get(eventType);
-    if (listener) {
-      listener(event);
+    const listeners = this.listeners.get(eventType);
+    if (listeners) {
+      for (const listener of listeners) {
+        listener(event);
+      }
     }
   }
 
@@ -189,6 +211,23 @@ class CallKitManager {
     }
   }
 
+  public async isCallRegistered(callUUID: string): Promise<boolean> {
+    if (!this.bridge || Platform.OS !== 'ios') {
+      return false;
+    }
+
+    try {
+      const result = await this.bridge.isCallRegistered(this.denormalizeUUID(callUUID));
+      return result.registered;
+    } catch (error) {
+      console.error('CallKit: Failed to check incoming call registration', {
+        callUUID,
+        error,
+      });
+      return false;
+    }
+  }
+
   public async endCall(callUUID: string): Promise<boolean> {
     if (!this.bridge || Platform.OS !== 'ios') {
       console.warn('CallKit: Not available on this platform');
@@ -204,6 +243,52 @@ class CallKitManager {
       return result.success;
     } catch (error) {
       console.error('CallKit: Failed to end call', error);
+      return false;
+    }
+  }
+
+  public async completeHeldCallAction(callUUID: string, success: boolean): Promise<boolean> {
+    if (!this.bridge || Platform.OS !== 'ios') {
+      return false;
+    }
+
+    try {
+      const uppercaseUUID = this.denormalizeUUID(callUUID);
+      const result = await this.bridge.completeHeldCallAction(uppercaseUUID, success);
+      return result.success;
+    } catch (error) {
+      console.error('CallKit: Failed to complete held call action', error);
+      return false;
+    }
+  }
+
+  public async setCallHeld(callUUID: string, isOnHold: boolean): Promise<boolean> {
+    if (!this.bridge || Platform.OS !== 'ios') {
+      return false;
+    }
+
+    try {
+      const result = await this.bridge.setCallHeld(this.denormalizeUUID(callUUID), isOnHold);
+      return result.success;
+    } catch (error) {
+      console.error('CallKit: Failed to change held state', { callUUID, isOnHold, error });
+      return false;
+    }
+  }
+
+  public async swapCalls(activeCallUUID: string, heldCallUUID: string): Promise<boolean> {
+    if (!this.bridge || Platform.OS !== 'ios') {
+      return false;
+    }
+
+    try {
+      const result = await this.bridge.swapCalls(
+        this.denormalizeUUID(activeCallUUID),
+        this.denormalizeUUID(heldCallUUID)
+      );
+      return result.success;
+    } catch (error) {
+      console.error('CallKit: Failed to swap calls', error);
       return false;
     }
   }
@@ -283,23 +368,36 @@ class CallKitManager {
   // Event listener management
 
   public onStartCall(listener: (event: CallKitEvent) => void): () => void {
-    this.listeners.set('startCall', listener);
-    return () => this.listeners.delete('startCall');
+    return this.addListener('startCall', listener);
   }
 
   public onAnswerCall(listener: (event: CallKitEvent) => void): () => void {
-    this.listeners.set('answerCall', listener);
-    return () => this.listeners.delete('answerCall');
+    return this.addListener('answerCall', listener);
   }
 
   public onEndCall(listener: (event: CallKitEvent) => void): () => void {
-    this.listeners.set('endCall', listener);
-    return () => this.listeners.delete('endCall');
+    return this.addListener('endCall', listener);
+  }
+
+  public onHeldCall(listener: (event: CallKitEvent) => void): () => void {
+    return this.addListener('heldCall', listener);
   }
 
   public onReceivePush(listener: (event: CallKitEvent) => void): () => void {
-    this.listeners.set('receivePush', listener);
-    return () => this.listeners.delete('receivePush');
+    return this.addListener('receivePush', listener);
+  }
+
+  private addListener(eventType: string, listener: (event: CallKitEvent) => void): () => void {
+    const listeners = this.listeners.get(eventType) ?? new Set();
+    listeners.add(listener);
+    this.listeners.set(eventType, listeners);
+
+    return () => {
+      listeners.delete(listener);
+      if (listeners.size === 0) {
+        this.listeners.delete(eventType);
+      }
+    };
   }
 
   // Utility methods

--- a/react-voice-commons-sdk/src/internal/calls/call-state-controller.ts
+++ b/react-voice-commons-sdk/src/internal/calls/call-state-controller.ts
@@ -5,7 +5,6 @@ import { Call } from '../../models/call';
 import { TelnyxCallState } from '../../models/call-state';
 import { SessionManager } from '../session/session-manager';
 import { callKitCoordinator } from '../../callkit/callkit-coordinator';
-import { VoicePnBridge } from '../voice-pn-bridge';
 
 /**
  * Central state machine for call management.
@@ -488,9 +487,10 @@ export class CallStateController {
 
       if (existingCallKitUUID) {
         console.log(
-          'CallStateController: Call already has CallKit integration, skipping duplicate report:',
+          'CallStateController: Linking push-created CallKit call to its signaling call:',
           existingCallKitUUID
         );
+        callKitCoordinator.linkExistingCallKitCall(telnyxCall, existingCallKitUUID);
       } else if (call.isIncoming) {
         // Handle incoming call with CallKit (only if not already integrated)
         console.log('CallStateController: Reporting incoming call to CallKitCoordinator');
@@ -520,10 +520,6 @@ export class CallStateController {
           this._activeCallId = null;
         }
 
-        // Clear pending push data so the next app launch isn't mistaken for a push launch
-        VoicePnBridge.clearPendingVoipPush().catch((e) =>
-          console.warn('CallStateController: Failed to clear pending voip push:', e)
-        );
         setTimeout(() => this._removeCall(call.callId), 0);
       }
     });

--- a/react-voice-commons-sdk/src/internal/session/session-manager.ts
+++ b/react-voice-commons-sdk/src/internal/session/session-manager.ts
@@ -12,6 +12,7 @@ import {
 } from '../../models/config';
 
 const USE_TRICKLE_ICE_STORAGE_KEY = '@use_trickle_ice';
+const PUSH_WHEN_ACTIVE_STORAGE_KEY = '@push_when_active';
 const MISSED_CALL_NOTIFICATIONS_STORAGE_KEY = '@enable_missed_call_notifications';
 
 /**
@@ -186,11 +187,27 @@ export class SessionManager {
     // Store the push notification payload for when the client is created
     (this as any)._pendingPushPayload = payload;
 
-    // Each push always rebuilds the TelnyxRTC client. The voice_sdk_id is
-    // baked into the WebSocket URL at socket-open time and can't be mutated
-    // mid-flight; reusing a connection from a previous push means the
-    // gateway routes THIS push's INVITE to a different (correctly-stamped)
-    // client and we sit on the wrong socket forever.
+    // A second-call push must stay on the client that owns the active/held
+    // call. Tearing it down destroys the first signaling session and clears
+    // the call collection before CallKit can complete Hold & Accept.
+    if (this._telnyxClient && this._hasActiveOrHeldCall(this._telnyxClient)) {
+      const actualPayload = this._extractPushPayload(payload);
+      const processVoIPNotification = (this._telnyxClient as any).processVoIPNotification;
+
+      if (typeof processVoIPNotification !== 'function') {
+        throw new Error('TelnyxRTC client cannot process an active-call VoIP notification');
+      }
+
+      console.log(
+        'SessionManager: Preserving active client while processing second-call push notification'
+      );
+      processVoIPNotification.call(this._telnyxClient, actualPayload);
+      (this as any)._pendingPushPayload = null;
+      return;
+    }
+
+    // The cold/no-active-call path still rebuilds the client so the socket is
+    // stamped with the push voice_sdk_id before connecting.
     if (this._telnyxClient) {
       await this._disconnectAndForgetClient(
         this._telnyxClient,
@@ -222,10 +239,12 @@ export class SessionManager {
         const storedCredentialToken = await AsyncStorage.getItem('@credential_token');
         const storedPushToken = await AsyncStorage.getItem('@push_token');
         const storedUseTrickleIce = await AsyncStorage.getItem(USE_TRICKLE_ICE_STORAGE_KEY);
+        const storedPushWhenActive = await AsyncStorage.getItem(PUSH_WHEN_ACTIVE_STORAGE_KEY);
         const storedMissedCallNotifications = await AsyncStorage.getItem(
           MISSED_CALL_NOTIFICATIONS_STORAGE_KEY
         );
         const useTrickleIce = storedUseTrickleIce === 'true';
+        const pushWhenActive = storedPushWhenActive === 'true';
         const enableMissedCallNotifications = storedMissedCallNotifications === 'true';
 
         if (this._isTeardownActive()) {
@@ -239,6 +258,7 @@ export class SessionManager {
           this._currentConfig = createCredentialConfig(storedUsername, storedPassword, {
             pushNotificationDeviceToken: storedPushToken,
             useTrickleIce,
+            pushWhenActive,
             enableMissedCallNotifications,
           });
         }
@@ -249,6 +269,7 @@ export class SessionManager {
           this._currentConfig = createTokenConfig(storedCredentialToken, {
             pushNotificationDeviceToken: storedPushToken,
             useTrickleIce,
+            pushWhenActive,
             enableMissedCallNotifications,
           });
         }
@@ -347,6 +368,15 @@ export class SessionManager {
     }
 
     console.log('SessionManager: RELEASE DEBUG - Push notification handling complete');
+  }
+
+  private _hasActiveOrHeldCall(client: TelnyxSDK.TelnyxRTC): boolean {
+    const calls =
+      typeof (client as any).getActiveCalls === 'function'
+        ? (client as any).getActiveCalls()
+        : Array.from(((client as any).calls as Map<string, any> | undefined)?.values?.() || []);
+
+    return calls.some((call: any) => call?.state === 'active' || call?.state === 'held');
   }
 
   /**
@@ -452,6 +482,7 @@ export class SessionManager {
           logLevel: config.debug ? 'debug' : 'warn',
           debug: config.debug ?? false,
           pushNotificationDeviceToken: config.pushNotificationDeviceToken,
+          pushWhenActive: config.pushWhenActive,
           enableMissedCallNotifications: config.enableMissedCallNotifications ?? false,
           useTrickleIce: config.useTrickleIce,
           enableCallReports: config.enableCallReports,
@@ -472,6 +503,7 @@ export class SessionManager {
           logLevel: config.debug ? 'debug' : 'warn',
           debug: config.debug ?? false,
           pushNotificationDeviceToken: config.pushNotificationDeviceToken,
+          pushWhenActive: config.pushWhenActive,
           enableMissedCallNotifications: config.enableMissedCallNotifications ?? false,
           useTrickleIce: config.useTrickleIce,
           enableCallReports: config.enableCallReports,

--- a/react-voice-commons-sdk/src/models/call.ts
+++ b/react-voice-commons-sdk/src/models/call.ts
@@ -285,6 +285,17 @@ export class Call {
     }
 
     try {
+      if (Platform.OS === 'ios') {
+        const { callKitCoordinator } = await import('../callkit/callkit-coordinator');
+        if (callKitCoordinator.isAvailable()) {
+          const success = await callKitCoordinator.setHeldFromUI(this._telnyxCall, true);
+          if (!success) {
+            throw new Error('CallKit failed to hold call');
+          }
+          return;
+        }
+      }
+
       await this._telnyxCall.hold();
     } catch (error) {
       console.error('Failed to hold call:', error);
@@ -301,6 +312,17 @@ export class Call {
     }
 
     try {
+      if (Platform.OS === 'ios') {
+        const { callKitCoordinator } = await import('../callkit/callkit-coordinator');
+        if (callKitCoordinator.isAvailable()) {
+          const success = await callKitCoordinator.setHeldFromUI(this._telnyxCall, false);
+          if (!success) {
+            throw new Error('CallKit failed to resume call');
+          }
+          return;
+        }
+      }
+
       await this._telnyxCall.unhold();
     } catch (error) {
       console.error('Failed to resume call:', error);
@@ -405,6 +427,18 @@ export class Call {
     this._telnyxCall.on('telnyx.call.state', (call: any, state: any) => {
       const telnyxState = this._mapToTelnyxCallState(state);
       this._callState.next(telnyxState);
+
+      // Keep the dedicated held observable derived from call state. Updating
+      // this only after the low-level SDK emits its successful transition
+      // preserves the previous value when hold/unhold signaling fails.
+      if (telnyxState === TelnyxCallState.HELD) {
+        this._isHeld.next(true);
+      } else if (
+        telnyxState === TelnyxCallState.ACTIVE ||
+        CallStateHelpers.isTerminated(telnyxState)
+      ) {
+        this._isHeld.next(false);
+      }
 
       // Start duration timer when call becomes active
       if (telnyxState === TelnyxCallState.ACTIVE && !this._startTime) {

--- a/react-voice-commons-sdk/src/models/config.ts
+++ b/react-voice-commons-sdk/src/models/config.ts
@@ -7,6 +7,8 @@ export interface CredentialConfig {
   sipPassword: string;
   debug?: boolean;
   pushNotificationDeviceToken?: string;
+  /** Receive PushKit calls while the WebSocket session is active. Default: false */
+  pushWhenActive?: boolean;
   /** Enable native missed call push notifications. Default: false */
   enableMissedCallNotifications?: boolean;
   /** Enable Trickle ICE. Default: false */
@@ -29,6 +31,8 @@ export interface TokenConfig {
   token: string;
   debug?: boolean;
   pushNotificationDeviceToken?: string;
+  /** Receive PushKit calls while the WebSocket session is active. Default: false */
+  pushWhenActive?: boolean;
   /** Enable native missed call push notifications. Default: false */
   enableMissedCallNotifications?: boolean;
   /** Enable Trickle ICE. Default: false */
@@ -113,6 +117,7 @@ export function validateConfig(config: Config): string[] {
  * @param options - Optional configuration settings
  * @param options.debug - Enable debug logging (sets SDK logLevel to 'debug')
  * @param options.pushNotificationDeviceToken - Device token for push notifications
+ * @param options.pushWhenActive - Keep active PushKit devices eligible for incoming calls
  * @returns Complete credential configuration object
  */
 export function createCredentialConfig(
@@ -135,6 +140,7 @@ export function createCredentialConfig(
  * @param options - Optional configuration settings
  * @param options.debug - Enable debug logging (sets SDK logLevel to 'debug')
  * @param options.pushNotificationDeviceToken - Device token for push notifications
+ * @param options.pushWhenActive - Keep active PushKit devices eligible for incoming calls
  * @returns Complete token configuration object
  */
 export function createTokenConfig(

--- a/react-voice-commons-sdk/src/telnyx-voice-app.tsx
+++ b/react-voice-commons-sdk/src/telnyx-voice-app.tsx
@@ -3,6 +3,7 @@ import { AppState, AppStateStatus, Platform } from 'react-native';
 import { TelnyxVoipClient, createBackgroundTelnyxVoipClient } from './telnyx-voip-client';
 import { TelnyxConnectionState } from './models/connection-state';
 import { Call } from './models/call';
+import { TelnyxCallState } from './models/call-state';
 import { TelnyxVoiceProvider } from './context/TelnyxVoiceContext';
 
 let sharedBackgroundClient: TelnyxVoipClient | null = null;
@@ -461,10 +462,19 @@ const TelnyxVoiceAppComponent: React.FC<TelnyxVoiceAppProps> = ({
         // Prevent duplicate processing if already connected or connecting.
         // Since push data is no longer cleared on read, this guard prevents
         // re-processing when checkForInitialPushNotification fires again on app resume.
-        if (
+        const isConnectedOrConnecting =
           voipClient.currentConnectionState === TelnyxConnectionState.CONNECTED ||
-          voipClient.currentConnectionState === TelnyxConnectionState.CONNECTING
-        ) {
+          voipClient.currentConnectionState === TelnyxConnectionState.CONNECTING;
+        const isActiveIOSCallWaitingPush =
+          Platform.OS === 'ios' &&
+          voipClient.currentConnectionState === TelnyxConnectionState.CONNECTED &&
+          voipClient.currentCalls.some(
+            (call) =>
+              call.currentState === TelnyxCallState.ACTIVE ||
+              call.currentState === TelnyxCallState.HELD
+          );
+
+        if (isConnectedOrConnecting && !isActiveIOSCallWaitingPush) {
           log(
             `SKIPPING - Already ${voipClient.currentConnectionState}, preventing duplicate processing`
           );

--- a/react-voice-commons-sdk/src/telnyx-voice-app.tsx
+++ b/react-voice-commons-sdk/src/telnyx-voice-app.tsx
@@ -495,10 +495,19 @@ const TelnyxVoiceAppComponent: React.FC<TelnyxVoiceAppProps> = ({
           if (callId) {
             const { callKitCoordinator } = require('./callkit/callkit-coordinator');
             log('Notifying CallKit coordinator about push notification:', callId);
-            await callKitCoordinator.handleCallKitPushReceived(callId, {
+            const processed = await callKitCoordinator.handleCallKitPushReceived(callId, {
               callData: { source: 'push_notification' },
               pushData: pushData,
             });
+            if (!processed) {
+              // The push was filtered, rejected, or otherwise ignored by
+              // CallKit. Reset the foreground-push lifecycle flags so the
+              // app does not stay in a state that skips background
+              // disconnect/reconnect handling.
+              log('CallKit push was not processed - resetting foreground flags');
+              setIsHandlingForegroundCall(false);
+              backgroundDetectorIgnore.current = false;
+            }
           } else {
             log('No call_id found in push data, falling back to direct handling');
             await voipClient.handlePushNotification(pushData);

--- a/react-voice-commons-sdk/src/telnyx-voip-client.ts
+++ b/react-voice-commons-sdk/src/telnyx-voip-client.ts
@@ -11,6 +11,12 @@ import { VoicePnBridge } from './internal/voice-pn-bridge';
 const USE_TRICKLE_ICE_STORAGE_KEY = '@use_trickle_ice';
 const PUSH_WHEN_ACTIVE_STORAGE_KEY = '@push_when_active';
 const MISSED_CALL_NOTIFICATIONS_STORAGE_KEY = '@enable_missed_call_notifications';
+const LEGACY_CALLKIT_ANSWER_KEY = '__legacy_callkit_answer__';
+
+interface PendingCallKitAnswer {
+  callKitUUIDOrHeaders?: string | Record<string, string>;
+  customHeaders: Record<string, string>;
+}
 
 /**
  * Configuration options for TelnyxVoipClient
@@ -41,6 +47,7 @@ export class TelnyxVoipClient {
   private readonly _sessionManager: SessionManager;
   private readonly _callStateController: CallStateController;
   private readonly _options: Required<TelnyxVoipClientOptions>;
+  private readonly _pendingCallKitAnswers = new Map<string, PendingCallKitAnswer>();
   private _disposed = false;
   private _disposePromise?: Promise<void>;
 
@@ -89,6 +96,7 @@ export class TelnyxVoipClient {
       console.log(
         '🔧 TelnyxVoipClient: Client ready, initializing call state controller listeners'
       );
+      this._flushPendingCallKitAnswers();
       this._callStateController.initializeClientListeners();
     });
 
@@ -580,9 +588,18 @@ export class TelnyxVoipClient {
     if (telnyxClient && typeof (telnyxClient as any).queueAnswerFromCallKit === 'function') {
       (telnyxClient as any).queueAnswerFromCallKit(callKitUUIDOrHeaders, customHeaders);
     } else {
-      console.warn(
-        'TelnyxVoipClient: TelnyxRTC client not available or method not found for queueAnswerFromCallKit'
-      );
+      const normalizedUUID =
+        typeof callKitUUIDOrHeaders === 'string' ? callKitUUIDOrHeaders.toLowerCase() : undefined;
+      const actionKey = normalizedUUID ?? LEGACY_CALLKIT_ANSWER_KEY;
+      let retainedUUIDOrHeaders: string | Record<string, string> | undefined = normalizedUUID;
+      if (callKitUUIDOrHeaders && typeof callKitUUIDOrHeaders !== 'string') {
+        retainedUUIDOrHeaders = { ...callKitUUIDOrHeaders };
+      }
+
+      this._pendingCallKitAnswers.set(actionKey, {
+        callKitUUIDOrHeaders: retainedUUIDOrHeaders,
+        customHeaders: { ...customHeaders },
+      });
     }
   }
 
@@ -645,6 +662,7 @@ export class TelnyxVoipClient {
       try {
         await this._sessionManager.dispose();
       } finally {
+        this._pendingCallKitAnswers.clear();
         this._callStateController.dispose();
       }
     })();
@@ -653,6 +671,34 @@ export class TelnyxVoipClient {
   }
 
   // ========== Private Methods ==========
+
+  /**
+   * Forward answers captured during cold start as soon as SessionManager has
+   * created the TelnyxRTC instance. SessionManager invokes its ready callback
+   * before connect(), so the UUID-keyed action is present when the INVITE
+   * arrives.
+   */
+  private _flushPendingCallKitAnswers(): void {
+    const telnyxClient = this._sessionManager.telnyxClient;
+    if (!telnyxClient || typeof (telnyxClient as any).queueAnswerFromCallKit !== 'function') {
+      return;
+    }
+
+    for (const [actionKey, pendingAnswer] of this._pendingCallKitAnswers) {
+      try {
+        (telnyxClient as any).queueAnswerFromCallKit(
+          pendingAnswer.callKitUUIDOrHeaders,
+          pendingAnswer.customHeaders
+        );
+        this._pendingCallKitAnswers.delete(actionKey);
+      } catch (error) {
+        console.error('TelnyxVoipClient: Failed to restore pending CallKit answer', {
+          actionKey,
+          error,
+        });
+      }
+    }
+  }
 
   /**
    * Prefer an explicitly supplied token, otherwise hydrate it from PushKit's

--- a/react-voice-commons-sdk/src/telnyx-voip-client.ts
+++ b/react-voice-commons-sdk/src/telnyx-voip-client.ts
@@ -1,4 +1,5 @@
 import { Observable } from 'rxjs';
+import { Platform } from 'react-native';
 import { TelnyxConnectionState } from './models/connection-state';
 import { Call } from './models/call';
 import { TelnyxCallState } from './models/call-state';
@@ -8,6 +9,7 @@ import { CallStateController } from './internal/calls/call-state-controller';
 import { VoicePnBridge } from './internal/voice-pn-bridge';
 
 const USE_TRICKLE_ICE_STORAGE_KEY = '@use_trickle_ice';
+const PUSH_WHEN_ACTIVE_STORAGE_KEY = '@push_when_active';
 const MISSED_CALL_NOTIFICATIONS_STORAGE_KEY = '@enable_missed_call_notifications';
 
 /**
@@ -207,6 +209,54 @@ export class TelnyxVoipClient {
   }
 
   /**
+   * Swap the current active call with a held call.
+   * On iOS this is coordinated through CallKit so native and SDK state stay aligned.
+   *
+   * @param targetCallId ID of the held call to make active
+   */
+  async swapCalls(targetCallId: string): Promise<void> {
+    this._throwIfDisposed();
+
+    const activeCall = this.currentActiveCall;
+    const heldCall = this.getCall(targetCallId);
+
+    if (!activeCall || !heldCall || activeCall.callId === heldCall.callId) {
+      throw new Error('An active call and a different held call are required to swap calls');
+    }
+    if (activeCall.currentState !== TelnyxCallState.ACTIVE) {
+      throw new Error(`Cannot swap active call in state: ${activeCall.currentState}`);
+    }
+    if (heldCall.currentState !== TelnyxCallState.HELD) {
+      throw new Error(`Cannot swap target call in state: ${heldCall.currentState}`);
+    }
+
+    if (Platform.OS === 'ios') {
+      const { callKitCoordinator } = await import('./callkit/callkit-coordinator');
+      if (callKitCoordinator.isAvailable()) {
+        const success = await callKitCoordinator.swapCallsFromUI(
+          activeCall.telnyxCall,
+          heldCall.telnyxCall
+        );
+        if (!success) {
+          throw new Error('CallKit failed to swap calls');
+        }
+        return;
+      }
+    }
+
+    await activeCall.hold();
+    try {
+      await heldCall.resume();
+      this.setActiveCall(heldCall.callId);
+    } catch (error) {
+      await activeCall.resume().catch((resumeError) => {
+        console.error('Failed to restore active call after swap failure', resumeError);
+      });
+      throw error;
+    }
+  }
+
+  /**
    * Current session ID (UUID) for this connection.
    */
   get sessionId(): string {
@@ -243,10 +293,10 @@ export class TelnyxVoipClient {
       console.log('TelnyxVoipClient: Logging in with credentials for user:', config.sipUser);
     }
 
-    const loginConfig = {
+    const loginConfig = await this._withNativeVoipPushToken({
       ...config,
       useTrickleIce: config.useTrickleIce ?? this._options.useTrickleIce,
-    };
+    });
 
     // Store credentials for future reconnection
     await this._storeCredentials(loginConfig);
@@ -275,10 +325,10 @@ export class TelnyxVoipClient {
       console.log('TelnyxVoipClient: Logging in with token');
     }
 
-    const loginConfig = {
+    const loginConfig = await this._withNativeVoipPushToken({
       ...config,
       useTrickleIce: config.useTrickleIce ?? this._options.useTrickleIce,
-    };
+    });
 
     // Store token for future reconnection
     await this._storeToken(loginConfig);
@@ -328,20 +378,30 @@ export class TelnyxVoipClient {
       const storedCredentialToken = await AsyncStorage.getItem('@credential_token');
       const storedPushToken = await AsyncStorage.getItem('@push_token');
       const storedUseTrickleIce = await AsyncStorage.getItem(USE_TRICKLE_ICE_STORAGE_KEY);
+      const storedPushWhenActive = await AsyncStorage.getItem(PUSH_WHEN_ACTIVE_STORAGE_KEY);
       const storedMissedCallNotifications = await AsyncStorage.getItem(
         MISSED_CALL_NOTIFICATIONS_STORAGE_KEY
       );
       const useTrickleIce =
         storedUseTrickleIce === null ? this._options.useTrickleIce : storedUseTrickleIce === 'true';
+      const pushWhenActive = storedPushWhenActive === 'true';
       const enableMissedCallNotifications = storedMissedCallNotifications === 'true';
+      const nativePushToken =
+        Platform.OS === 'ios' ? (await VoicePnBridge.getVoipToken())?.trim() : null;
+      const pushNotificationDeviceToken = nativePushToken || storedPushToken;
+
+      if (nativePushToken && nativePushToken !== storedPushToken) {
+        await AsyncStorage.setItem('@push_token', nativePushToken);
+      }
 
       // Check if we have credential-based authentication data
       if (storedUsername && storedPassword) {
         // Create credential config from stored data
         const { createCredentialConfig } = require('./models/config');
         const config = createCredentialConfig(storedUsername, storedPassword, {
-          pushNotificationDeviceToken: storedPushToken,
+          pushNotificationDeviceToken,
           useTrickleIce,
+          pushWhenActive,
           enableMissedCallNotifications,
         });
 
@@ -361,8 +421,9 @@ export class TelnyxVoipClient {
         // Create token config from stored data
         const { createTokenConfig } = require('./models/config');
         const config = createTokenConfig(storedCredentialToken, {
-          pushNotificationDeviceToken: storedPushToken,
+          pushNotificationDeviceToken,
           useTrickleIce,
+          pushWhenActive,
           enableMissedCallNotifications,
         });
 
@@ -502,16 +563,22 @@ export class TelnyxVoipClient {
    * This should be called when the user answers from CallKit before the socket connection is established
    * @param customHeaders Optional custom headers to include with the answer
    */
-  queueAnswerFromCallKit(customHeaders: Record<string, string> = {}): void {
+  queueAnswerFromCallKit(
+    callKitUUIDOrHeaders?: string | Record<string, string>,
+    customHeaders: Record<string, string> = {}
+  ): void {
     this._throwIfDisposed();
 
     if (this._options.debug) {
-      console.log('TelnyxVoipClient: Queuing answer action from CallKit', customHeaders);
+      console.log('TelnyxVoipClient: Queuing answer action from CallKit', {
+        callKitUUIDOrHeaders,
+        customHeaders,
+      });
     }
 
     const telnyxClient = this._sessionManager.telnyxClient;
     if (telnyxClient && typeof (telnyxClient as any).queueAnswerFromCallKit === 'function') {
-      (telnyxClient as any).queueAnswerFromCallKit(customHeaders);
+      (telnyxClient as any).queueAnswerFromCallKit(callKitUUIDOrHeaders, customHeaders);
     } else {
       console.warn(
         'TelnyxVoipClient: TelnyxRTC client not available or method not found for queueAnswerFromCallKit'
@@ -523,7 +590,7 @@ export class TelnyxVoipClient {
    * Queue an end action for when the call invite arrives (for CallKit integration)
    * This should be called when the user ends from CallKit before the socket connection is established
    */
-  queueEndFromCallKit(): void {
+  queueEndFromCallKit(callKitUUID?: string): void {
     this._throwIfDisposed();
 
     if (this._options.debug) {
@@ -532,11 +599,26 @@ export class TelnyxVoipClient {
 
     const telnyxClient = this._sessionManager.telnyxClient;
     if (telnyxClient && typeof (telnyxClient as any).queueEndFromCallKit === 'function') {
-      (telnyxClient as any).queueEndFromCallKit();
+      (telnyxClient as any).queueEndFromCallKit(callKitUUID);
     } else {
       console.warn(
         'TelnyxVoipClient: TelnyxRTC client not available or method not found for queueEndFromCallKit'
       );
+    }
+  }
+
+  /**
+   * Associate the next push-delivered INVITE with its app-facing CallKit UUID.
+   * The underlying signaling call ID remains unchanged.
+   * @internal
+   */
+  setPushNotificationCallKitUUID(callKitUUID: string | null): void {
+    const telnyxClient = this._sessionManager.telnyxClient;
+    if (
+      telnyxClient &&
+      typeof (telnyxClient as any).setPushNotificationCallKitUUID === 'function'
+    ) {
+      (telnyxClient as any).setPushNotificationCallKitUUID(callKitUUID);
     }
   }
 
@@ -573,6 +655,31 @@ export class TelnyxVoipClient {
   // ========== Private Methods ==========
 
   /**
+   * Prefer an explicitly supplied token, otherwise hydrate it from PushKit's
+   * native storage. PushKit registration starts in AppDelegate before React
+   * mounts, so this removes the race between the JS token event and login.
+   */
+  private async _withNativeVoipPushToken<T extends Config>(config: T): Promise<T> {
+    if (Platform.OS !== 'ios' || config.pushNotificationDeviceToken?.trim()) {
+      return config;
+    }
+
+    const nativePushToken = (await VoicePnBridge.getVoipToken())?.trim();
+    if (!nativePushToken) {
+      return config;
+    }
+
+    if (this._options.debug) {
+      console.log('TelnyxVoipClient: Using PushKit token from native storage');
+    }
+
+    return {
+      ...config,
+      pushNotificationDeviceToken: nativePushToken,
+    };
+  }
+
+  /**
    * Store credential configuration for automatic reconnection
    */
   private async _storeCredentials(config: CredentialConfig): Promise<void> {
@@ -584,6 +691,10 @@ export class TelnyxVoipClient {
       await AsyncStorage.setItem(
         USE_TRICKLE_ICE_STORAGE_KEY,
         String(config.useTrickleIce ?? false)
+      );
+      await AsyncStorage.setItem(
+        PUSH_WHEN_ACTIVE_STORAGE_KEY,
+        String(config.pushWhenActive ?? false)
       );
       await AsyncStorage.setItem(
         MISSED_CALL_NOTIFICATIONS_STORAGE_KEY,
@@ -619,6 +730,10 @@ export class TelnyxVoipClient {
       await AsyncStorage.setItem(
         USE_TRICKLE_ICE_STORAGE_KEY,
         String(config.useTrickleIce ?? false)
+      );
+      await AsyncStorage.setItem(
+        PUSH_WHEN_ACTIVE_STORAGE_KEY,
+        String(config.pushWhenActive ?? false)
       );
       await AsyncStorage.setItem(
         MISSED_CALL_NOTIFICATIONS_STORAGE_KEY,

--- a/react-voice-commons-sdk/src/types/telnyx-sdk.d.ts
+++ b/react-voice-commons-sdk/src/types/telnyx-sdk.d.ts
@@ -34,6 +34,7 @@ declare module '@telnyx/react-native-voice-sdk' {
     debug?: boolean;
     logLevel?: string;
     pushNotificationDeviceToken?: string;
+    pushWhenActive?: boolean;
     enableMissedCallNotifications?: boolean;
     useTrickleIce?: boolean;
     enableCallReports?: boolean;


### PR DESCRIPTION
## Summary

Fix the customer-reported repeated hold/unhold failure and complete iOS call-waiting support across the low-level React Native Voice SDK, React Voice Commons, CallKit, and the example app.

## Customer reports addressed

- Repeated `hold()` / `unhold()` cycles no longer leave calls stuck in `HELD`; the gateway's canonical `holdState: "active"` unhold response is accepted.
- A second inbound call can be delivered while another call is active or held, including while the phone is locked.
- CallKit supports two simultaneous one-call groups and exposes **Hold & Accept**.
- CallKit answer, end, hold, resume, and swap actions are UUID-targeted so the correct signaling call is controlled.
- Focus/DND-filtered incoming registrations are treated as terminal and no longer cascade into `UnknownCallUUID` / request-transaction errors or ghost calls.
- The example app now exposes active/held state, Hold/Resume controls, other-call status, and call swapping.

## Implementation

- Add opt-in `pushWhenActive` signaling parity with native iOS:
  - `push_when_active=true`
  - `pn_late_fanout=true`
  - `answered_device_token`
- Hydrate missing/stale login tokens from native PushKit storage and persist the active-push preference for reconnect/cold-start flows.
- Preserve the active signaling client when a second-call push arrives.
- Keep CallKit UUIDs separate from signaling call IDs and key pending actions by UUID.
- Route app-originated hold/resume/swap/end operations through CallKit.
- Roll back partial swaps, guard compensation against concurrent operations, and restore a held survivor after the selected call ends.
- Synchronize native CallKit call/action collections and advertise holding on incoming calls.
- Add regression coverage and update integration/changelog documentation.

`pushWhenActive` remains opt-in and defaults to `false`. The demo enables it because active-call PushKit delivery is part of its call-waiting behavior.

## Automated validation

- [x] Low-level SDK Jest: 15 suites, 143 tests
- [x] Commons SDK Jest: 13 suites, 120 tests
- [x] Commons TypeScript build and `tsc --noEmit`
- [x] Commons ESLint: 0 errors
- [x] Swift parse check
- [x] Unsigned generic-device Xcode build: `BUILD SUCCEEDED`
- [x] Prettier and `git diff --check`
- [x] Independent code, architecture, and adversarial reviews

## Physical iOS acceptance tests

Tested on a physical iPhone with a development VoIP credential matching the installed bundle, using two independent WebRTC clients (SIP A and SIP B).

- [x] **Basic incoming and outgoing calls**
  - Answered a foreground inbound call and placed an outbound call.
  - Confirmed two-way audio, Active UI, Hold and Hangup controls, and synchronized teardown in the app, CallKit, and WebRTC portal.

- [x] **Repeated hold/resume — original customer bug**
  - Performed at least five Hold → Resume cycles from the React Native UI.
  - Confirmed Held/Resume UI, restored audio after every resume, and a live portal call throughout.
  - Confirmed no `Cannot hold call in state: HELD` or invalid hold/unhold response errors.

- [x] **Remote hold indication**
  - Held and resumed from the WebRTC caller.
  - Confirmed the React Native UI changed between Held and Active and audio returned.

- [x] **Foreground call waiting**
  - Kept SIP A active and called from SIP B.
  - Confirmed CallKit displayed **Hold & Accept**, SIP A remained alive and held, and SIP B became active with audio.

- [x] **Call swapping**
  - Confirmed the app listed the held call with a Swap control.
  - Swapped at least three times from the React Native UI and once through native CallKit.
  - After each swap, exactly one call was active, the other remained held/alive, audio followed the selected call, and app/CallKit/portal state agreed.
  - Ended the selected call and confirmed the held survivor became active before ending it.

- [x] **Locked-phone VoIP push**
  - Logged in once, backgrounded the app, locked the phone, and placed inbound calls.
  - Confirmed CallKit appeared on the lock screen, calls could be answered without unlocking, audio worked, and teardown synchronized.

- [x] **Locked-phone call waiting**
  - Kept SIP A active, locked the phone, and called from SIP B.
  - Confirmed the second call surfaced with **Hold & Accept**, SIP A remained held rather than terminating, swapping worked, and both calls ended cleanly.

- [x] **Focus mode behavior**
  - With a blocking Focus enabled, confirmed iOS could report `com.apple.CallKit.error.incomingcall error 3` without a subsequent request-transaction error 4 or ghost call.
  - Disabled Focus and confirmed subsequent incoming and outgoing calls worked normally.

## PR hygiene

- No OpenSpec files are included.
- No credentials, certificates, provisioning profiles, personal signing team, bundle identifier, or local Xcode setup changes are included.
