### PR TITLE
fix: loop Android incoming call ringtone

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,18 @@ await voipClient.loginWithToken(config);
 
 `pushWhenActive` is opt-in and defaults to `false`. Enable it on iOS when the device must receive a second PushKit call while another call is active or held.
 
+### Android Incoming Ringtone
+
+Android uses the device's selected phone ringtone by default. To use an app-bundled sound instead, add a supported audio file such as `my_ringtone.wav` to `android/app/src/main/res/raw/` and pass its resource name without the extension when logging in:
+
+```tsx
+const config = createCredentialConfig('your_sip_username', 'your_sip_password', {
+  incomingCallRingtone: 'my_ringtone',
+});
+```
+
+The SDK persists this setting for incoming FCM pushes. If the resource is missing or the option is omitted, it falls back to the device ringtone.
+
 ### Automatic Storage & Reconnection
 
 The library automatically stores authentication data securely for seamless reconnection. **You don't need to manually manage these storage keys** - the library handles everything internally.

--- a/react-voice-commons-sdk/CHANGELOG.md
+++ b/react-voice-commons-sdk/CHANGELOG.md
@@ -2,29 +2,26 @@
 
 ## Unreleased
 
-### Bug Fixing
-
-- Preserve an iOS CallKit answer that occurs before React Native event listeners attach during a VoIP-push cold launch.
-- Hydrate iOS login and reconnect configurations from the current native PushKit token when callers omit one, preventing locked-device inbound calls from being missed when JavaScript login races token delivery.
-- Support two simultaneous iOS CallKit calls with UUID-targeted answer, end, hold, resume, and survivor restoration.
-- Route app hold/resume through CallKit and compensate partial call-swap failures to keep native and WebRTC state aligned.
-- Preserve the active signaling client when a second-call push arrives and avoid duplicate cold-answer actions.
-- Persist and forward the opt-in `pushWhenActive` configuration required for locked/background active-call PushKit delivery.
-- Treat Focus/DND-filtered CallKit registrations as terminal so rejected UUIDs cannot produce follow-up `UnknownCallUUID` answer transactions or ghost signaling calls.
-
-### Enhancement
-
-- Add public `swapCalls(targetCallId)` support and matching demo hold/resume/swap controls.
-
 ## [1.1.0] (2026-08-07)
 
 ### Enhancement
 
+- Add and persist opt-in `pushWhenActive` support so push routing remains available when an active WebSocket connection would otherwise be prioritized.
 - Add Android `incomingCallRingtone` configuration. Apps can provide the name of an audio resource bundled in `android/app/src/main/res/raw`; the setting is retained for incoming FCM calls.
+- Add iOS call-waiting support, including UUID-targeted answer, end, hold, resume, and `swapCalls(targetCallId)` operations for two simultaneous CallKit calls.
+- Expose the explicitly selected active call through the public client API and re-emit call collections when a tracked call changes state.
+- Forward custom SIP headers supplied to `newCall()` in the React Native SDK's expected format.
+- Add Android push-notification fallbacks when call notifications are unavailable, and declare the required foreground-service type for active calls.
+- Add documentation for `pushWhenActive`, answered-elsewhere handling, Trickle ICE, and Android custom incoming ringtones.
 
 ### Bug Fixing
 
-- Play and loop the Android incoming-call ringtone until the call is answered, rejected, ended, or dismissed. The SDK now falls back to the device's selected phone ringtone when no valid app resource is configured.
+- Play and loop the Android incoming-call ringtone until the call is answered, rejected, ended, or dismissed. The SDK falls back to the device's selected phone ringtone when no valid app resource is configured.
+- Preserve iOS CallKit answers that occur before React Native listeners attach during a VoIP-push cold launch, including the case where the app omits a PushKit token while the native token is already available.
+- Prevent stale CallKit callbacks and subscription leaks after React re-renders or the active call changes.
+- Handle repeated holds, call swaps, rejected pushes, malformed PushKit payloads, Focus/DND-filtered CallKit registrations, and a second incoming call without leaving ghost calls or stuck foreground flags.
+- Harden session teardown and reconnection by serializing disposal, cancelling pending connection work, and waiting for socket cleanup before continuing.
+- Clear stale fallback push actions and keep incoming-call handling available when notifications are disabled.
 
 ## [0.4.3] (2026-04-30)
 

--- a/react-voice-commons-sdk/CHANGELOG.md
+++ b/react-voice-commons-sdk/CHANGELOG.md
@@ -16,6 +16,16 @@
 
 - Add public `swapCalls(targetCallId)` support and matching demo hold/resume/swap controls.
 
+## [1.1.0] (2026-08-07)
+
+### Enhancement
+
+- Add Android `incomingCallRingtone` configuration. Apps can provide the name of an audio resource bundled in `android/app/src/main/res/raw`; the setting is retained for incoming FCM calls.
+
+### Bug Fixing
+
+- Play and loop the Android incoming-call ringtone until the call is answered, rejected, ended, or dismissed. The SDK now falls back to the device's selected phone ringtone when no valid app resource is configured.
+
 ## [0.4.3] (2026-04-30)
 
 ### Bug Fixing

--- a/react-voice-commons-sdk/README.md
+++ b/react-voice-commons-sdk/README.md
@@ -296,6 +296,18 @@ await voipClient.loginWithToken(config);
 
 `pushWhenActive` is opt-in and defaults to `false`. Enable it on iOS when the device must receive a second PushKit call while another call is active or held.
 
+### Android Incoming Ringtone
+
+Android uses the device's selected phone ringtone by default. To use an app-bundled sound instead, add a supported audio file such as `my_ringtone.wav` to `android/app/src/main/res/raw/` and pass its resource name without the extension when logging in:
+
+```tsx
+const config = createCredentialConfig('your_sip_username', 'your_sip_password', {
+  incomingCallRingtone: 'my_ringtone',
+});
+```
+
+The SDK persists this setting for incoming FCM pushes. If the resource is missing or the option is omitted, it falls back to the device ringtone.
+
 ### Automatic Storage & Reconnection
 
 The library automatically stores authentication data securely for seamless reconnection. **You don't need to manually manage these storage keys** - the library handles everything internally.

--- a/react-voice-commons-sdk/android/src/main/java/com/telnyx/react_voice_commons/TelnyxNotificationHelper.kt
+++ b/react-voice-commons-sdk/android/src/main/java/com/telnyx/react_voice_commons/TelnyxNotificationHelper.kt
@@ -15,6 +15,7 @@ import android.media.AudioAttributes
 import android.media.AudioManager
 import android.media.Ringtone
 import android.media.RingtoneManager
+import android.net.Uri
 import android.os.Build
 import android.util.Log
 import androidx.core.app.NotificationCompat
@@ -41,16 +42,17 @@ class TelnyxNotificationHelper(private val context: Context) {
         /**
          * Notifications can produce only a short alert (and some OEMs suppress it when
          * a full-screen call notification immediately launches the app). Keep the
-         * device's selected phone ringtone playing until the incoming call is handled.
+         * configured app ringtone, or the device's selected phone ringtone, playing
+         * until the incoming call is handled.
          */
         private fun startIncomingCallRingtone(context: Context) {
             synchronized(ringtoneLock) {
                 if (incomingCallRingtone?.isPlaying == true) return
 
-                val ringtoneUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_RINGTONE)
+                val ringtoneUri = getIncomingCallRingtoneUri(context)
                 val ringtone = RingtoneManager.getRingtone(context.applicationContext, ringtoneUri)
                 if (ringtone == null) {
-                    Log.w(TAG, "No default phone ringtone is configured")
+                    Log.w(TAG, "No incoming call ringtone is configured")
                     return
                 }
 
@@ -70,6 +72,23 @@ class TelnyxNotificationHelper(private val context: Context) {
                     ringtone.stop()
                 }
             }
+        }
+
+        private fun getIncomingCallRingtoneUri(context: Context): Uri {
+            val resourceName = VoicePnManager.getIncomingCallRingtoneResource(context)
+            if (!resourceName.isNullOrBlank()) {
+                val resourceId = context.resources.getIdentifier(
+                    resourceName,
+                    "raw",
+                    context.packageName
+                )
+                if (resourceId != 0) {
+                    return Uri.parse("android.resource://${context.packageName}/$resourceId")
+                }
+                Log.w(TAG, "Incoming ringtone resource '$resourceName' was not found; using the device ringtone")
+            }
+
+            return RingtoneManager.getDefaultUri(RingtoneManager.TYPE_RINGTONE)
         }
 
         private fun stopIncomingCallRingtone() {

--- a/react-voice-commons-sdk/android/src/main/java/com/telnyx/react_voice_commons/TelnyxNotificationHelper.kt
+++ b/react-voice-commons-sdk/android/src/main/java/com/telnyx/react_voice_commons/TelnyxNotificationHelper.kt
@@ -27,7 +27,7 @@ import androidx.core.content.ContextCompat
  */
 class TelnyxNotificationHelper(private val context: Context) {
     companion object {
-        const val INCOMING_CALL_CHANNEL_ID = "telnyx_voice_incoming_calls_v2"
+        private const val INCOMING_CALL_CHANNEL_PREFIX = "telnyx_voice_incoming_calls_v3"
         const val ONGOING_CALL_CHANNEL_ID = "telnyx_voice_ongoing_calls"
         const val MISSED_CALL_CHANNEL_ID = "telnyx_voice_missed_calls"
         const val INCOMING_CALL_CHANNEL_NAME = "Incoming Telnyx Voice Calls"
@@ -49,7 +49,7 @@ class TelnyxNotificationHelper(private val context: Context) {
             synchronized(ringtoneLock) {
                 if (incomingCallRingtone?.isPlaying == true) return
 
-                val ringtoneUri = getIncomingCallRingtoneUri(context)
+                val ringtoneUri = getIncomingCallRingtoneUriForPlayback(context) ?: return
                 val ringtone = RingtoneManager.getRingtone(context.applicationContext, ringtoneUri)
                 if (ringtone == null) {
                     Log.w(TAG, "No incoming call ringtone is configured")
@@ -74,7 +74,7 @@ class TelnyxNotificationHelper(private val context: Context) {
             }
         }
 
-        private fun getIncomingCallRingtoneUri(context: Context): Uri {
+        private fun getConfiguredIncomingCallRingtoneUri(context: Context): Uri {
             val resourceName = VoicePnManager.getIncomingCallRingtoneResource(context)
             if (!resourceName.isNullOrBlank()) {
                 val resourceId = context.resources.getIdentifier(
@@ -89,6 +89,32 @@ class TelnyxNotificationHelper(private val context: Context) {
             }
 
             return RingtoneManager.getDefaultUri(RingtoneManager.TYPE_RINGTONE)
+        }
+
+        private fun getIncomingCallChannelId(context: Context): String {
+            val resourceName = VoicePnManager.getIncomingCallRingtoneResource(context)
+            if (resourceName.isNullOrBlank()) return "${INCOMING_CALL_CHANNEL_PREFIX}_default"
+
+            val resourceId = context.resources.getIdentifier(resourceName, "raw", context.packageName)
+            return if (resourceId == 0) {
+                "${INCOMING_CALL_CHANNEL_PREFIX}_default"
+            } else {
+                "${INCOMING_CALL_CHANNEL_PREFIX}_${Integer.toUnsignedString(resourceName.hashCode(), 16)}"
+            }
+        }
+
+        private fun getIncomingCallRingtoneUriForPlayback(context: Context): Uri? {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+                return getConfiguredIncomingCallRingtoneUri(context)
+            }
+
+            val channel = (context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager)
+                .getNotificationChannel(getIncomingCallChannelId(context))
+            if (channel?.sound == null) {
+                Log.d(TAG, "Incoming call ringtone is disabled in notification settings")
+                return null
+            }
+            return channel.sound
         }
 
         private fun stopIncomingCallRingtone() {
@@ -127,8 +153,6 @@ class TelnyxNotificationHelper(private val context: Context) {
     }
 
     private val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-    private val defaultRingtoneUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_RINGTONE)
-
     init {
         createNotificationChannels()
     }
@@ -234,7 +258,7 @@ class TelnyxNotificationHelper(private val context: Context) {
             // New ID: Android preserves a channel's sound after it is created, so the
             // prior silent channel cannot be updated for existing installations.
             val incomingCallChannel = NotificationChannel(
-                INCOMING_CALL_CHANNEL_ID,
+                getIncomingCallChannelId(context),
                 INCOMING_CALL_CHANNEL_NAME,
                 NotificationManager.IMPORTANCE_HIGH
             ).apply {
@@ -243,7 +267,7 @@ class TelnyxNotificationHelper(private val context: Context) {
                 lightColor = Color.GREEN
                 enableVibration(true)
                 setSound(
-                    defaultRingtoneUri,
+                    getConfiguredIncomingCallRingtoneUri(context),
                     AudioAttributes.Builder()
                         .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
                         .setUsage(AudioAttributes.USAGE_NOTIFICATION_RINGTONE)
@@ -310,7 +334,7 @@ class TelnyxNotificationHelper(private val context: Context) {
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
 
-        val builder = NotificationCompat.Builder(context, INCOMING_CALL_CHANNEL_ID)
+        val builder = NotificationCompat.Builder(context, getIncomingCallChannelId(context))
             .setContentTitle("Incoming Call")
             .setContentText("$displayName")
             .setSmallIcon(android.R.drawable.ic_menu_call)
@@ -326,7 +350,7 @@ class TelnyxNotificationHelper(private val context: Context) {
         // ringtone directly on the incoming-call notification.
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
             @Suppress("DEPRECATION")
-            builder.setSound(defaultRingtoneUri, AudioManager.STREAM_RING)
+            builder.setSound(getConfiguredIncomingCallRingtoneUri(context), AudioManager.STREAM_RING)
         }
 
         // Add action buttons - use direct activity PendingIntents to avoid trampoline restrictions
@@ -378,7 +402,7 @@ class TelnyxNotificationHelper(private val context: Context) {
         val blockReason = notifyIfPermitted(
             NOTIFICATION_ID,
             notification,
-            INCOMING_CALL_CHANNEL_ID,
+            getIncomingCallChannelId(context),
         )
         if (blockReason == null) {
             startIncomingCallRingtone(context)

--- a/react-voice-commons-sdk/android/src/main/java/com/telnyx/react_voice_commons/TelnyxNotificationHelper.kt
+++ b/react-voice-commons-sdk/android/src/main/java/com/telnyx/react_voice_commons/TelnyxNotificationHelper.kt
@@ -13,6 +13,7 @@ import android.content.pm.PackageManager
 import android.graphics.Color
 import android.media.AudioAttributes
 import android.media.AudioManager
+import android.media.Ringtone
 import android.media.RingtoneManager
 import android.os.Build
 import android.util.Log
@@ -34,6 +35,55 @@ class TelnyxNotificationHelper(private val context: Context) {
         const val NOTIFICATION_ID = 1001
         const val ONGOING_CALL_NOTIFICATION_ID = 1002
         private const val TAG = "TelnyxNotifications"
+        private val ringtoneLock = Any()
+        private var incomingCallRingtone: Ringtone? = null
+
+        /**
+         * Notifications can produce only a short alert (and some OEMs suppress it when
+         * a full-screen call notification immediately launches the app). Keep the
+         * device's selected phone ringtone playing until the incoming call is handled.
+         */
+        private fun startIncomingCallRingtone(context: Context) {
+            synchronized(ringtoneLock) {
+                if (incomingCallRingtone?.isPlaying == true) return
+
+                val ringtoneUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_RINGTONE)
+                val ringtone = RingtoneManager.getRingtone(context.applicationContext, ringtoneUri)
+                if (ringtone == null) {
+                    Log.w(TAG, "No default phone ringtone is configured")
+                    return
+                }
+
+                try {
+                    ringtone.audioAttributes = AudioAttributes.Builder()
+                        .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+                        .setUsage(AudioAttributes.USAGE_NOTIFICATION_RINGTONE)
+                        .build()
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                        ringtone.isLooping = true
+                    }
+                    ringtone.play()
+                    incomingCallRingtone = ringtone
+                    Log.d(TAG, "Started incoming call ringtone")
+                } catch (e: RuntimeException) {
+                    Log.e(TAG, "Failed to start incoming call ringtone", e)
+                    ringtone.stop()
+                }
+            }
+        }
+
+        private fun stopIncomingCallRingtone() {
+            synchronized(ringtoneLock) {
+                incomingCallRingtone?.let { ringtone ->
+                    try {
+                        ringtone.stop()
+                    } catch (e: RuntimeException) {
+                        Log.w(TAG, "Failed to stop incoming call ringtone", e)
+                    }
+                }
+                incomingCallRingtone = null
+            }
+        }
         
         /**
          * Static method to hide notifications from anywhere in the app
@@ -42,6 +92,7 @@ class TelnyxNotificationHelper(private val context: Context) {
         fun hideNotificationFromContext(context: Context) {
             val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
             notificationManager.cancel(NOTIFICATION_ID)
+            stopIncomingCallRingtone()
             Log.d(TAG, "Dismissed Telnyx notification from static context")
         }
         
@@ -311,6 +362,7 @@ class TelnyxNotificationHelper(private val context: Context) {
             INCOMING_CALL_CHANNEL_ID,
         )
         if (blockReason == null) {
+            startIncomingCallRingtone(context)
             Log.d(TAG, "Showed incoming call notification for: $callerName ($callerNumber)")
         } else {
             launchFullScreenIntentFallback(notification, callId, metadata, blockReason)
@@ -436,6 +488,7 @@ class TelnyxNotificationHelper(private val context: Context) {
 
     fun hideIncomingCallNotification() {
         notificationManager.cancel(NOTIFICATION_ID)
+        stopIncomingCallRingtone()
         Log.d(TAG, "Hid incoming call notification")
     }
 

--- a/react-voice-commons-sdk/android/src/main/java/com/telnyx/react_voice_commons/TelnyxNotificationHelper.kt
+++ b/react-voice-commons-sdk/android/src/main/java/com/telnyx/react_voice_commons/TelnyxNotificationHelper.kt
@@ -13,6 +13,7 @@ import android.content.pm.PackageManager
 import android.graphics.Color
 import android.media.AudioAttributes
 import android.media.AudioManager
+import android.media.MediaPlayer
 import android.media.Ringtone
 import android.media.RingtoneManager
 import android.net.Uri
@@ -38,6 +39,7 @@ class TelnyxNotificationHelper(private val context: Context) {
         private const val TAG = "TelnyxNotifications"
         private val ringtoneLock = Any()
         private var incomingCallRingtone: Ringtone? = null
+        private var incomingCallMediaPlayer: MediaPlayer? = null
 
         /**
          * Notifications can produce only a short alert (and some OEMs suppress it when
@@ -47,9 +49,19 @@ class TelnyxNotificationHelper(private val context: Context) {
          */
         private fun startIncomingCallRingtone(context: Context) {
             synchronized(ringtoneLock) {
-                if (incomingCallRingtone?.isPlaying == true) return
+                if (
+                    incomingCallRingtone?.isPlaying == true ||
+                    incomingCallMediaPlayer?.isPlaying == true
+                ) {
+                    return
+                }
 
                 val ringtoneUri = getIncomingCallRingtoneUriForPlayback(context) ?: return
+                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
+                    startLegacyIncomingCallRingtone(context, ringtoneUri)
+                    return
+                }
+
                 val ringtone = RingtoneManager.getRingtone(context.applicationContext, ringtoneUri)
                 if (ringtone == null) {
                     Log.w(TAG, "No incoming call ringtone is configured")
@@ -61,9 +73,7 @@ class TelnyxNotificationHelper(private val context: Context) {
                         .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
                         .setUsage(AudioAttributes.USAGE_NOTIFICATION_RINGTONE)
                         .build()
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-                        ringtone.isLooping = true
-                    }
+                    ringtone.isLooping = true
                     ringtone.play()
                     incomingCallRingtone = ringtone
                     Log.d(TAG, "Started incoming call ringtone")
@@ -71,6 +81,43 @@ class TelnyxNotificationHelper(private val context: Context) {
                     Log.e(TAG, "Failed to start incoming call ringtone", e)
                     ringtone.stop()
                 }
+            }
+        }
+
+        private fun startLegacyIncomingCallRingtone(context: Context, ringtoneUri: Uri) {
+            try {
+                val mediaPlayer = MediaPlayer().apply {
+                    setAudioAttributes(
+                        AudioAttributes.Builder()
+                            .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+                            .setUsage(AudioAttributes.USAGE_NOTIFICATION_RINGTONE)
+                            .build()
+                    )
+                    setDataSource(context.applicationContext, ringtoneUri)
+                    isLooping = true
+                    setOnPreparedListener { player ->
+                        synchronized(ringtoneLock) {
+                            if (incomingCallMediaPlayer === player) {
+                                player.start()
+                            } else {
+                                player.release()
+                            }
+                        }
+                    }
+                    setOnErrorListener { player, _, _ ->
+                        Log.e(TAG, "Failed to play incoming call ringtone")
+                        if (incomingCallMediaPlayer === player) {
+                            incomingCallMediaPlayer = null
+                        }
+                        player.release()
+                        true
+                    }
+                }
+                incomingCallMediaPlayer = mediaPlayer
+                mediaPlayer.prepareAsync()
+                Log.d(TAG, "Preparing incoming call ringtone")
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to start incoming call ringtone", e)
             }
         }
 
@@ -127,6 +174,15 @@ class TelnyxNotificationHelper(private val context: Context) {
                     }
                 }
                 incomingCallRingtone = null
+                incomingCallMediaPlayer?.let { mediaPlayer ->
+                    try {
+                        mediaPlayer.stop()
+                    } catch (_: IllegalStateException) {
+                        // The player may still be preparing.
+                    }
+                    mediaPlayer.release()
+                }
+                incomingCallMediaPlayer = null
             }
         }
         

--- a/react-voice-commons-sdk/android/src/main/java/com/telnyx/react_voice_commons/VoicePnBridgeModule.kt
+++ b/react-voice-commons-sdk/android/src/main/java/com/telnyx/react_voice_commons/VoicePnBridgeModule.kt
@@ -226,6 +226,21 @@ class VoicePnBridgeModule(reactContext: ReactApplicationContext) : ReactContextB
     }
 
     @ReactMethod
+    fun setIncomingCallRingtone(resourceName: String?, promise: Promise) {
+        try {
+            promise.resolve(
+                VoicePnManager.setIncomingCallRingtoneResource(
+                    reactApplicationContext,
+                    resourceName?.trim()?.takeIf { it.isNotEmpty() }
+                )
+            )
+        } catch (e: Exception) {
+            Log.e(TAG, "Error setting incoming call ringtone", e)
+            promise.reject("SET_INCOMING_CALL_RINGTONE_ERROR", e.message, e)
+        }
+    }
+
+    @ReactMethod
     fun setMissedCallNotificationsEnabled(enabled: Boolean, promise: Promise) {
         try {
             val result = VoicePnManager.setMissedCallNotificationsEnabled(

--- a/react-voice-commons-sdk/android/src/main/java/com/telnyx/react_voice_commons/VoicePnBridgeModule.kt
+++ b/react-voice-commons-sdk/android/src/main/java/com/telnyx/react_voice_commons/VoicePnBridgeModule.kt
@@ -145,6 +145,7 @@ class VoicePnBridgeModule(reactContext: ReactApplicationContext) : ReactContextB
             Log.d(TAG, "showOngoingCallNotification called from React Native")
             
             val notificationHelper = TelnyxNotificationHelper(reactApplicationContext)
+            notificationHelper.hideIncomingCallNotification()
             notificationHelper.showOngoingCallNotification(
                 callerName ?: "Unknown Caller",
                 callerNumber ?: "",
@@ -228,12 +229,15 @@ class VoicePnBridgeModule(reactContext: ReactApplicationContext) : ReactContextB
     @ReactMethod
     fun setIncomingCallRingtone(resourceName: String?, promise: Promise) {
         try {
-            promise.resolve(
-                VoicePnManager.setIncomingCallRingtoneResource(
-                    reactApplicationContext,
-                    resourceName?.trim()?.takeIf { it.isNotEmpty() }
-                )
+            val configured = VoicePnManager.setIncomingCallRingtoneResource(
+                reactApplicationContext,
+                resourceName?.trim()?.takeIf { it.isNotEmpty() }
             )
+            // Create the resource-specific channel while JavaScript is available.
+            // Android preserves channel settings, and a later FCM push may arrive
+            // while the app process is not running.
+            TelnyxNotificationHelper(reactApplicationContext)
+            promise.resolve(configured)
         } catch (e: Exception) {
             Log.e(TAG, "Error setting incoming call ringtone", e)
             promise.reject("SET_INCOMING_CALL_RINGTONE_ERROR", e.message, e)

--- a/react-voice-commons-sdk/android/src/main/java/com/telnyx/react_voice_commons/VoicePnManager.kt
+++ b/react-voice-commons-sdk/android/src/main/java/com/telnyx/react_voice_commons/VoicePnManager.kt
@@ -9,6 +9,7 @@ object VoicePnManager {
     private const val TAG = "VoicePnManager"
     private const val PREFS_NAME = "telnyx_voice_prefs"
     private const val MISSED_CALL_NOTIFICATIONS_ENABLED = "telnyx_enable_missed_call_notifications"
+    private const val INCOMING_CALL_RINGTONE_RESOURCE = "telnyx_incoming_call_ringtone_resource"
     
     private fun getSharedPreferences(context: Context): SharedPreferences {
         return context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
@@ -92,6 +93,24 @@ object VoicePnManager {
         Log.d(TAG, "getMissedCallNotificationsEnabled called")
         return getSharedPreferences(context)
             .getBoolean(MISSED_CALL_NOTIFICATIONS_ENABLED, true)
+    }
+
+    fun setIncomingCallRingtoneResource(context: Context, resourceName: String?): Boolean {
+        getSharedPreferences(context)
+            .edit()
+            .apply {
+                if (resourceName.isNullOrBlank()) {
+                    remove(INCOMING_CALL_RINGTONE_RESOURCE)
+                } else {
+                    putString(INCOMING_CALL_RINGTONE_RESOURCE, resourceName)
+                }
+            }
+            .apply()
+        return true
+    }
+
+    fun getIncomingCallRingtoneResource(context: Context): String? {
+        return getSharedPreferences(context).getString(INCOMING_CALL_RINGTONE_RESOURCE, null)
     }
 
     // PnModule functions

--- a/react-voice-commons-sdk/lib/internal/voice-pn-bridge.d.ts
+++ b/react-voice-commons-sdk/lib/internal/voice-pn-bridge.d.ts
@@ -25,6 +25,7 @@ export interface VoicePnBridgeInterface {
   ): Promise<boolean>;
   hideOngoingCallNotification(): Promise<boolean>;
   hideIncomingCallNotification(): Promise<boolean>;
+  setIncomingCallRingtone(resourceName: string | null): Promise<boolean>;
   getPendingCallKitAnswer(): Promise<string | null>;
   clearPendingCallKitAnswer(): Promise<boolean>;
   getVoipToken(): Promise<string | null>;
@@ -93,6 +94,11 @@ export declare class VoicePnBridge {
    * Useful for dismissing notifications when call is answered/rejected in app
    */
   static hideIncomingCallNotification(): Promise<boolean>;
+  /**
+   * Configure Android's incoming-call ringtone using an app resource in `res/raw`.
+   * Pass no value to use the device's default phone ringtone.
+   */
+  static setIncomingCallRingtone(resourceName?: string): Promise<boolean>;
   /**
    * Get pending CallKit answer UUID from native storage (iOS only).
    * When the user answers a CallKit call before JS listeners are ready,

--- a/react-voice-commons-sdk/lib/internal/voice-pn-bridge.js
+++ b/react-voice-commons-sdk/lib/internal/voice-pn-bridge.js
@@ -125,6 +125,19 @@ class VoicePnBridge {
     }
   }
   /**
+   * Configure Android's incoming-call ringtone using an app resource in `res/raw`.
+   * Pass no value to use the device's default phone ringtone.
+   */
+  static async setIncomingCallRingtone(resourceName) {
+    if (react_native_1.Platform.OS !== 'android') return true;
+    try {
+      return await NativeBridge.setIncomingCallRingtone(resourceName?.trim() || null);
+    } catch (error) {
+      console.error('VoicePnBridge: Error setting incoming call ringtone:', error);
+      return false;
+    }
+  }
+  /**
    * Get pending CallKit answer UUID from native storage (iOS only).
    * When the user answers a CallKit call before JS listeners are ready,
    * the native side persists the answer UUID in UserDefaults so JS can detect it.

--- a/react-voice-commons-sdk/lib/models/config.d.ts
+++ b/react-voice-commons-sdk/lib/models/config.d.ts
@@ -11,6 +11,8 @@ export interface CredentialConfig {
   pushWhenActive?: boolean;
   /** Enable native missed call push notifications. Default: false */
   enableMissedCallNotifications?: boolean;
+  /** Android only: name of a bundled `res/raw` ringtone (without its file extension). Falls back to the device ringtone. */
+  incomingCallRingtone?: string;
   /** Enable Trickle ICE. Default: false */
   useTrickleIce?: boolean;
   /** Enable automatic call quality reporting. Default: true */
@@ -34,6 +36,8 @@ export interface TokenConfig {
   pushWhenActive?: boolean;
   /** Enable native missed call push notifications. Default: false */
   enableMissedCallNotifications?: boolean;
+  /** Android only: name of a bundled `res/raw` ringtone (without its file extension). Falls back to the device ringtone. */
+  incomingCallRingtone?: string;
   /** Enable Trickle ICE. Default: false */
   useTrickleIce?: boolean;
   /** Enable automatic call quality reporting. Default: true */

--- a/react-voice-commons-sdk/lib/telnyx-voip-client.js
+++ b/react-voice-commons-sdk/lib/telnyx-voip-client.js
@@ -309,6 +309,7 @@ class TelnyxVoipClient {
       ...config,
       useTrickleIce: config.useTrickleIce ?? this._options.useTrickleIce,
     });
+    await voice_pn_bridge_1.VoicePnBridge.setIncomingCallRingtone(loginConfig.incomingCallRingtone);
     // Store credentials for future reconnection
     await this._storeCredentials(loginConfig);
     await this._sessionManager.connectWithCredential(loginConfig);
@@ -335,6 +336,7 @@ class TelnyxVoipClient {
       ...config,
       useTrickleIce: config.useTrickleIce ?? this._options.useTrickleIce,
     });
+    await voice_pn_bridge_1.VoicePnBridge.setIncomingCallRingtone(loginConfig.incomingCallRingtone);
     // Store token for future reconnection
     await this._storeToken(loginConfig);
     await this._sessionManager.connectWithToken(loginConfig);

--- a/react-voice-commons-sdk/package.json
+++ b/react-voice-commons-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@telnyx/react-voice-commons-sdk",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A high-level, state-agnostic, drop-in module for the Telnyx React Native SDK that simplifies WebRTC voice calling integration",
   "main": "lib/index.js",
   "module": "lib/index.js",

--- a/react-voice-commons-sdk/src/internal/voice-pn-bridge.ts
+++ b/react-voice-commons-sdk/src/internal/voice-pn-bridge.ts
@@ -31,6 +31,7 @@ export interface VoicePnBridgeInterface {
   ): Promise<boolean>;
   hideOngoingCallNotification(): Promise<boolean>;
   hideIncomingCallNotification(): Promise<boolean>;
+  setIncomingCallRingtone(resourceName: string | null): Promise<boolean>;
 
   // CallKit answer persistence (iOS only)
   getPendingCallKitAnswer(): Promise<string | null>;
@@ -183,6 +184,20 @@ export class VoicePnBridge {
       return await NativeBridge.hideIncomingCallNotification();
     } catch (error) {
       console.error('VoicePnBridge: Error hiding incoming call notification:', error);
+      return false;
+    }
+  }
+
+  /**
+   * Configure Android's incoming-call ringtone using an app resource in `res/raw`.
+   * Pass no value to use the device's default phone ringtone.
+   */
+  static async setIncomingCallRingtone(resourceName?: string): Promise<boolean> {
+    if (Platform.OS !== 'android') return true;
+    try {
+      return await NativeBridge.setIncomingCallRingtone(resourceName?.trim() || null);
+    } catch (error) {
+      console.error('VoicePnBridge: Error setting incoming call ringtone:', error);
       return false;
     }
   }

--- a/react-voice-commons-sdk/src/models/config.ts
+++ b/react-voice-commons-sdk/src/models/config.ts
@@ -11,6 +11,8 @@ export interface CredentialConfig {
   pushWhenActive?: boolean;
   /** Enable native missed call push notifications. Default: false */
   enableMissedCallNotifications?: boolean;
+  /** Android only: name of a bundled `res/raw` ringtone (without its file extension). Falls back to the device ringtone. */
+  incomingCallRingtone?: string;
   /** Enable Trickle ICE. Default: false */
   useTrickleIce?: boolean;
   /** Enable automatic call quality reporting. Default: true */
@@ -35,6 +37,8 @@ export interface TokenConfig {
   pushWhenActive?: boolean;
   /** Enable native missed call push notifications. Default: false */
   enableMissedCallNotifications?: boolean;
+  /** Android only: name of a bundled `res/raw` ringtone (without its file extension). Falls back to the device ringtone. */
+  incomingCallRingtone?: string;
   /** Enable Trickle ICE. Default: false */
   useTrickleIce?: boolean;
   /** Enable automatic call quality reporting. Default: true */

--- a/react-voice-commons-sdk/src/telnyx-voip-client.ts
+++ b/react-voice-commons-sdk/src/telnyx-voip-client.ts
@@ -306,6 +306,8 @@ export class TelnyxVoipClient {
       useTrickleIce: config.useTrickleIce ?? this._options.useTrickleIce,
     });
 
+    await VoicePnBridge.setIncomingCallRingtone(loginConfig.incomingCallRingtone);
+
     // Store credentials for future reconnection
     await this._storeCredentials(loginConfig);
 
@@ -337,6 +339,8 @@ export class TelnyxVoipClient {
       ...config,
       useTrickleIce: config.useTrickleIce ?? this._options.useTrickleIce,
     });
+
+    await VoicePnBridge.setIncomingCallRingtone(loginConfig.incomingCallRingtone);
 
     // Store token for future reconnection
     await this._storeToken(loginConfig);


### PR DESCRIPTION
## Summary
- play and loop the device’s default phone ringtone while an Android incoming call is pending
- add `incomingCallRingtone` for an app-bundled `android/app/src/main/res/raw` sound; use its resource name without the extension
- persist the selected resource for cold-start FCM calls and fall back to the system ringtone when it is absent or invalid
- release metadata and changelog updated for `1.1.0`

## Usage
```ts
const config = createCredentialConfig("user", "password", {
  incomingCallRingtone: "my_ringtone", // android/app/src/main/res/raw/my_ringtone.wav
});
await voipClient.login(config);
```

## Validation
- `cd android && ./gradlew :app:compileDebugKotlin`
- `npm run lint`
- built and installed the debug app on a Samsung SM-S921B
- verified the system-default ringtone plays and stops when an incoming Telnyx push is handled
- repository-wide `npx tsc --noEmit` remains blocked by unrelated existing type errors in the demo and underlying voice package

VSDK-487